### PR TITLE
Update ubi image to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ COPY tests/ tests/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Tag corresponding to digest d1f8eff6032334a81d7cbfd73dacee680e8138db57ecbc91548b97bb45e698e5 is 8.6-902
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:d1f8eff6032334a81d7cbfd73dacee680e8138db57ecbc91548b97bb45e698e5
+# Tag corresponding to digest d1f8eff6032334a81d7cbfd73dacee680e8138db57ecbc91548b97bb45e698e5 is 8.6-902.1661794353
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:c8c1c0f893a7ba679fd65863f2d1389179a92957c31e95521b3290c6b6fc4a76
 
 RUN microdnf install yum \
     && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \


### PR DESCRIPTION
# Description
Update ubi image to 8.6-902.1661794353

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/350 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Ran sanity
[build-logs-latest-ubi-image-update.log](https://github.com/dell/csm-operator/files/9496414/build-logs-latest-ubi-image-update.log)


