### PR TITLE
add observability topology for PowerScale, UT, e2e and etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Currently, the Dell Container Storage Modules Operator can be used to deploy the
 * CSI Driver for Dell Technologies PowerScale
   * CSM Authorization
   * CSM Replication
+  * CSM Observability
 
 **NOTE**: You can refer to additional information about the Dell Container Storage Modules Operator on the new documentation website [here](https://dell.github.io/csm-docs/docs/deployment/csmoperator/)
 

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -30,6 +30,9 @@ type DriverType string
 // ModuleType - type representing the type of the modules. e.g. - authorization, podmon
 type ModuleType string
 
+// ObservabilityComponentType - type representing the type of components inside observability module. e.g. - topology
+type ObservabilityComponentType string
+
 const (
 	// Replication - placeholder for replication constant
 	Replication ModuleType = "replication"
@@ -48,6 +51,9 @@ const (
 
 	// ReverseProxy - placeholder for constant csireverseproxy
 	ReverseProxy ModuleType = "csireverseproxy"
+
+	// Topology - placeholder for constant topology
+	Topology ObservabilityComponentType = "topology"
 
 	// PowerFlex - placeholder for constant powerflex
 	PowerFlex DriverType = "powerflex"

--- a/operatorconfig/moduleconfig/common/version-values.yaml
+++ b/operatorconfig/moduleconfig/common/version-values.yaml
@@ -10,3 +10,4 @@ powerscale:
   v2.4.0:
       authorization: "v1.4.0"
       replication: "v1.3.0"
+      observability: "v1.3.0"

--- a/operatorconfig/moduleconfig/observability/v1.3.0/karavi-topology.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.3.0/karavi-topology.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1 
+kind: ConfigMap 
+metadata:
+  name: karavi-topology-configmap
+  namespace: karavi
+data:
+  karavi-topology.yaml: |
+    PROVISIONER_NAMES: csi-isilon.dellemc.com
+    LOG_LEVEL: <TOPOLOGY_LOG_LEVEL>
+    LOG_FORMAT: text
+    ZIPKIN_URI: ""
+    ZIPKIN_SERVICE_NAME: karavi-topology
+    ZIPKIN_PROBABILITY: 0.0
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karavi-observability-topology-controller
+  namespace: karavi
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karavi-observability-topology-controller
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karavi-observability-topology-controller
+subjects:
+  - kind: ServiceAccount
+    name: karavi-observability-topology-controller
+    namespace: karavi
+roleRef:
+  kind: ClusterRole
+  name: karavi-observability-topology-controller
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: karavi-topology
+    app.kubernetes.io/instance: karavi-observability
+  name: karavi-topology
+  namespace: karavi
+spec:
+  type: ClusterIP
+  ports:
+  - name: karavi-topology
+    port: 8443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: karavi-topology
+    app.kubernetes.io/instance: karavi-observability
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karavi-topology
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: karavi-topology
+    app.kubernetes.io/instance: karavi-observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-topology
+      app.kubernetes.io/instance: karavi-observability
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karavi-topology
+        app.kubernetes.io/instance: karavi-observability
+    spec:
+      volumes:
+        - name: karavi-topology-secret-volume
+          secret:
+            secretName: karavi-topology-tls
+            items:
+            - key: tls.crt
+              path: localhost.crt
+            - key: tls.key
+              path: localhost.key
+        - name: karavi-topology-configmap
+          configMap:
+            name: karavi-topology-configmap
+      serviceAccount: karavi-observability-topology-controller
+      containers:
+      - name: karavi-topology
+        image: <TOPOLOGY_IMAGE>
+        resources: {}
+        env:
+        - name: PORT
+          value: "8443"
+        - name: DEBUG
+          value: "false"
+        volumeMounts:
+        - name: karavi-topology-secret-volume
+          mountPath: "/certs"
+        - name: karavi-topology-configmap
+          mountPath: "/etc/config"
+      restartPolicy: Always
+status: {}
+

--- a/pkg/modules/observability.go
+++ b/pkg/modules/observability.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+package modules
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	csmv1 "github.com/dell/csm-operator/api/v1"
+	drivers "github.com/dell/csm-operator/pkg/drivers"
+	"github.com/dell/csm-operator/pkg/logger"
+	utils "github.com/dell/csm-operator/pkg/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+
+	// ObservabilityTopologyName - component topology
+	ObservabilityTopologyName string = "topology"
+
+	// ObservabilityMetricsPowerScaleName - component metrics-powerscale
+	ObservabilityMetricsPowerScaleName string = "metrics-powerscale"
+
+	// ObservabilityMetricsPowerFlexName - component metrics-powerflex
+	ObservabilityMetricsPowerFlexName string = "metrics-powerflex"
+
+	// TopologyLogLevel -
+	TopologyLogLevel string = "<TOPOLOGY_LOG_LEVEL>"
+
+	// TopologyImage -
+	TopologyImage string = "<TOPOLOGY_IMAGE>"
+
+	// TopologyYamlFile -
+	TopologyYamlFile string = "karavi-topology.yaml"
+)
+
+// ObservabilitySupportedDrivers is a map containing the CSI Drivers supported by CMS Replication. The key is driver name and the value is the driver plugin identifier
+var ObservabilitySupportedDrivers = map[string]SupportedDriverParam{
+	"powerscale": {
+		PluginIdentifier:              drivers.PowerScalePluginIdentifier,
+		DriverConfigParamsVolumeMount: drivers.PowerScaleConfigParamsVolumeMount,
+	},
+	"isilon": {
+		PluginIdentifier:              drivers.PowerScalePluginIdentifier,
+		DriverConfigParamsVolumeMount: drivers.PowerScaleConfigParamsVolumeMount,
+	},
+}
+
+// ObservabilityPrecheck  - runs precheck for CSM Observability
+func ObservabilityPrecheck(ctx context.Context, op utils.OperatorConfig, obs csmv1.Module, cr csmv1.ContainerStorageModule, r utils.ReconcileCSM) error {
+	log := logger.GetLogger(ctx)
+
+	if _, ok := ObservabilitySupportedDrivers[string(cr.Spec.Driver.CSIDriverType)]; !ok {
+		return fmt.Errorf("CSM Operator does not suport Observability deployment for %s driver", cr.Spec.Driver.CSIDriverType)
+	}
+
+	// check if provided version is supported
+	if obs.ConfigVersion != "" {
+		err := checkVersion(string(csmv1.Observability), obs.ConfigVersion, op.ConfigDirectory)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Infof("\nperformed pre checks for: %s", obs.Name)
+	return nil
+}
+
+// ObservabilityTopology - delete or update topology objects
+func ObservabilityTopology(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient client.Client) error {
+	YamlString, err := getTopology(op, cr)
+	if err != nil {
+		return err
+	}
+
+	topoObjects, err := utils.GetObservabilityComponentObj([]byte(YamlString))
+	if err != nil {
+		return err
+	}
+
+	for _, ctrlObj := range topoObjects {
+		if isDeleting {
+			if err := utils.DeleteObject(ctx, ctrlObj, ctrlClient); err != nil {
+				return err
+			}
+		} else {
+			if err := utils.ApplyObject(ctx, ctrlObj, ctrlClient); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// getTopology - get topology yaml string
+func getTopology(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (string, error) {
+	YamlString := ""
+
+	obs, err := getObservabilityModule(cr)
+	if err != nil {
+		return YamlString, err
+	}
+
+	buf, err := readConfigFile(obs, cr, op, TopologyYamlFile)
+	if err != nil {
+		return YamlString, err
+	}
+	YamlString = string(buf)
+
+	logLevel := "INFO"
+	topologyImage := "dellemc/csm-topology:v1.3.0"
+
+	for _, component := range obs.Components {
+		if component.Name == ObservabilityTopologyName {
+			if component.Image != "" {
+				topologyImage = string(component.Image)
+			}
+			for _, env := range component.Envs {
+				if strings.Contains(TopologyLogLevel, env.Name) {
+					logLevel = env.Value
+				}
+			}
+		}
+	}
+
+	YamlString = strings.ReplaceAll(YamlString, TopologyLogLevel, logLevel)
+	YamlString = strings.ReplaceAll(YamlString, TopologyImage, topologyImage)
+	return YamlString, nil
+}
+
+// getObservabilityModule - get instance of observability module
+func getObservabilityModule(cr csmv1.ContainerStorageModule) (csmv1.Module, error) {
+	for _, m := range cr.Spec.Modules {
+		if m.Name == csmv1.Observability {
+			return m, nil
+
+		}
+	}
+	return csmv1.Module{}, fmt.Errorf("could not find observability module")
+}

--- a/pkg/modules/observability_test.go
+++ b/pkg/modules/observability_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+package modules
+
+import (
+	"context"
+	"testing"
+
+	csmv1 "github.com/dell/csm-operator/api/v1"
+	utils "github.com/dell/csm-operator/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlClientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestObservabilityPrecheck(t *testing.T) {
+	type fakeControllerRuntimeClientWrapper func(clusterConfigData []byte) (ctrlClient.Client, error)
+
+	tests := map[string]func(t *testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper){
+		"success": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			observability := tmpCR.Spec.Modules[0]
+
+			sourceClient := ctrlClientFake.NewClientBuilder().Build()
+			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
+				clusterClient := ctrlClientFake.NewClientBuilder().Build()
+				return clusterClient, nil
+			}
+
+			return true, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
+
+		"success - driver type PowerScale": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
+			observability := tmpCR.Spec.Modules[0]
+
+			sourceClient := ctrlClientFake.NewClientBuilder().Build()
+			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
+				clusterClient := ctrlClientFake.NewClientBuilder().Build()
+				return clusterClient, nil
+			}
+
+			return true, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
+
+		"success - version provided": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			observability := tmpCR.Spec.Modules[0]
+			observability.ConfigVersion = "v1.3.0"
+
+			sourceClient := ctrlClientFake.NewClientBuilder().Build()
+			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
+				clusterClient := ctrlClientFake.NewClientBuilder().Build()
+				return clusterClient, nil
+			}
+
+			return true, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
+
+		"Fail - unsupported observability version": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			observability := tmpCR.Spec.Modules[0]
+			observability.ConfigVersion = "v100000.0.0"
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+
+			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
+				return ctrlClientFake.NewClientBuilder().WithObjects().Build(), nil
+			}
+
+			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
+
+		"Fail - unsupported driver": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			tmpCR.Spec.Driver.CSIDriverType = "unsupported-driver"
+			observability := tmpCR.Spec.Modules[0]
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+
+			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
+				return ctrlClientFake.NewClientBuilder().WithObjects().Build(), nil
+			}
+
+			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldNewControllerRuntimeClientWrapper := utils.NewControllerRuntimeClientWrapper
+			oldNewK8sClientWrapper := utils.NewK8sClientWrapper
+			defer func() {
+				utils.NewControllerRuntimeClientWrapper = oldNewControllerRuntimeClientWrapper
+				utils.NewK8sClientWrapper = oldNewK8sClientWrapper
+			}()
+
+			success, observability, tmpCR, sourceClient, fakeControllerRuntimeClient := tc(t)
+			utils.NewControllerRuntimeClientWrapper = fakeControllerRuntimeClient
+			utils.NewK8sClientWrapper = func(clusterConfigData []byte) (*kubernetes.Clientset, error) {
+				return nil, nil
+			}
+
+			fakeReconcile := utils.FakeReconcileCSM{
+				Client:    sourceClient,
+				K8sClient: fake.NewSimpleClientset(),
+			}
+
+			err := ObservabilityPrecheck(context.TODO(), operatorConfig, observability, tmpCR, &fakeReconcile)
+			if success {
+				assert.NoError(t, err)
+
+			} else {
+				assert.Error(t, err)
+			}
+
+		})
+	}
+}
+
+func TestObservabilityTopologyController(t *testing.T) {
+	tests := map[string]func(t *testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig){
+		"success - deleting": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+
+			cr := &rbacv1.ClusterRole{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ClusterRole",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "karavi-observability-topology-controller",
+				},
+			}
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(cr).Build()
+
+			return true, true, tmpCR, sourceClient, operatorConfig
+		},
+
+		"success - creating": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+
+			return true, false, tmpCR, sourceClient, operatorConfig
+		},
+
+		"Fail - observability module not found": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_replica.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+
+			return false, false, tmpCR, sourceClient, operatorConfig
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			success, isDeleting, cr, sourceClient, op := tc(t)
+
+			err := ObservabilityTopology(context.TODO(), isDeleting, op, cr, sourceClient)
+			if success {
+				assert.NoError(t, err)
+
+			} else {
+				assert.Error(t, err)
+			}
+
+		})
+	}
+}

