### PR TITLE
Replace reference to Dell EMC by Dell Technologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 -->
 
-# Dell EMC Container Storage Modules (CSM) Operator
+# Dell Technologies Container Storage Modules (CSM) Operator
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](https://github.com/dell/csm/blob/main/docs/CODE_OF_CONDUCT.md)
 [![License](https://img.shields.io/github/license/dell/csm-operator)](LICENSE)
 [![Docker Pulls](https://img.shields.io/docker/pulls/dellemc/csm-operator)](https://hub.docker.com/r/dellemc/csm-operator)
 [![Go version](https://img.shields.io/github/go-mod/go-version/dell/csm-operator)](go.mod)
 [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/dell/csm-operator?include_prereleases&label=latest&style=flat-square)](https://github.com/dell/csm-operator/releases/latest)
 
-Dell EMC Container Storage Modules (CSM) Operator is an open-source Kubernetes operator which can be used to install and manage various CSI Drivers and CSM Modules.
+Dell Technologies Container Storage Modules (CSM) Operator is an open-source Kubernetes operator which can be used to install and manage various CSI Drivers and CSM Modules.
 
 ## Table of Contents
 
@@ -37,21 +37,21 @@ Dell EMC Container Storage Modules (CSM) Operator is an open-source Kubernetes o
   * [Uninstall CSI Drivers and CSM Modules](#uninstall-csi-drivers-and-csm-modules)
 
 # Dell CSM Operator
-Dell CSM Operator is a Kubernetes native application which helps in installing and managing CSI Drivers and CSM Modules provided by Dell EMC for its various storage platforms. 
+Dell CSM Operator is a Kubernetes native application which helps in installing and managing CSI Drivers and CSM Modules provided by Dell Technologies for its various storage platforms. 
 Dell CSM Operator uses Kubernetes CRDs (Custom Resource Definitions) to define a manifest that describes the deployment specifications for each driver to be deployed.
 
 Dell CSM Operator is built using the [operator framework](https://github.com/operator-framework) and runs custom Kubernetes controllers to manage the driver installations. These controllers listen for any create/update/delete request for the respective CRDs and try to reconcile the request.
 
-Currently, the Dell CSM Operator can be used to deploy the following CSI drivers provided by Dell EMC
+Currently, the Dell CSM Operator can be used to deploy the following CSI drivers provided by Dell Technologies
 
-* CSI Driver for Dell EMC PowerScale
+* CSI Driver for Dell Technologies PowerScale
   * CSM Authorization
 
 **NOTE**: You can refer to additional information about the Dell CSM Operator on the new documentation website [here](https://dell.github.io/csm-docs/docs/deployment/csmoperator/)
 
 ## Support
-The Dell CSM Operator image is available on Dockerhub and is officially supported by Dell EMC.
-For any CSM Operator and driver issues, questions or feedback, join the [Dell EMC Container community](https://www.dell.com/community/Containers/bd-p/Containers).
+The Dell CSM Operator image is available on Dockerhub and is officially supported by Dell Technologies.
+For any CSM Operator and driver issues, questions or feedback, join the [Dell Technologies Container community](https://www.dell.com/community/Containers/bd-p/Containers) or the [Slack channel for Dell Container Storage Modules](https://dellemccsm.slack.com/).
 
 ## Supported Platforms
 Dell CSM Operator has been tested and qualified with 
@@ -74,6 +74,6 @@ This project is adhering to [Semantic Versioning](https://semver.org/).
 
 ## About
 
-Dell EMC Container Storage Modules (CSM) Operator is 100% open source and community-driven. All components are available
+Dell Technologies Container Storage Modules (CSM) Operator is 100% open source and community-driven. All components are available
 under [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0.html) on
 GitHub.

--- a/api/v1alpha1/csm_types.go
+++ b/api/v1alpha1/csm_types.go
@@ -25,7 +25,7 @@ type ContainerStorageModuleSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Driver is a CSI Drivers for Dell EMC
+	// Driver is a CSI Drivers for Dell Technologies
 	Driver Driver `json:"driver,omitempty" yaml:"driver,omitempty"`
 
 	// Modules is list of Container Storage Module modules you want to deploy

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -132,7 +132,7 @@ type PodStatus struct {
 // Driver of CSIDriver
 // +k8s:openapi-gen=true
 type Driver struct {
-	// CSIDriverType is the CSI Driver type for Dell EMC - e.g, powermax, powerflex,...
+	// CSIDriverType is the CSI Driver type for Dell Technologies - e.g, powermax, powerflex,...
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="CSI Driver Type"
 	CSIDriverType DriverType `json:"csiDriverType" yaml:"csiDriverType"`
 

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -204,7 +204,7 @@ spec:
       - description: Tolerations is the list of tolerations for the driver pods
         displayName: Tolerations
         path: driver.controller.tolerations
-      - description: CSIDriverType is the CSI Driver type for Dell EMC - e.g, powermax,
+      - description: CSIDriverType is the CSI Driver type for Dell Technologies - e.g, powermax,
           powerflex,...
         displayName: CSI Driver Type
         path: driver.csiDriverType

--- a/bundle/manifests/storage.dell.com_containerstoragemodules.yaml
+++ b/bundle/manifests/storage.dell.com_containerstoragemodules.yaml
@@ -50,7 +50,7 @@ spec:
             description: ContainerStorageModuleSpec defines the desired state of ContainerStorageModule
             properties:
               driver:
-                description: Driver is a CSI Drivers for Dell EMC
+                description: Driver is a CSI Drivers for Dell Technologies
                 properties:
                   authSecret:
                     description: AuthSecret is the name of the credentials secret
@@ -437,7 +437,7 @@ spec:
                         type: array
                     type: object
                   csiDriverType:
-                    description: CSIDriverType is the CSI Driver type for Dell EMC
+                    description: CSIDriverType is the CSI Driver type for Dell Technologies
                       - e.g, powermax, powerflex,...
                     type: string
                   dnsPolicy:

--- a/config/crd/bases/storage.dell.com_containerstoragemodules.yaml
+++ b/config/crd/bases/storage.dell.com_containerstoragemodules.yaml
@@ -56,7 +56,7 @@ spec:
             description: ContainerStorageModuleSpec defines the desired state of ContainerStorageModule
             properties:
               driver:
-                description: Driver is a CSI Drivers for Dell EMC
+                description: Driver is a CSI Drivers for Dell Technologies
                 properties:
                   authSecret:
                     description: AuthSecret is the name of the credentials secret
@@ -449,7 +449,7 @@ spec:
                         type: string
                     type: object
                   csiDriverType:
-                    description: CSIDriverType is the CSI Driver type for Dell EMC
+                    description: CSIDriverType is the CSI Driver type for Dell Technologies
                       - e.g, powermax, powerflex,...
                     type: string
                   dnsPolicy:

--- a/config/manifests/bases/dell-csm-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dell-csm-operator.clusterserviceversion.yaml
@@ -85,7 +85,7 @@ spec:
       - description: Tolerations is the list of tolerations for the driver pods
         displayName: Tolerations
         path: driver.controller.tolerations
-      - description: CSIDriverType is the CSI Driver type for Dell EMC - e.g, powermax,
+      - description: CSIDriverType is the CSI Driver type for Dell Technologies - e.g, powermax,
           powerflex,...
         displayName: CSI Driver Type
         path: driver.csiDriverType

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -550,7 +550,7 @@ func (r *ContainerStorageModuleReconciler) getDriverConfig(ctx context.Context,
 	)
 
 	// Get Driver resources
-	log.Infof("Getting %s CSI Driver for Dell EMC", cr.Spec.Driver.CSIDriverType)
+	log.Infof("Getting %s CSI Driver for Dell Technologies", cr.Spec.Driver.CSIDriverType)
 	driverType := cr.Spec.Driver.CSIDriverType
 
 	if driverType == csmv1.PowerScale {

--- a/deploy/crds/storage.dell.com_containerstoragemodules.yaml
+++ b/deploy/crds/storage.dell.com_containerstoragemodules.yaml
@@ -49,7 +49,7 @@ spec:
             description: ContainerStorageModuleSpec defines the desired state of ContainerStorageModule
             properties:
               driver:
-                description: Driver is a CSI Drivers for Dell EMC
+                description: Driver is a CSI Drivers for Dell Technologies
                 properties:
                   authSecret:
                     description: AuthSecret is the name of the credentials secret for the driver
@@ -322,7 +322,7 @@ spec:
                         type: string
                     type: object
                   csiDriverType:
-                    description: CSIDriverType is the CSI Driver type for Dell EMC - e.g, powermax, powerflex,...
+                    description: CSIDriverType is the CSI Driver type for Dell Technologies - e.g, powermax, powerflex,...
                     type: string
                   dnsPolicy:
                     description: DNSPolicy is the dnsPolicy of the daemonset for Node plugin


### PR DESCRIPTION
# Description
Since January 2022 we are not supposed to use the brand Dell EMC ; therefore replacing comments & logs with Dell Technologies.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
/!\ I have not recompiled the code /!\