### PR TITLE
Add observability metrics for PowerScale

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -14,6 +14,7 @@ general:
     - CVE-2022-1271
     - CVE-2022-2526
     - CVE-2022-27664
+    - CVE-2022-3515
   bestPracticeViolations:
     # list of best practies violatied that needs a fix
     - 

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -663,6 +663,22 @@ func (r *ContainerStorageModuleReconciler) reconcileObservability(ctx context.Co
 		}
 	}
 
+	if utils.IsComponentEnabled(ctx, cr, r, csmv1.Observability, modules.ObservabilityOtelCollectorName) {
+		log.Infow("Reconcile Otel Collector")
+		if err := modules.OtelCollector(ctx, isDeleting, op, cr, ctrlClient); err != nil {
+			log.Errorf("failed to deploy otel collector")
+			return err
+		}
+	}
+
+	if utils.IsComponentEnabled(ctx, cr, r, csmv1.Observability, modules.ObservabilityMetricsPowerScaleName) {
+		log.Infow("Reconcile PowerScale metrics")
+		if err := modules.PowerScaleMetrics(ctx, isDeleting, op, cr, ctrlClient); err != nil {
+			log.Errorf("failed to deploy powerscale metrics")
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -656,26 +656,20 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 // isDeleting - ture: Delete; false: Create/Update
 func (r *ContainerStorageModuleReconciler) reconcileObservability(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient client.Client) error {
 	log := logger.GetLogger(ctx)
-	if utils.IsComponentEnabled(ctx, cr, r, csmv1.Observability, modules.ObservabilityTopologyName) {
-		log.Infow(fmt.Sprintf("Reconcile topology"))
-		if err := modules.ObservabilityTopology(ctx, isDeleting, op, cr, ctrlClient); err != nil {
-			return err
-		}
+
+	comp2reconFunc := map[string]func(context.Context, bool, utils.OperatorConfig, csmv1.ContainerStorageModule, client.Client) error{
+		modules.ObservabilityTopologyName:          modules.ObservabilityTopology,
+		modules.ObservabilityOtelCollectorName:     modules.OtelCollector,
+		modules.ObservabilityMetricsPowerScaleName: modules.PowerScaleMetrics,
 	}
 
-	if utils.IsComponentEnabled(ctx, cr, r, csmv1.Observability, modules.ObservabilityOtelCollectorName) {
-		log.Infow("Reconcile Otel Collector")
-		if err := modules.OtelCollector(ctx, isDeleting, op, cr, ctrlClient); err != nil {
-			log.Errorf("failed to deploy otel collector")
-			return err
-		}
-	}
-
-	if utils.IsComponentEnabled(ctx, cr, r, csmv1.Observability, modules.ObservabilityMetricsPowerScaleName) {
-		log.Infow("Reconcile PowerScale metrics")
-		if err := modules.PowerScaleMetrics(ctx, isDeleting, op, cr, ctrlClient); err != nil {
-			log.Errorf("failed to deploy powerscale metrics")
-			return err
+	for comp, reconFunc := range comp2reconFunc {
+		if utils.IsComponentEnabled(ctx, cr, r, csmv1.Observability, comp) {
+			log.Infow(fmt.Sprintf("reconcile %s", comp))
+			if err := reconFunc(ctx, isDeleting, op, cr, ctrlClient); err != nil {
+				log.Errorf("failed to reconcile %s", comp)
+				return err
+			}
 		}
 	}
 

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -817,6 +817,26 @@ func getObservabilityModule() []csmv1.Module {
 						},
 					},
 				},
+				{
+					Name:    "otel-collector",
+					Enabled: &[]bool{true}[0],
+					Envs: []corev1.EnvVar{
+						{
+							Name:  "NGINX_PROXY_IMAGE",
+							Value: "nginxinc/nginx-unprivileged:1.20",
+						},
+					},
+				},
+				{
+					Name:    "metrics-powerscale",
+					Enabled: &[]bool{true}[0],
+					Envs: []corev1.EnvVar{
+						{
+							Name:  "POWERSCALE_MAX_CONCURRENT_QUERIES",
+							Value: "10",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -879,6 +899,37 @@ func (suite *CSMControllerTestSuite) TestDeleteErrorReconcile() {
 	updateCSMError = false
 }
 
+func (suite *CSMControllerTestSuite) TestReconcileObservabilityError() {
+	csm := shared.MakeCSM(csmName, suite.namespace, configVersion)
+	csm.Spec.Modules = getObservabilityModule()
+	reconciler := suite.createReconciler()
+	badOperatorConfig := utils.OperatorConfig{
+		ConfigDirectory: "../in-valid-path",
+	}
+	err := reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient)
+	assert.NotNil(suite.T(), err)
+
+	// Only test for Otel component
+	csm.Spec.Modules[0].Components[0].Enabled = &[]bool{false}[0]
+	err = reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient)
+	assert.NotNil(suite.T(), err)
+
+	// Only test for Metrics component
+	csm.Spec.Modules[0].Components[1].Enabled = &[]bool{false}[0]
+	err = reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient)
+	assert.Error(suite.T(), err)
+
+	// Test for all components disabled
+	csm.Spec.Modules[0].Components[2].Enabled = &[]bool{false}[0]
+	err = reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient)
+	assert.Nil(suite.T(), err)
+
+	// Restore the status
+	for _, c := range csm.Spec.Modules[0].Components {
+		c.Enabled = &[]bool{false}[0]
+	}
+}
+
 // helper method to create k8s objects
 func (suite *CSMControllerTestSuite) makeFakeCSM(name, ns string, withFinalizer bool, modules []csmv1.Module) {
 
@@ -901,6 +952,10 @@ func (suite *CSMControllerTestSuite) makeFakeCSM(name, ns string, withFinalizer 
 	sec = shared.MakeSecret("skip-replication-cluster-check", utils.ReplicationControllerNameSpace, configVersion)
 	err = suite.fakeClient.Create(ctx, sec)
 	assert.Nil(suite.T(), err)
+
+	// this secret required by observability isilon module
+	obsIsilonSec := shared.MakeSecret("isilon-creds", "karavi", configVersion)
+	suite.fakeClient.Create(ctx, obsIsilonSec)
 
 	csm := shared.MakeCSM(name, ns, configVersion)
 	csm.Spec.Driver.Common.Image = "image"

--- a/operatorconfig/moduleconfig/observability/v1.3.0/karavi-metrics-powerscale.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.3.0/karavi-metrics-powerscale.yaml
@@ -1,0 +1,142 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karavi-metrics-powerscale-controller
+  namespace: karavi
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karavi-metrics-powerscale-controller
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes", "storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karavi-metrics-powerscale-controller
+subjects:
+  - kind: ServiceAccount
+    name: karavi-metrics-powerscale-controller
+    namespace: karavi
+roleRef:
+  kind: ClusterRole
+  name: karavi-metrics-powerscale-controller
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powerscale
+    app.kubernetes.io/instance: karavi
+  name: karavi-metrics-powerscale
+  namespace: karavi
+spec:
+  type: ClusterIP
+  ports:
+    - name: karavi-metrics-powerscale
+      port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: karavi-metrics-powerscale
+    app.kubernetes.io/instance: karavi
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: karavi-metrics-powerscale-configmap
+  namespace: karavi
+data:
+  karavi-metrics-powerscale.yaml : |
+    COLLECTOR_ADDR: <COLLECTOR_ADDRESS>
+    PROVISIONER_NAMES: csi-isilon.dellemc.com
+    POWERSCALE_MAX_CONCURRENT_QUERIES: <POWERSCALE_MAX_CONCURRENT_QUERIES>
+    POWERSCALE_CAPACITY_METRICS_ENABLED: <POWERSCALE_CAPACITY_METRICS_ENABLED>
+    POWERSCALE_PERFORMANCE_METRICS_ENABLED: <POWERSCALE_PERFORMANCE_METRICS_ENABLED>
+    POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY: <POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY>
+    POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY: <POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY>
+    POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY: <POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY>
+    POWERSCALE_ISICLIENT_INSECURE: <ISICLIENT_INSECURE>
+    POWERSCALE_ISICLIENT_AUTH_TYPE: <ISICLIENT_AUTH_TYPE>
+    POWERSCALE_ISICLIENT_VERBOSE: <ISICLIENT_VERBOSE>
+    LOG_LEVEL: <POWERSCALE_LOG_LEVEL>
+    LOG_FORMAT: <POWERSCALE_LOG_FORMAT>
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karavi-metrics-powerscale
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powerscale
+    app.kubernetes.io/instance: karavi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-metrics-powerscale
+      app.kubernetes.io/instance: karavi
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karavi-metrics-powerscale
+        app.kubernetes.io/instance: karavi
+    spec:
+      serviceAccount: karavi-metrics-powerscale-controller
+      containers:
+        - name: karavi-metrics-powerscale
+          image: <POWERSCALE_OBS_IMAGE>
+          resources: {}
+          env:
+            - name: POWERSCALE_METRICS_ENDPOINT
+              value: "karavi-metrics-powerscale"
+            - name: POWERSCALE_METRICS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TLS_ENABLED
+              value: "true"
+          volumeMounts:
+            - name: isilon-creds
+              mountPath: /isilon-creds
+            - name: tls-secret
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            - name: karavi-metrics-powerscale-configmap
+              mountPath: /etc/config
+      volumes:
+        - name: isilon-creds
+          secret:
+            secretName: isilon-creds
+        - name: tls-secret
+          secret:
+            secretName: otel-collector-tls
+            items:
+              - key: tls.crt
+                path: cert.crt
+        - name: karavi-metrics-powerscale-configmap
+          configMap:
+            name: karavi-metrics-powerscale-configmap
+      restartPolicy: Always
+status: {}
+

--- a/operatorconfig/moduleconfig/observability/v1.3.0/karavi-otel-collector.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.3.0/karavi-otel-collector.yaml
@@ -1,0 +1,152 @@
+apiVersion: v1
+data:
+  otel-collector-config.yaml: |-
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:55680
+            tls:
+              cert_file: /etc/ssl/certs/tls.crt
+              key_file: /etc/ssl/certs/tls.key
+    
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+      logging:
+    
+    extensions:
+      health_check: {}
+    
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: []
+          exporters: [logging,prometheus]
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: karavi
+
+---
+
+apiVersion: v1
+data:
+  nginx.conf: |-
+    worker_processes  1;
+    events {
+      worker_connections  1024;
+    }
+  
+    pid /tmp/nginx.pid;
+  
+    http {
+      include       mime.types;
+      default_type  application/octet-stream;
+      sendfile        on;
+      keepalive_timeout  65;
+      server {
+        listen       8443 ssl;
+        server_name  localhost;
+        ssl_certificate      /etc/ssl/certs/tls.crt;
+        ssl_certificate_key  /etc/ssl/certs/tls.key;
+        ssl_protocols TLSv1.2;
+        ssl_ciphers AESGCM:-aNULL:-DH:-kRSA:@STRENGTH;
+        ssl_prefer_server_ciphers on;
+        location / {
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header Host $http_host;
+          proxy_pass http://127.0.0.1:8889/;
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: karavi
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: karavi-observability
+spec:
+  type: ClusterIP
+  ports:
+    - port: 55680
+      targetPort: 55680
+      name: receiver
+    - port: 8443
+      targetPort: 8443
+      name: exporter-https
+  selector:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: karavi-observability
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: karavi-observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+      app.kubernetes.io/instance: karavi-observability
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-collector
+        app.kubernetes.io/instance: karavi-observability
+    spec:
+      volumes:
+        - name: tls-secret
+          secret:
+            secretName: otel-collector-tls
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+        - name: otel-collector-config
+          configMap:
+            name: otel-collector-config
+      containers:
+        - name: nginx-proxy
+          image: <NGINX_PROXY_IMAGE>
+          volumeMounts:
+            - name: tls-secret
+              mountPath: /etc/ssl/certs
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+        - name: otel-collector
+          image: <OTEL_COLLECTOR_IMAGE>
+          args:
+            - --config=/etc/otel-collector-config.yaml
+          resources: {}
+          volumeMounts:
+            - name: otel-collector-config
+              mountPath: /etc/otel-collector-config.yaml
+              subPath: otel-collector-config.yaml
+            - name: tls-secret
+              mountPath: /etc/ssl/certs
+      restartPolicy: Always
+status: {}

--- a/pkg/modules/observability.go
+++ b/pkg/modules/observability.go
@@ -11,6 +11,9 @@ package modules
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"strings"
 
 	csmv1 "github.com/dell/csm-operator/api/v1"
@@ -21,6 +24,8 @@ import (
 )
 
 const (
+	// ObservabilityOtelCollectorName - component otel-collector
+	ObservabilityOtelCollectorName string = "otel-collector"
 
 	// ObservabilityTopologyName - component topology
 	ObservabilityTopologyName string = "topology"
@@ -39,6 +44,57 @@ const (
 
 	// TopologyYamlFile -
 	TopologyYamlFile string = "karavi-topology.yaml"
+
+	// OtelCollectorAddress - Otel collector address
+	OtelCollectorAddress string = "<COLLECTOR_ADDRESS>"
+
+	// PowerScaleMaxConcurrentQueries - max concurrent queries
+	PowerScaleMaxConcurrentQueries string = "<POWERSCALE_MAX_CONCURRENT_QUERIES>"
+
+	// PowerscaleCapacityMetricsEnabled - enable/disable collection of capacity metrics
+	PowerscaleCapacityMetricsEnabled string = "<POWERSCALE_CAPACITY_METRICS_ENABLED>"
+
+	// PowerscalePerformanceMetricsEnabled - enable/disable collection of performance metrics
+	PowerscalePerformanceMetricsEnabled string = "<POWERSCALE_PERFORMANCE_METRICS_ENABLED>"
+
+	// PowerscaleClusterCapacityPollFrequency - polling frequency to get cluster capacity data
+	PowerscaleClusterCapacityPollFrequency string = "<POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY>"
+
+	// PowerscaleClusterPerformancePollFrequency - polling frequency to get cluster performance data
+	PowerscaleClusterPerformancePollFrequency string = "<POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY>"
+
+	// PowerscaleQuotaCapacityPollFrequency - polling frequency to get Quota capacity data
+	PowerscaleQuotaCapacityPollFrequency string = "<POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY>"
+
+	// IsiclientInsecure - skip certificate validation
+	IsiclientInsecure string = "<ISICLIENT_INSECURE>"
+
+	// IsiclientAuthType - enables session-based/basic authentication
+	IsiclientAuthType string = "<ISICLIENT_AUTH_TYPE>"
+
+	// IsiclientVerbose - content of the OneFS REST API message
+	IsiclientVerbose string = "<ISICLIENT_VERBOSE>"
+
+	// PowerscaleLogLevel - the level for the PowerScale metrics
+	PowerscaleLogLevel string = "<POWERSCALE_LOG_LEVEL>"
+
+	// PowerscaleLogFormat - log format
+	PowerscaleLogFormat string = "<POWERSCALE_LOG_FORMAT>"
+
+	// PowerScaleImage - PowerScale image name
+	PowerScaleImage string = "<POWERSCALE_OBS_IMAGE>"
+
+	// NginxProxyImage - Nginx proxy image name
+	NginxProxyImage string = "<NGINX_PROXY_IMAGE>"
+
+	// OtelCollectorImage - Otel collector image name
+	OtelCollectorImage string = "<OTEL_COLLECTOR_IMAGE>"
+
+	// PscaleObsYamlFile - PowerScale Observability yaml file
+	PscaleObsYamlFile string = "karavi-metrics-powerscale.yaml"
+
+	// OtelCollectorYamlFile - Otel Collector yaml file
+	OtelCollectorYamlFile string = "karavi-otel-collector.yaml"
 )
 
 // ObservabilitySupportedDrivers is a map containing the CSI Drivers supported by CMS Replication. The key is driver name and the value is the driver plugin identifier
@@ -66,6 +122,21 @@ func ObservabilityPrecheck(ctx context.Context, op utils.OperatorConfig, obs csm
 		err := checkVersion(string(csmv1.Observability), obs.ConfigVersion, op.ConfigDirectory)
 		if err != nil {
 			return err
+		}
+	}
+
+	// Pre-check For PowerScale secrets
+	secrets := []string{"isilon-creds"}
+
+	for _, name := range secrets {
+		found := &corev1.Secret{}
+		err := r.GetClient().Get(ctx, types.NamespacedName{Name: name,
+			Namespace: "karavi"}, found)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return fmt.Errorf("failed to find secret %s and certificate validation is requested", name)
+			}
+			log.Error(err, "Failed to query for secret. Warning - the controller pod may not start")
 		}
 	}
 
@@ -133,6 +204,176 @@ func getTopology(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (stri
 
 	YamlString = strings.ReplaceAll(YamlString, TopologyLogLevel, logLevel)
 	YamlString = strings.ReplaceAll(YamlString, TopologyImage, topologyImage)
+	return YamlString, nil
+}
+
+// OtelCollector - delete or update otel collector objects
+func OtelCollector(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient client.Client) error {
+	YamlString, err := getOtelCollector(op, cr)
+	if err != nil {
+		return err
+	}
+
+	powerscaleMetricsObjects, err := utils.GetObservabilityComponentObj([]byte(YamlString))
+	if err != nil {
+		return err
+	}
+
+	for _, ctrlObj := range powerscaleMetricsObjects {
+		if isDeleting {
+			if err := utils.DeleteObject(ctx, ctrlObj, ctrlClient); err != nil {
+				return err
+			}
+		} else {
+			if err := utils.ApplyObject(ctx, ctrlObj, ctrlClient); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// getOtelCollector - get otel collector yaml string
+func getOtelCollector(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (string, error) {
+	YamlString := ""
+
+	obs, err := getObservabilityModule(cr)
+	if err != nil {
+		return YamlString, err
+	}
+
+	buf, err := readConfigFile(obs, cr, op, OtelCollectorYamlFile)
+	if err != nil {
+		return YamlString, err
+	}
+	YamlString = string(buf)
+
+	nginxProxyImage := "nginxinc/nginx-unprivileged:1.20"
+	otelCollectorImage := "otel/opentelemetry-collector:0.42.0"
+
+	for _, component := range obs.Components {
+		if component.Name == ObservabilityOtelCollectorName {
+			if component.Image != "" {
+				otelCollectorImage = string(component.Image)
+			}
+			for _, env := range component.Envs {
+				if strings.Contains(NginxProxyImage, env.Name) {
+					nginxProxyImage = env.Value
+				}
+			}
+		}
+	}
+
+	YamlString = strings.ReplaceAll(YamlString, OtelCollectorImage, otelCollectorImage)
+	YamlString = strings.ReplaceAll(YamlString, NginxProxyImage, nginxProxyImage)
+	return YamlString, nil
+}
+
+// PowerScaleMetrics - delete or update powerscale metrics objects
+func PowerScaleMetrics(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient client.Client) error {
+	YamlString, err := getPowerScaleMetrics(op, cr)
+	if err != nil {
+		return err
+	}
+
+	powerscaleMetricsObjects, err := utils.GetObservabilityComponentObj([]byte(YamlString))
+	if err != nil {
+		return err
+	}
+
+	for _, ctrlObj := range powerscaleMetricsObjects {
+		if isDeleting {
+			if err := utils.DeleteObject(ctx, ctrlObj, ctrlClient); err != nil {
+				return err
+			}
+		} else {
+			if err := utils.ApplyObject(ctx, ctrlObj, ctrlClient); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// getPowerScaleMetrics - get powerscale metrics yaml string
+func getPowerScaleMetrics(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (string, error) {
+	YamlString := ""
+
+	obs, err := getObservabilityModule(cr)
+	if err != nil {
+		return YamlString, err
+	}
+
+	buf, err := readConfigFile(obs, cr, op, PscaleObsYamlFile)
+	if err != nil {
+		return YamlString, err
+	}
+	YamlString = string(buf)
+
+	logLevel := "INFO"
+	otelCollectorAddress := "otel-collector:55680"
+	pscaleImage := "dellemc/dellemc/csm-metrics-powerscale:v1.0.0"
+	maxConcurrentQueries := "10"
+	capacityEnabled := "true"
+	performanceEnabled := "true"
+	clusterCapacityPollFrequency := "30"
+	clusterPerformancePollFrequency := "20"
+	quotaCapacityPollFrequency := "30"
+	clientInsecure := "true"
+	clientAuthType := "1"
+	clientVerbose := "0"
+	logFormat := "TEXT"
+
+	for _, component := range obs.Components {
+		if component.Name == ObservabilityMetricsPowerScaleName {
+			if component.Image != "" {
+				pscaleImage = string(component.Image)
+			}
+			for _, env := range component.Envs {
+				if strings.Contains(PowerscaleLogLevel, env.Name) {
+					logLevel = env.Value
+				} else if strings.Contains(PowerScaleMaxConcurrentQueries, env.Name) {
+					maxConcurrentQueries = env.Value
+				} else if strings.Contains(PowerscaleCapacityMetricsEnabled, env.Name) {
+					capacityEnabled = env.Value
+				} else if strings.Contains(PowerscalePerformanceMetricsEnabled, env.Name) {
+					performanceEnabled = env.Value
+				} else if strings.Contains(PowerscaleClusterCapacityPollFrequency, env.Name) {
+					clusterCapacityPollFrequency = env.Value
+				} else if strings.Contains(PowerscaleClusterPerformancePollFrequency, env.Name) {
+					clusterPerformancePollFrequency = env.Value
+				} else if strings.Contains(PowerscaleQuotaCapacityPollFrequency, env.Name) {
+					quotaCapacityPollFrequency = env.Value
+				} else if strings.Contains(IsiclientInsecure, env.Name) {
+					clientInsecure = env.Value
+				} else if strings.Contains(IsiclientAuthType, env.Name) {
+					clientAuthType = env.Value
+				} else if strings.Contains(IsiclientVerbose, env.Name) {
+					clientVerbose = env.Value
+				} else if strings.Contains(PowerscaleLogFormat, env.Name) {
+					logFormat = env.Value
+				} else if strings.Contains(OtelCollectorAddress, env.Name) {
+					otelCollectorAddress = env.Value
+				}
+			}
+		}
+	}
+
+	YamlString = strings.ReplaceAll(YamlString, PowerScaleImage, pscaleImage)
+	YamlString = strings.ReplaceAll(YamlString, PowerscaleLogLevel, logLevel)
+	YamlString = strings.ReplaceAll(YamlString, PowerScaleMaxConcurrentQueries, maxConcurrentQueries)
+	YamlString = strings.ReplaceAll(YamlString, PowerscaleCapacityMetricsEnabled, capacityEnabled)
+	YamlString = strings.ReplaceAll(YamlString, PowerscalePerformanceMetricsEnabled, performanceEnabled)
+	YamlString = strings.ReplaceAll(YamlString, PowerscaleClusterCapacityPollFrequency, clusterCapacityPollFrequency)
+	YamlString = strings.ReplaceAll(YamlString, PowerscaleClusterPerformancePollFrequency, clusterPerformancePollFrequency)
+	YamlString = strings.ReplaceAll(YamlString, PowerscaleQuotaCapacityPollFrequency, quotaCapacityPollFrequency)
+	YamlString = strings.ReplaceAll(YamlString, IsiclientInsecure, clientInsecure)
+	YamlString = strings.ReplaceAll(YamlString, IsiclientAuthType, clientAuthType)
+	YamlString = strings.ReplaceAll(YamlString, IsiclientVerbose, clientVerbose)
+	YamlString = strings.ReplaceAll(YamlString, PowerscaleLogFormat, logFormat)
+	YamlString = strings.ReplaceAll(YamlString, OtelCollectorAddress, otelCollectorAddress)
 	return YamlString, nil
 }
 

--- a/pkg/modules/testdata/cr_powerscale_observability.yaml
+++ b/pkg/modules/testdata/cr_powerscale_observability.yaml
@@ -32,3 +32,84 @@ spec:
             # Default value: "INFO"
             - name: "TOPOLOGY_LOG_LEVEL"
               value: "INFO"
+
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: false
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: otel/opentelemetry-collector:0.42.0
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.20"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.20"
+
+        - name: metrics-powerscale
+          # enabled: Enable/Disable PowerScale metrics
+          enabled: true
+          # image: Defines PowerScale metrics image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-metrics-powerscale:v1.0.0
+          envs:
+            # POWERSCALE_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerScale
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERSCALE_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERSCALE_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_PERFORMANCE_METRICS_ENABLED: enable/disable collection of performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY: set polling frequency to get cluster capacity metrics data
+            # Allowed values: int
+            # Default value: 30
+            - name: "POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get cluster performance metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY"
+              value: "20"
+            # POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY: set polling frequency to get Quota capacity metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # ISICLIENT_INSECURE: set true/false to skip/verify OneFS API server's certificates
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_INSECURE"
+              value: "true"
+            # ISICLIENT_AUTH_TYPE: set 0/1 to enables session-based/basic Authentication
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_AUTH_TYPE"
+              value: "1"
+            # ISICLIENT_VERBOSE: set 0/1/2 decide High/Medium/Low content of the OneFS REST API message should be logged in debug level logs
+            # Allowed values: 0,1,2
+            # Default value: 0
+            - name: "ISICLIENT_VERBOSE"
+              value: "0"
+            # PowerScale metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERSCALE_LOG_LEVEL"
+              value: "INFO"
+            # PowerScale Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERSCALE_LOG_FORMAT"
+              value: "TEXT"
+            # Otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"

--- a/samples/storage_csm_powerscale_v240.yaml
+++ b/samples/storage_csm_powerscale_v240.yaml
@@ -327,3 +327,84 @@ spec:
             # Default value: "INFO"
             - name: "TOPOLOGY_LOG_LEVEL"
               value: "INFO"           
+
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: false
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: otel/opentelemetry-collector:0.42.0
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.20"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.20"
+
+        - name: metrics-powerscale
+          # enabled: Enable/Disable PowerScale metrics
+          enabled: false
+          # image: Defines PowerScale metrics image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-metrics-powerscale:v1.0.0
+          envs:
+            # POWERSCALE_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerScale
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERSCALE_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERSCALE_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_PERFORMANCE_METRICS_ENABLED: enable/disable collection of performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY: set polling frequency to get cluster capacity metrics data
+            # Allowed values: int
+            # Default value: 30
+            - name: "POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get cluster performance metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY"
+              value: "20"
+            # POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY: set polling frequency to get Quota capacity metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # ISICLIENT_INSECURE: set true/false to skip/verify OneFS API server's certificates
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_INSECURE"
+              value: "true"
+            # ISICLIENT_AUTH_TYPE: set 0/1 to enables session-based/basic Authentication
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_AUTH_TYPE"
+              value: "1"
+            # ISICLIENT_VERBOSE: set 0/1/2 decide High/Medium/Low content of the OneFS REST API message should be logged in debug level logs
+            # Allowed values: 0,1,2
+            # Default value: 0
+            - name: "ISICLIENT_VERBOSE"
+              value: "0"
+            # PowerScale metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERSCALE_LOG_LEVEL"
+              value: "INFO"
+            # PowerScale Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERSCALE_LOG_FORMAT"
+              value: "TEXT"
+            # Otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -74,8 +74,8 @@ var _ = BeforeSuite(func() {
 	Expect(valuesFile).NotTo(BeEmpty(), "Missing environment variable required for tests. E2E_VALUES_FILE must both be set.")
 
 	for _, moduleEnvVar := range moduleEnvVars {
-		moduleEnvVar = os.Getenv(moduleEnvVar)
-		if moduleEnvVar != "" {
+		enabled := os.Getenv(moduleEnvVar)
+		if enabled == "true" {
 			installedModules = append(installedModules, strings.ToLower(moduleEnvVar))
 		}
 	}

--- a/tests/e2e/steps/step_common.go
+++ b/tests/e2e/steps/step_common.go
@@ -100,6 +100,32 @@ func checkObservabilityRunningPods(namespace string, k8sClient kubernetes.Interf
 				allReady = false
 				notReadyMessage += fmt.Sprintf("\nThe pod(%s) is %s", pod.Name, pod.Status.Phase)
 			}
+		} else if strings.Contains(pod.Name, "metrics") {
+			if pod.Status.Phase == corev1.PodRunning {
+				for _, cntStat := range pod.Status.ContainerStatuses {
+					if cntStat.State.Running == nil {
+						allReady = false
+						notReadyMessage += fmt.Sprintf("\nThe container(%s) in pod(%s) is %s", cntStat.Name, pod.Name, cntStat.State)
+						break
+					}
+				}
+			} else {
+				allReady = false
+				notReadyMessage += fmt.Sprintf("\nThe pod(%s) is %s", pod.Name, pod.Status.Phase)
+			}
+		} else if strings.Contains(pod.Name, "otel") {
+			if pod.Status.Phase == corev1.PodRunning {
+				for _, cntStat := range pod.Status.ContainerStatuses {
+					if cntStat.State.Running == nil {
+						allReady = false
+						notReadyMessage += fmt.Sprintf("\nThe container(%s) in pod(%s) is %s", cntStat.Name, pod.Name, cntStat.State)
+						break
+					}
+				}
+			} else {
+				allReady = false
+				notReadyMessage += fmt.Sprintf("\nThe pod(%s) is %s", pod.Name, pod.Status.Phase)
+			}
 		}
 	}
 

--- a/tests/e2e/testfiles/storage_csm_powerscale.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale.yaml
@@ -267,3 +267,84 @@ spec:
             # Default value: "INFO"
             - name: "TOPOLOGY_LOG_LEVEL"
               value: "INFO"              
+
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: false
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: otel/opentelemetry-collector:0.42.0
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.20"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.20"
+
+        - name: metrics-powerscale
+          # enabled: Enable/Disable PowerScale metrics
+          enabled: false
+          # image: Defines PowerScale metrics image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-metrics-powerscale:v1.0.0
+          envs:
+            # POWERSCALE_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerScale
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERSCALE_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERSCALE_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_PERFORMANCE_METRICS_ENABLED: enable/disable collection of performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY: set polling frequency to get cluster capacity metrics data
+            # Allowed values: int
+            # Default value: 30
+            - name: "POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get cluster performance metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY"
+              value: "20"
+            # POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY: set polling frequency to get Quota capacity metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # ISICLIENT_INSECURE: set true/false to skip/verify OneFS API server's certificates
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_INSECURE"
+              value: "true"
+            # ISICLIENT_AUTH_TYPE: set 0/1 to enables session-based/basic Authentication
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_AUTH_TYPE"
+              value: "1"
+            # ISICLIENT_VERBOSE: set 0/1/2 decide High/Medium/Low content of the OneFS REST API message should be logged in debug level logs
+            # Allowed values: 0,1,2
+            # Default value: 0
+            - name: "ISICLIENT_VERBOSE"
+              value: "0"
+            # PowerScale metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERSCALE_LOG_LEVEL"
+              value: "INFO"
+            # PowerScale Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERSCALE_LOG_FORMAT"
+              value: "TEXT"
+            # Otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"

--- a/tests/e2e/testfiles/storage_csm_powerscale_observability.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_observability.yaml
@@ -253,3 +253,84 @@ spec:
             # Default value: "INFO"
             - name: "TOPOLOGY_LOG_LEVEL"
               value: "INFO"           
+
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: true
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: otel/opentelemetry-collector:0.42.0
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.20"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.20"
+
+        - name: metrics-powerscale
+          # enabled: Enable/Disable PowerScale metrics
+          enabled: true
+          # image: Defines PowerScale metrics image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-metrics-powerscale:v1.0.0
+          envs:
+            # POWERSCALE_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerScale
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERSCALE_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERSCALE_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_PERFORMANCE_METRICS_ENABLED: enable/disable collection of performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY: set polling frequency to get cluster capacity metrics data
+            # Allowed values: int
+            # Default value: 30
+            - name: "POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get cluster performance metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY"
+              value: "20"
+            # POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY: set polling frequency to get Quota capacity metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # ISICLIENT_INSECURE: set true/false to skip/verify OneFS API server's certificates
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_INSECURE"
+              value: "true"
+            # ISICLIENT_AUTH_TYPE: set 0/1 to enables session-based/basic Authentication
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_AUTH_TYPE"
+              value: "1"
+            # ISICLIENT_VERBOSE: set 0/1/2 decide High/Medium/Low content of the OneFS REST API message should be logged in debug level logs
+            # Allowed values: 0,1,2
+            # Default value: 0
+            - name: "ISICLIENT_VERBOSE"
+              value: "0"
+            # PowerScale metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERSCALE_LOG_LEVEL"
+              value: "INFO"
+            # PowerScale Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERSCALE_LOG_FORMAT"
+              value: "TEXT"
+            # Otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"

--- a/tests/e2e/testfiles/values.yaml
+++ b/tests/e2e/testfiles/values.yaml
@@ -165,7 +165,7 @@
     - "Delete resources"
 
 - scenario: "Install PowerScale Driver(Standalone), Enable Observability"
-  path: "testfiles/storage_csm_powerscale_observability.yaml"
+  path: "testfiles/storage_csm_powerscale.yaml"
   modules:
     - "observability"
   steps:


### PR DESCRIPTION
# Description
Add observability metrics for PowerScale

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/488|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] UT
    PASS
```
~/csm-operator/controllers# go test ./... -coverprofile cover.out
ok      github.com/dell/csm-operator/controllers        0.730s  coverage: 88.6% of statements
~/csm-operator/pkg/modules# go test ./... -coverprofile cover.out
ok      github.com/dell/csm-operator/pkg/modules        0.130s  coverage: 89.3% of statements
```

- [x] e2e
  PASS
```
Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2022-10-18 23:15:17.4351608 -0400 -0400
            Ended:     2022-10-18 23:17:42.531959242 -0400 -0400
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 22.842835543s
                        Min: 6.544071162s
                        Max: 39.141599925s
                        Histogram:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 9.680700677s
                        Min: 8.832446786s
                        Max: 10.528954568s
                        Histogram:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 1m3.68881545s
                        Min: 41.985988825s
                        Max: 1m25.391642075s
                        Histogram:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 21.476539ms
                        Min: 16.909508ms
                        Max: 26.04357ms
                        Histogram:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 10.798936548s
                        Min: 6.36200046s
                        Max: 15.235872636s
                        Histogram:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 35.157570585s
                        Min: 15.399487697s
                        Max: 1m20.485918142s
                        Histogram:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.419191333s
                        Min: 942.561274ms
                        Max: 1.827422881s
                        Histogram:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-b05ad0c7/VolumeIoSuite9/EntityNumberOverTime.png

[2022-10-18 23:17:43]  INFO Avg time of a run:   130.66s
[2022-10-18 23:17:43]  INFO Avg time of a del:   12.03s
[2022-10-18 23:17:43]  INFO Avg time of all:     145.10s
[2022-10-18 23:17:43]  INFO During this run 100.0% of suites succeeded
STEP:      Executing  Enable forceRemoveDriver on CR
STEP:      Executing  Delete resources
STEP: Ending: Install PowerScale Driver(Standalone)

STEP: Starting: Install PowerScale Driver(With Authorization)
STEP: Required module not installed: authorization
STEP: Required module not installed, skipping
STEP: Ending: Install PowerScale Driver(With Authorization)

STEP: Starting: Install PowerScale Driver(Standalone), Enable Authorization
STEP: Required module not installed: authorization
STEP: Required module not installed, skipping
STEP: Ending: Install PowerScale Driver(Standalone), Enable Authorization

STEP: Starting: Install PowerScale Driver(With Replication)
STEP: Required module not installed: replication
STEP: Required module not installed, skipping
STEP: Ending: Install PowerScale Driver(With Replication)

STEP: Starting: Install PowerScale Driver(Standalone), Enable Replication
STEP: Required module not installed: replication
STEP: Required module not installed, skipping
STEP: Ending: Install PowerScale Driver(Standalone), Enable Replication

STEP: Starting: Uninstall PowerScale Driver
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resources
Oct 18 23:17:48.161: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 18 23:17:48.461: INFO: stderr: ""
Oct 18 23:17:48.461: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
STEP:      Executing  Validate custom resources
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Enable forceRemoveDriver on CR
STEP:      Executing  Delete resources
STEP:      Executing  Validate [powerscale] driver is not installed
STEP: Ending: Uninstall PowerScale Driver

STEP: Starting: Install PowerScale Driver(With Authorization), Disable Authorization module"
STEP: Required module not installed: authorization
STEP: Required module not installed, skipping
STEP: Ending: Install PowerScale Driver(With Authorization), Disable Authorization module"

STEP: Starting: Install PowerScale Driver(With Replication), Disable Replication module"
STEP: Required module not installed: replication
STEP: Required module not installed, skipping
STEP: Ending: Install PowerScale Driver(With Replication), Disable Replication module"

STEP: Starting: Install PowerScale Driver(With Observability)
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resources
Oct 18 23:18:13.542: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 18 23:18:13.771: INFO: stderr: ""
Oct 18 23:18:13.771: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
STEP:      Executing  Validate custom resources
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is installed
STEP:      Executing  Enable forceRemoveDriver on CR
STEP:      Executing  Delete resources
STEP: Ending: Install PowerScale Driver(With Observability)

STEP: Starting: Install PowerScale Driver(Standalone), Enable Observability
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resources
Oct 18 23:18:28.853: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 18 23:18:29.076: INFO: stderr: ""
Oct 18 23:18:29.076: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
STEP:      Executing  Validate custom resources
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is not installed
STEP:      Executing  Enable [observability] module
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is installed
STEP:      Executing  Enable forceRemoveDriver on CR
STEP:      Executing  Delete resources
STEP: Ending: Install PowerScale Driver(Standalone), Enable Observability

STEP: Starting: Install PowerScale Driver(With Observability), Disable Observability module"
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resources
Oct 18 23:18:44.203: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 18 23:18:44.420: INFO: stderr: ""
Oct 18 23:18:44.420: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
STEP:      Executing  Validate custom resources
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is installed
STEP:      Executing  Disable [observability] module
STEP:      Executing  Validate [powerscale] driver is installed
STEP:      Executing  Validate [observability] module is not installed
STEP:      Executing  Enable forceRemoveDriver on CR
STEP:      Executing  Delete resources
STEP: Ending: Install PowerScale Driver(With Observability), Disable Observability module"


• [SLOW TEST:242.485 seconds]
[run-e2e-test]E2E Testing
/root/csm-operator/tests/e2e/e2e_test.go:110
  Running all test Given Test Scenarios
  /root/csm-operator/tests/e2e/e2e_test.go:111
------------------------------

Ran 1 of 1 Specs in 242.708 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS



```

- [x] Manual
Capacity panel
![image](https://user-images.githubusercontent.com/105041254/196419674-6fb88d47-c577-4957-84ef-76b8f9f2d5c4.png)

IO panel
![image](https://user-images.githubusercontent.com/105041254/196419802-fb4cc5f8-7167-4b90-8cc6-5be1889439f8.png)