--- a/pkg/modules/testdata/cr_powerscale_observability.yaml
+++ b/pkg/modules/testdata/cr_powerscale_observability.yaml
@@ -1,0 +1,34 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: test-isilon
+  namespace: test-isilon
+spec:
+  driver:
+    csiDriverType: "isilon"
+    configVersion: v2.4.0
+    authSecret: test-isilon-creds 
+    replicas: 1
+    common:
+      image: "dellemc/csi-isilon:v2.4.0"
+      imagePullPolicy: IfNotPresent
+
+  modules:
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: true
+      configVersion: v1.3.0
+      components: 
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: true
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-topology:v1.3.0
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"

--- a/samples/storage_csm_powerscale_v240.yaml
+++ b/samples/storage_csm_powerscale_v240.yaml
@@ -308,3 +308,22 @@ spec:
           # Allowed values: time
           - name: "RETRY_INTERVAL_MAX"
             value: "5m"
+
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: false
+      configVersion: v1.3.0
+      components: 
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: false
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-topology:v1.3.0
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"           

--- a/scripts/run-e2e-test.sh
+++ b/scripts/run-e2e-test.sh
@@ -14,7 +14,7 @@ export GO111MODULE=on
 export ACK_GINKGO_DEPRECATIONS=1.16.4
 export ACK_GINKGO_RC=true
 
