### PR TITLE
KRV-3862 : Fetch the right config file in case of Openshift environment

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -1,9 +1,9 @@
 package k8s
 
 import (
-	"fmt"
-
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/discovery"
+	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
@@ -22,19 +22,20 @@ var GetClientSetWrapper = func() (kubernetes.Interface, error) {
 
 	return clientset, nil
 }
-
-// GetVersion returns version of the k8s cluster
-func GetVersion() (string, error) {
-	k8sClientSet, err := GetClientSetWrapper()
+// GetKubeAPIServerVersion returns version of the k8s/openshift cluster
+func GetKubeAPIServerVersion() (*version.Info, error) {
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	// Create the discoveryClient
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
-		return "nil", err
+		return nil, err
 	}
-	sv, err := k8sClientSet.Discovery().ServerVersion()
+	sv, err := discoveryClient.ServerVersion()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-
-	return fmt.Sprintf("%s.%s", sv.Major, sv.Minor), nil
+	return sv, nil
 }
 
 // IsOpenShift - Returns a boolean which indicates if we are running in an OpenShift cluster

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -152,7 +152,7 @@ func Test_GetVersion(t *testing.T) {
 				GetClientSetWrapper = patch.getClientSetWrapper
 			}
 
-			out, err := GetVersion()
+			out, err := GetKubeAPIServerVersion()
 			if !success {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
# Description
Fetch the right config file in case of Openshift environment

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/254 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Installation in k8s : 
 
![k8s_system](https://user-images.githubusercontent.com/92289639/162122355-d08e8bde-d6c5-4dad-a2d6-1bc88a36f878.JPG)


Installation in OCP:
![ocp_system](https://user-images.githubusercontent.com/92289639/162122374-b9c91270-10ee-47e0-b1b3-49aa1036e91c.JPG)

