### PR TITLE
Set namespace to default and correct serviceaccount name

### DIFF
--- a/bundle/manifests/dell-csm-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/dell-csm-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: dell-csm-operator-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: default
+  namespace: default

--- a/bundle/manifests/dell-csm-operator-proxy-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/dell-csm-operator-proxy-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: dell-csm-operator-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: default
+  namespace: default

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -780,7 +780,7 @@ spec:
           - volumeattachments/status
           verbs:
           - patch
-        serviceAccountName: dell-csm-operator-controller-manager
+        serviceAccountName: dell-csm-operator-manager-service-account
       deployments:
       - name: dell-csm-operator-controller-manager
         spec:
@@ -839,7 +839,7 @@ spec:
                   allowPrivilegeEscalation: false
               securityContext:
                 runAsNonRoot: true
-              serviceAccountName: dell-csm-operator-controller-manager
+              serviceAccountName: dell-csm-operator-manager-service-account
               terminationGracePeriodSeconds: 10
     strategy: deployment
   installModes:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: dell-csm-operator
+namespace: default
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      serviceAccountName: manager-service-account
       securityContext:
         runAsNonRoot: true
       containers:
@@ -46,5 +47,4 @@ spec:
           requests:
             cpu: 100m
             memory: 192Mi
-      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: default
   namespace: system

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: default
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: manager-service-account
   namespace: default

--- a/config/serviceaccount/serviceaccount.yaml
+++ b/config/serviceaccount/serviceaccount.yaml
@@ -3,5 +3,5 @@ kind: ServiceAccount
 metadata:
   labels:
     control-plane: controller-manager
-  name: controller-manager
+  name: manager-service-account
   namespace: default

--- a/deploy/olm/operator_community.yaml
+++ b/deploy/olm/operator_community.yaml
@@ -14,6 +14,9 @@ metadata:
     olm.providedAPIs: ContainerStorageModule.v1alpha1.storage.dell.com
   name: dell-csm-operatorgroup
   namespace: test-csm-operator-olm
+spec:
+  targetNamespaces:
+    - test-csm-operator-olm
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     control-plane: controller-manager
-  name: dell-csm-operator-controller-manager
+  name: dell-csm-operator-manager-service-account
   namespace: dell-csm-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -389,8 +389,8 @@ roleRef:
   name: dell-csm-operator-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: default
+  namespace: dell-csm-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -402,7 +402,7 @@ roleRef:
   name: dell-csm-operator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: dell-csm-operator-controller-manager
+  name: dell-csm-operator-manager-service-account
   namespace: dell-csm-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -415,8 +415,8 @@ roleRef:
   name: dell-csm-operator-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: default
+  namespace: dell-csm-operator
 ---
 apiVersion: v1
 data:
@@ -501,5 +501,5 @@ spec:
           allowPrivilegeEscalation: false
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: dell-csm-operator-controller-manager
+      serviceAccountName: dell-csm-operator-manager-service-account
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
# Description
This PR 

- Fixes the issue where CSV was getting installed in all namepaces
- Sets the namespace to default for all objects 
- Corrects the ServiceAccount name

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/350 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
Validation Screenshots

**Before fix**
![image](https://user-images.githubusercontent.com/80810999/182402276-c387666a-eee5-4035-b6ea-348402599a66.png)

**After fix**
![image](https://user-images.githubusercontent.com/80810999/182401211-7f2f27e1-eae0-4a36-b9b9-acd91a37154c.png)