-if ! (cd tests/e2e && go mod vendor && go get -u github.com/onsi/ginkgo/ginkgo); then
+if ! (cd ../tests/e2e && go mod vendor && go get -u github.com/onsi/ginkgo/ginkgo); then
     echo "go mod vendor or go get ginkgo error"
     exit 1
 fi
@@ -29,7 +29,7 @@ else
     read -ra OPTS <<<"-v $GINKGO_OPTS"
 fi
 
-cd tests/e2e && ginkgo -mod=mod "${OPTS[@]}"
+cd ../tests/e2e && ginkgo -mod=mod "${OPTS[@]}"
 
 # Checking for test status
 TEST_PASS=$?

--- a/tests/e2e/steps/step_common.go
+++ b/tests/e2e/steps/step_common.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	csmv1 "github.com/dell/csm-operator/api/v1"
 
@@ -70,6 +71,61 @@ func checkAllRunningPods(namespace string, k8sClient kubernetes.Interface) error
 	if !allReady {
 		return fmt.Errorf(notReadyMessage)
 	}
+	return nil
+}
+
+func checkObservabilityRunningPods(namespace string, k8sClient kubernetes.Interface) error {
+	notReadyMessage := ""
+	allReady := true
+
+	pods, err := fpod.GetPodsInNamespace(k8sClient, namespace, map[string]string{})
+	if err != nil {
+		return err
+	}
+	if len(pods) == 0 {
+		return fmt.Errorf("no pod was found in %s", namespace)
+	}
+	for _, pod := range pods {
+		if strings.Contains(pod.Name, "topology") {
+			if pod.Status.Phase == corev1.PodRunning {
+				for _, cntStat := range pod.Status.ContainerStatuses {
+					if cntStat.State.Running == nil {
+						allReady = false
+						notReadyMessage += fmt.Sprintf("\nThe container(%s) in pod(%s) is %s", cntStat.Name, pod.Name, cntStat.State)
+						break
+					}
+				}
+			} else {
+				allReady = false
+				notReadyMessage += fmt.Sprintf("\nThe pod(%s) is %s", pod.Name, pod.Status.Phase)
+			}
+		}
+	}
+
+	if !allReady {
+		return fmt.Errorf(notReadyMessage)
+	}
+	return nil
+}
+
+func checkObservabilityNoRunningPods(namespace string, k8sClient kubernetes.Interface) error {
+	pods, err := fpod.GetPodsInNamespace(k8sClient, namespace, map[string]string{})
+	if err != nil {
+		return err
+	}
+
+	podsFound := ""
+	n := 0
+	for _, pod := range pods {
+		if strings.Contains(pod.Name, "topology") {
+			podsFound += (pod.Name + ",")
+			n++
+		}
+	}
+	if n != 0 {
+		return fmt.Errorf("found the following pods: %s", podsFound)
+	}
+
 	return nil
 }
 

--- a/tests/e2e/steps/steps_def.go
+++ b/tests/e2e/steps/steps_def.go
@@ -139,6 +139,10 @@ func (step *Step) validateModuleInstalled(res Resource, module string) error {
 
 			case csmv1.Replication:
 				return step.validateReplicationInstalled(res)
+
+			case csmv1.Observability:
+				return step.validateObservabilityInstalled(res)
+
 			}
 		}
 	}
@@ -166,7 +170,58 @@ func (step *Step) validateModuleNotInstalled(res Resource, module string) error 
 
 			case csmv1.Replication:
 				return step.validateReplicationNotInstalled(res)
+
+			case csmv1.Observability:
+				return step.validateObservabilityNotInstalled(res)
+
 			}
+		}
+	}
+
+	return nil
+}
+
+func (step *Step) validateObservabilityInstalled(res Resource) error {
+	cr := res.CustomResource
+
+	// check installation for all replicas
+	fakeReconcile := utils.FakeReconcileCSM{
+		Client:    step.ctrlClient,
+		K8sClient: step.clientSet,
+	}
+
+	_, clusterClients, err := utils.GetDefaultClusters(context.TODO(), cr, &fakeReconcile)
+	if err != nil {
+		return err
+	}
+	for _, cluster := range clusterClients {
+		// check observability in all clusters
+		if err := checkObservabilityRunningPods(utils.ObservabilityNamespace, cluster.ClusterK8sClient); err != nil {
+			return fmt.Errorf("failed to check for observability installation in %s: %v", cluster.ClusterID, err)
+		}
+	}
+
+	return nil
+}
+
+func (step *Step) validateObservabilityNotInstalled(res Resource) error {
+	cr := res.CustomResource
+
+	/* TODO(Michael): explore better way to handle this instead of using hacks*/
+	// check installation for all replicas
+	fakeReconcile := utils.FakeReconcileCSM{
+		Client:    step.ctrlClient,
+		K8sClient: step.clientSet,
+	}
+
+	_, clusterClients, err := utils.GetDefaultClusters(context.TODO(), cr, &fakeReconcile)
+	if err != nil {
+		return err
+	}
+	for _, cluster := range clusterClients {
+		// check observability is not installed
+		if err := checkObservabilityNoRunningPods(utils.ObservabilityNamespace, cluster.ClusterK8sClient); err != nil {
+			return fmt.Errorf("failed observability installation check %s: %v", cluster.ClusterID, err)
 		}
 	}
 
@@ -384,6 +439,12 @@ func (step *Step) disableModule(res Resource, module string) error {
 	for i, m := range found.Spec.Modules {
 		if m.Enabled && m.Name == csmv1.ModuleType(module) {
 			found.Spec.Modules[i].Enabled = false
+
+			if m.Name == csmv1.Observability {
+				for j := range m.Components {
+					found.Spec.Modules[i].Components[j].Enabled = &[]bool{false}[0]
+				}
+			}
 		}
 	}
 

--- a/tests/e2e/testfiles/storage_csm_powerscale.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale.yaml
@@ -249,4 +249,21 @@ spec:
           # Allowed values: time
           - name: "RETRY_INTERVAL_MAX"
             value: "5m"
-           
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: false
+      configVersion: v1.3.0
+      components: 
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: false
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-topology:v1.3.0
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"              

--- a/tests/e2e/testfiles/storage_csm_powerscale_observability.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_observability.yaml
@@ -1,0 +1,255 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: test-isilon
+  namespace: test-isilon
+spec:
+  driver:
+    csiDriverType: "isilon" 
+    csiDriverSpec:
+      # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+      # Allowed values: ReadWriteOnceWithFSType, File , None
+      # Default value: ReadWriteOnceWithFSType
+      fSGroupPolicy: "ReadWriteOnceWithFSType"
+    # Config version for CSI PowerScale v2.4.0 driver
+    configVersion: v2.4.0
+    authSecret: test-isilon-creds
+    replicas: 2
+    dnsPolicy: ClusterFirstWithHostNet
+    # Uninstall CSI Driver and/or modules when CR is deleted
+    forceRemoveDriver: true
+    common:
+      # Image for CSI PowerScale driver v2.4.0
+      image: "dellemc/csi-isilon:v2.4.0"
+      imagePullPolicy: IfNotPresent
+      envs:
+        # X_CSI_VERBOSE: Indicates what content of the OneFS REST API message should be logged in debug level logs
+        # Allowed Values:
+        #   0: log full content of the HTTP request and response
+        #   1: log without the HTTP response body
+        #   2: log only 1st line of the HTTP request and response
+        # Default value: 0
+        - name: X_CSI_VERBOSE
+          value: "1"
+
+        # X_CSI_ISI_PORT: Specify the HTTPs port number of the PowerScale OneFS API server
+        # This value acts as a default value for endpointPort, if not specified for a cluster config in secret
+        # Allowed value: valid port number
+        # Default value: 8080	
+        - name: X_CSI_ISI_PORT
+          value: "8080"
+
+        # X_CSI_ISI_PATH: The base path for the volumes to be created on PowerScale cluster.
+        # This value acts as a default value for isiPath, if not specified for a cluster config in secret
+        # Ensure that this path exists on PowerScale cluster.
+        # Allowed values: unix absolute path
+        # Default value: /ifs
+        # Examples: /ifs/data/csi, /ifs/engineering
+        - name: X_CSI_ISI_PATH
+          value: "/ifs/data/csi"
+
+        # X_CSI_ISI_NO_PROBE_ON_START: Indicates whether the controller/node should probe all the PowerScale clusters during driver initialization
+        # Allowed values:
+        #   true : do not probe all PowerScale clusters during driver initialization	
+        #   false: probe all PowerScale clusters during driver initialization
+        # Default value: false
+        - name: X_CSI_ISI_NO_PROBE_ON_START
+          value: "false"
+
+        # X_CSI_ISI_AUTOPROBE: automatically probe the PowerScale cluster if not done already during CSI calls.
+        # Allowed values:
+        #   true : enable auto probe.
+        #   false: disable auto probe.
+        # Default value: false
+        - name: X_CSI_ISI_AUTOPROBE
+          value: "true"
+
+        # X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION: Specify whether the PowerScale OneFS API server's certificate chain and host name should be verified.
+        # Formerly this attribute was named as "X_CSI_ISI_INSECURE"
+        # This value acts as a default value for skipCertificateValidation, if not specified for a cluster config in secret
+        # Allowed values:
+        #   true: skip OneFS API server's certificate verification
+        #   false: verify OneFS API server's certificates 
+        # Default value: true	
+        - name: X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION
+          value: "true"
+
+        # X_CSI_CUSTOM_TOPOLOGY_ENABLED: Specify if custom topology label <provisionerName>.dellemc.com/<powerscalefqdnorip>:<provisionerName>
+        # has to be used for making connection to backend PowerScale Array.
+        # If X_CSI_CUSTOM_TOPOLOGY_ENABLED is set to true, then do not specify allowedTopologies in storage class.
+        # Allowed values:
+        #   true : enable custom topology
+        #   false: disable custom topology
+        # Default value: false
+        - name: X_CSI_CUSTOM_TOPOLOGY_ENABLED
+          value: "false"
+
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: None
+        - name: KUBELET_CONFIG_DIR
+          value: "/var/lib/kubelet"
+        
+        # certSecretCount: Represents number of certificate secrets, which user is going to create for
+        # ssl authentication. (isilon-cert-0..isilon-cert-n)
+        # Allowed values: n, where n > 0
+        # Default value: None
+        - name: "CERT_SECRET_COUNT"
+          value: "1"
+
+        # CSI driver log level
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "debug"
+        - name: "CSI_LOG_LEVEL"
+          value: "debug"
+
+    controller:
+      envs:
+      # X_CSI_ISI_QUOTA_ENABLED: Indicates whether the provisioner should attempt to set (later unset) quota
+      # on a newly provisioned volume.
+      # This requires SmartQuotas to be enabled on PowerScale cluster.
+      # Allowed values:
+      #   true: set quota for volume
+      #   false: do not set quota for volume
+      - name: X_CSI_ISI_QUOTA_ENABLED
+        value: "true"
+
+      # X_CSI_ISI_ACCESS_ZONE: The name of the access zone a volume can be created in.
+      # If storageclass is missing with AccessZone parameter, then value of X_CSI_ISI_ACCESS_ZONE is used for the same.
+      # Default value: System
+      # Examples: System, zone1
+      - name: X_CSI_ISI_ACCESS_ZONE
+        value: "System"
+
+      # X_CSI_ISI_VOLUME_PATH_PERMISSIONS: The permissions for isi volume directory path
+      # This value acts as a default value for isiVolumePathPermissions, if not specified for a cluster config in secret
+      # Allowed values: valid octal mode number
+      # Default value: "0777"
+      # Examples: "0777", "777", "0755"
+      - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
+        value: "0777"
+
+      # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
+      # Install the 'external-health-monitor' sidecar accordingly.
+      # Allowed values:
+      #   true: enable checking of health condition of CSI volumes
+      #   false: disable checking of health condition of CSI volumes
+      # Default value: false
+      - name: X_CSI_HEALTH_MONITOR_ENABLED
+        value: "false"
+
+      # nodeSelector: Define node selection constraints for pods of controller deployment.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the controller deployment, if required.
+      # Default value: None
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      tolerations:
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # tolerations:
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+
+    node:
+      envs:
+      # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
+      # If value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node.
+      # This limit is applicable to all the nodes in the cluster for which node label 'max-isilon-volumes-per-node' is not set.
+      # Allowed values: n, where n >= 0
+      # Default value: 0
+      - name: X_CSI_MAX_VOLUMES_PER_NODE
+        value: "0"
+
+      # X_CSI_ALLOWED_NETWORKS: Custom networks for PowerScale export
+      # Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
+      # Allowed values: list of one or more networks
+      # Default value: None
+      # Provide them in the following format: "[net1, net2]"
+      # CIDR format should be used
+      # eg: "[192.168.1.0/24, 192.168.100.0/22]"
+      - name: X_CSI_ALLOWED_NETWORKS
+        value: ""
+
+      # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
+      # Install the 'external-health-monitor' sidecar accordingly.
+      # Allowed values:
+      #   true: enable checking of health condition of CSI volumes
+      #   false: disable checking of health condition of CSI volumes
+      # Default value: false
+      - name: X_CSI_HEALTH_MONITOR_ENABLED
+        value: "false"
+
+      # nodeSelector: Define node selection constraints for pods of node daemonset
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the node daemonset, if required.
+      # Default value: None
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      tolerations:
+      #  - key: "node.kubernetes.io/memory-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # tolerations:
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+
+    sideCars:
+      - name: provisioner
+        args: ["--volume-name-prefix=csipscale"]
+      # health monitor is disabled by default, refer to driver documentation before enabling it
+      - name: external-health-monitor
+        enabled: false
+        args: ["--monitor-interval=60s"]
+
+  modules:
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: true
+      configVersion: v1.3.0
+      components: 
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: true
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-topology:v1.3.0
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"           

--- a/tests/e2e/testfiles/values.yaml
+++ b/tests/e2e/testfiles/values.yaml
@@ -137,3 +137,44 @@
     - "Delete resources"
 
 
+- scenario: "Install PowerScale Driver(With Observability)"
+  path: "<path-to-cr-for-powerscale-with-observability-enabled>"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resources"
+    - "Validate custom resources"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [observability] module is installed"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR"
+    - "Delete resources"
+
+- scenario: "Install PowerScale Driver(Standalone), Enable Observability"
+  path: "<path-to-cr-for-powerscale-with-observability-disabled>"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resources"
+    - "Validate custom resources"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [observability] module is not installed"
+    - "Enable [observability] module"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [observability] module is installed"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR"
+    - "Delete resources"
+
+- scenario: Install PowerScale Driver(With Observability), Disable Observability module"
+  path: "<path-to-cr-for-powerscale-with-observability-enabled>"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resources"
+    - "Validate custom resources"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [observability] module is installed"
+    - "Disable [observability] module"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [observability] module is not installed"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR"
+    - "Delete resources"


### PR DESCRIPTION
# Description
add observability topology for PowerScale, UT, e2e and etc

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/488 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] UT
Current coverage:
`[root@vpi6179 controllers]# go test ./... -coverprofile cover.out
ok      github.com/dell/csm-operator/controllers        0.591s  coverage: 88.5% of statements
[root@vpi6179 modules]# go test ./... -coverprofile cover.out
ok      github.com/dell/csm-operator/pkg/modules        0.105s  coverage: 88.9% of statements
`
- [x] E2E
`Running Suite: CSM Operator End-to-End Tests
============================================
Random Seed: 1664430799 - Will randomize all specs
Will run 1 of 1 specs

STEP: Getting test environment variables
STEP: Reading values file
STEP: Getting a k8s client
[run-e2e-test]E2E Testing
  Running all test Given Test Scenarios
  /home/dellemc/csm-operator/tests/e2e/e2e_test.go:75
[It] Running all test Given Test Scenarios
  /home/dellemc/csm-operator/tests/e2e/e2e_test.go:75
STEP: Starting: Install PowerScale Driver(With Observability)
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resources
Sep 29 01:53:23.261: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Sep 29 01:53:23.507: INFO: stderr: ""
Sep 29 01:53:23.507: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
STEP:      Executing  Validate custom resources
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is installed
STEP:      Executing  Enable forceRemoveDriver on CR
STEP:      Executing  Delete resources
STEP: Ending: Install PowerScale Driver(With Observability)
STEP:
STEP:
STEP: Starting: Install PowerScale Driver(Standalone), Enable Observability
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resources
Sep 29 01:53:38.553: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Sep 29 01:53:38.802: INFO: stderr: ""
Sep 29 01:53:38.802: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
STEP:      Executing  Validate custom resources
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is not installed
STEP:      Executing  Enable [observability] module
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is installed
STEP:      Executing  Enable forceRemoveDriver on CR
STEP:      Executing  Delete resources
STEP: Ending: Install PowerScale Driver(Standalone), Enable Observability
STEP:
STEP:
STEP: Starting: Install PowerScale Driver(With Observability), Disable Observability module"
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resources
Sep 29 01:53:53.878: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Sep 29 01:53:54.166: INFO: stderr: ""
Sep 29 01:53:54.166: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
STEP:      Executing  Validate custom resources
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is installed
STEP:      Executing  Disable [observability] module
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is not installed
STEP:      Executing  Enable forceRemoveDriver on CR
STEP:      Executing  Delete resources
STEP: Ending: Install PowerScale Driver(With Observability), Disable Observability module"
STEP:
STEP:

• [SLOW TEST:55.986 seconds]
[run-e2e-test]E2E Testing
/home/dellemc/csm-operator/tests/e2e/e2e_test.go:74
  Running all test Given Test Scenarios
  /home/dellemc/csm-operator/tests/e2e/e2e_test.go:75
------------------------------

Ran 1 of 1 Specs in 56.344 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 59.587013979s
Test Suite Passed

`
- [x] Manual
![image](https://user-images.githubusercontent.com/63342088/192953433-edeabb87-1e85-4711-b8d5-502ebf3fd720.png)
 
