### PR TITLE
enable authorization for observability metrics-powerscale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,latest)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -498,8 +498,8 @@ func (r *ContainerStorageModuleReconciler) oldStandAloneModuleCleanup(ctx contex
 		}
 		// check if observability needs to be uninstalled
 		// NOTE: check if individual component need to be uninstalled
-		oldObservabilityEnabled, _ := utils.IsModuleEnabled(ctx, *oldCR, r, csmv1.Observability)
-		newObservabilityEnabled, _ := utils.IsModuleEnabled(ctx, *newCR, r, csmv1.Observability)
+		oldObservabilityEnabled, _ := utils.IsModuleEnabled(ctx, *oldCR, csmv1.Observability)
+		newObservabilityEnabled, _ := utils.IsModuleEnabled(ctx, *newCR, csmv1.Observability)
 		if oldObservabilityEnabled && !newObservabilityEnabled {
 			_, clusterClients, err := utils.GetDefaultClusters(ctx, *oldCR, r)
 			if err != nil {
@@ -508,7 +508,7 @@ func (r *ContainerStorageModuleReconciler) oldStandAloneModuleCleanup(ctx contex
 			for _, cluster := range clusterClients {
 				// remove module observability
 				log.Infow("Deleting observability")
-				if err = r.reconcileObservability(ctx, true, operatorConfig, *oldCR, cluster.ClusterCTRLClient); err != nil {
+				if err = r.reconcileObservability(ctx, true, operatorConfig, *oldCR, cluster.ClusterCTRLClient, cluster.ClusterK8sClient); err != nil {
 					return err
 				}
 			}
@@ -638,10 +638,10 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 		}
 
 		// if Observability is enabled, create or update obs components: topology, metrics of PowerScale and PowerFlex
-		if observabilityEnabled, _ := utils.IsModuleEnabled(ctx, cr, r, csmv1.Observability); observabilityEnabled {
+		if observabilityEnabled, _ := utils.IsModuleEnabled(ctx, cr, csmv1.Observability); observabilityEnabled {
 			log.Infow("Create/Update observability")
 
-			if err = r.reconcileObservability(ctx, false, operatorConfig, cr, cluster.ClusterCTRLClient); err != nil {
+			if err = r.reconcileObservability(ctx, false, operatorConfig, cr, cluster.ClusterCTRLClient, cluster.ClusterK8sClient); err != nil {
 				return err
 			}
 		}
@@ -653,22 +653,29 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 
 // reconcileObservability - Delete/Create/Update observability components
 // isDeleting - ture: Delete; false: Create/Update
-func (r *ContainerStorageModuleReconciler) reconcileObservability(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient client.Client) error {
+func (r *ContainerStorageModuleReconciler) reconcileObservability(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient client.Client, k8sClient kubernetes.Interface) error {
 	log := logger.GetLogger(ctx)
 
 	comp2reconFunc := map[string]func(context.Context, bool, utils.OperatorConfig, csmv1.ContainerStorageModule, client.Client) error{
-		modules.ObservabilityTopologyName:          modules.ObservabilityTopology,
-		modules.ObservabilityOtelCollectorName:     modules.OtelCollector,
-		modules.ObservabilityMetricsPowerScaleName: modules.PowerScaleMetrics,
+		modules.ObservabilityTopologyName:      modules.ObservabilityTopology,
+		modules.ObservabilityOtelCollectorName: modules.OtelCollector,
 	}
 
 	for comp, reconFunc := range comp2reconFunc {
-		if utils.IsComponentEnabled(ctx, cr, r, csmv1.Observability, comp) {
+		if utils.IsComponentEnabled(ctx, cr, csmv1.Observability, comp) {
 			log.Infow(fmt.Sprintf("reconcile %s", comp))
 			if err := reconFunc(ctx, isDeleting, op, cr, ctrlClient); err != nil {
 				log.Errorf("failed to reconcile %s", comp)
 				return err
 			}
+		}
+	}
+
+	if utils.IsComponentEnabled(ctx, cr, csmv1.Observability, modules.ObservabilityMetricsPowerScaleName) {
+		log.Infow("Reconcile PowerScale metrics")
+		if err := modules.PowerScaleMetrics(ctx, isDeleting, op, cr, ctrlClient, k8sClient); err != nil {
+			log.Errorf("failed to deploy powerscale metrics")
+			return err
 		}
 	}
 
@@ -831,9 +838,9 @@ func (r *ContainerStorageModuleReconciler) removeDriver(ctx context.Context, ins
 		}
 
 		// remove module observability
-		if observabilityEnabled, _ := utils.IsModuleEnabled(ctx, instance, r, csmv1.Observability); observabilityEnabled {
+		if observabilityEnabled, _ := utils.IsModuleEnabled(ctx, instance, csmv1.Observability); observabilityEnabled {
 			log.Infow("Deleting observability")
-			if err = r.reconcileObservability(ctx, true, operatorConfig, instance, cluster.ClusterCTRLClient); err != nil {
+			if err = r.reconcileObservability(ctx, true, operatorConfig, instance, cluster.ClusterCTRLClient, cluster.ClusterK8sClient); err != nil {
 				return err
 			}
 		}

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -906,22 +906,22 @@ func (suite *CSMControllerTestSuite) TestReconcileObservabilityError() {
 	badOperatorConfig := utils.OperatorConfig{
 		ConfigDirectory: "../in-valid-path",
 	}
-	err := reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient)
+	err := reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient, suite.k8sClient)
 	assert.NotNil(suite.T(), err)
 
 	// Only test for Otel component
 	csm.Spec.Modules[0].Components[0].Enabled = &[]bool{false}[0]
-	err = reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient)
+	err = reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient, suite.k8sClient)
 	assert.NotNil(suite.T(), err)
 
 	// Only test for Metrics component
 	csm.Spec.Modules[0].Components[1].Enabled = &[]bool{false}[0]
-	err = reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient)
+	err = reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient, suite.k8sClient)
 	assert.Error(suite.T(), err)
 
 	// Test for all components disabled
 	csm.Spec.Modules[0].Components[2].Enabled = &[]bool{false}[0]
-	err = reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient)
+	err = reconciler.reconcileObservability(ctx, false, badOperatorConfig, csm, suite.fakeClient, suite.k8sClient)
 	assert.Nil(suite.T(), err)
 
 	// Restore the status
@@ -954,8 +954,18 @@ func (suite *CSMControllerTestSuite) makeFakeCSM(name, ns string, withFinalizer 
 	assert.Nil(suite.T(), err)
 
 	// this secret required by observability isilon module
-	obsIsilonSec := shared.MakeSecret("isilon-creds", "karavi", configVersion)
+	obsIsilonSec := shared.MakeSecret(name+"-creds", "karavi", configVersion)
 	suite.fakeClient.Create(ctx, obsIsilonSec)
+
+	// this secret required by observability authorization isilon module
+	sec = shared.MakeSecret("karavi-authorization-config", "karavi", configVersion)
+	err = suite.fakeClient.Create(ctx, sec)
+	assert.Nil(suite.T(), err)
+
+	// this secret required by observability authorization isilon module
+	sec = shared.MakeSecret("proxy-authz-tokens", "karavi", configVersion)
+	err = suite.fakeClient.Create(ctx, sec)
+	assert.Nil(suite.T(), err)
 
 	csm := shared.MakeCSM(name, ns, configVersion)
 	csm.Spec.Driver.Common.Image = "image"

--- a/operatorconfig/moduleconfig/observability/v1.3.0/karavi-metrics-powerscale.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.3.0/karavi-metrics-powerscale.yaml
@@ -81,6 +81,17 @@ data:
 
 ---
 
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: karavi
+data:
+  driver-config-params.yaml: |
+    CSI_LOG_LEVEL: debug
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -127,7 +138,7 @@ spec:
       volumes:
         - name: isilon-creds
           secret:
-            secretName: isilon-creds
+            secretName: <DriverDefaultReleaseName>-creds
         - name: tls-secret
           secret:
             secretName: otel-collector-tls
@@ -137,6 +148,9 @@ spec:
         - name: karavi-metrics-powerscale-configmap
           configMap:
             name: karavi-metrics-powerscale-configmap
+        - name: csi-isilon-config-params
+          configMap:
+             name: <DriverDefaultReleaseName>-config-params
       restartPolicy: Always
 status: {}
 

--- a/pkg/modules/observability_test.go
+++ b/pkg/modules/observability_test.go
@@ -14,6 +14,7 @@ import (
 
 	csmv1 "github.com/dell/csm-operator/api/v1"
 	utils "github.com/dell/csm-operator/pkg/utils"
+	"github.com/dell/csm-operator/tests/shared/clientgoclient"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "isilon-creds")
+			isilonCreds := getSecret("karavi", "test-isilon-creds")
 
 			tmpCR := customResource
 			observability := tmpCR.Spec.Modules[0]
@@ -53,7 +54,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "isilon-creds")
+			isilonCreds := getSecret("karavi", "test-isilon-creds")
 
 			tmpCR := customResource
 			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
@@ -74,7 +75,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "isilon-creds")
+			isilonCreds := getSecret("karavi", "test-isilon-creds")
 
 			tmpCR := customResource
 			observability := tmpCR.Spec.Modules[0]
@@ -89,13 +90,38 @@ func TestObservabilityPrecheck(t *testing.T) {
 			return true, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
 		},
 
+		"success - auth injected": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			isilonCreds := getSecret("karavi", "test-isilon-creds")
+			karaviAuthconfig := getSecret("karavi", "karavi-authorization-config")
+			proxyAuthzTokens := getSecret("karavi", "proxy-authz-tokens")
+
+			tmpCR := customResource
+			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
+			observability := tmpCR.Spec.Modules[0]
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds, karaviAuthconfig, proxyAuthzTokens).Build()
+			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
+				clusterClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds).Build()
+				return clusterClient, nil
+			}
+
+			return true, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
+
 		"Fail - unsupported observability version": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
 			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
 			if err != nil {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "isilon-creds")
+			isilonCreds := getSecret("karavi", "test-isilon-creds")
 
 			tmpCR := customResource
 			observability := tmpCR.Spec.Modules[0]
@@ -116,7 +142,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "isilon-creds")
+			isilonCreds := getSecret("karavi", "test-isilon-creds")
 
 			tmpCR := customResource
 			tmpCR.Spec.Driver.CSIDriverType = "unsupported-driver"
@@ -129,6 +155,81 @@ func TestObservabilityPrecheck(t *testing.T) {
 			}
 
 			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
+
+		"Fail - isilon secrets not provided": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
+			observability := tmpCR.Spec.Modules[0]
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+
+			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
+				return ctrlClientFake.NewClientBuilder().WithObjects().Build(), nil
+			}
+
+			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
+
+		"Fail - auth secrets not provided": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			isilonCreds := getSecret("karavi", "test-isilon-creds")
+
+			tmpCR := customResource
+			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
+			observability := tmpCR.Spec.Modules[0]
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds).Build()
+
+			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
+				return ctrlClientFake.NewClientBuilder().WithObjects().Build(), nil
+			}
+
+			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
+
+		"Fail - SKIP_CERTIFICATE_VALIDATION is false but no cert": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			isilonCreds := getSecret("karavi", "test-isilon-creds")
+			karaviAuthconfig := getSecret("karavi", "karavi-authorization-config")
+			proxyAuthzTokens := getSecret("karavi", "proxy-authz-tokens")
+
+			tmpCR := customResource
+			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
+			observability := tmpCR.Spec.Modules[0]
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			// set skipCertificateValidation to false
+			for i, env := range auth.Components[0].Envs {
+				if env.Name == "SKIP_CERTIFICATE_VALIDATION" {
+					auth.Components[0].Envs[i].Value = "false"
+				}
+			}
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds, karaviAuthconfig, proxyAuthzTokens).Build()
+
+			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
+				return ctrlClientFake.NewClientBuilder().WithObjects().Build(), nil
+			}
+
+			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
+
 		},
 	}
 	for name, tc := range tests {
@@ -254,7 +355,29 @@ func TestPowerScaleMetrics(t *testing.T) {
 
 			return true, true, tmpCR, sourceClient, operatorConfig
 		},
+		"success - deleting with auth": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
 
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			cr := &rbacv1.ClusterRole{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ClusterRole",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "karavi-metrics-powerscale-controller",
+				},
+			}
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(cr).Build()
+
+			return true, true, tmpCR, sourceClient, operatorConfig
+		},
 		"success - creating": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
 			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
 			if err != nil {
@@ -262,6 +385,20 @@ func TestPowerScaleMetrics(t *testing.T) {
 			}
 
 			tmpCR := customResource
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+
+			return true, false, tmpCR, sourceClient, operatorConfig
+		},
+		"success - creating with auth": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
 
 			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
 
@@ -285,8 +422,8 @@ func TestPowerScaleMetrics(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			success, isDeleting, cr, sourceClient, op := tc(t)
-
-			err := PowerScaleMetrics(context.TODO(), isDeleting, op, cr, sourceClient)
+			k8sClient := clientgoclient.NewFakeClient(sourceClient)
+			err := PowerScaleMetrics(context.TODO(), isDeleting, op, cr, sourceClient, k8sClient)
 			if success {
 				assert.NoError(t, err)
 

--- a/pkg/modules/testdata/cr_powerscale_observability.yaml
+++ b/pkg/modules/testdata/cr_powerscale_observability.yaml
@@ -113,3 +113,17 @@ spec:
             # Default value: "otel-collector:55680"
             - name: "COLLECTOR_ADDRESS"
               value: "otel-collector:55680"
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: false
+      components:
+      - name: karavi-authorization-proxy
+        image: dellemc/csm-authorization-sidecar:v1.4.0
+        envs:
+          # proxyHost: hostname of the csm-authorization server
+          - name: "PROXY_HOST"
+            value: "testing-proxy-host"
+        
+          # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server       
+          - name: "SKIP_CERTIFICATE_VALIDATION"
+            value: "true"

--- a/pkg/resources/deployment/deployment.go
+++ b/pkg/resources/deployment/deployment.go
@@ -29,9 +29,8 @@ func SyncDeployment(ctx context.Context, deployment appsv1.DeploymentApplyConfig
 		log.Errorw("get SyncDeployment error", "Error", err.Error())
 	}
 	opts := metav1.ApplyOptions{FieldManager: "application/apply-patch"}
-	if found.Name == "" {
-		log.Infow("No existing Deployment", "Name:", found.Name)
-
+	if found == nil || found.Name == "" {
+		log.Infow("No existing Deployment", "Name:", deployment.Name)
 	} else {
 		log.Infow("found deployment", "image", found.Spec.Template.Spec.Containers[0].Image)
 	}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -4,7 +4,6 @@ import (
 	"sync/atomic"
 
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -23,13 +22,13 @@ type ReconcileCSM interface {
 // FakeReconcileCSM -
 type FakeReconcileCSM struct {
 	reconcile.Reconciler
-	client.Client
+	crclient.Client
 	K8sClient   kubernetes.Interface
 	updateCount int32
 }
 
 // GetClient -
-func (r *FakeReconcileCSM) GetClient() client.Client {
+func (r *FakeReconcileCSM) GetClient() crclient.Client {
 	return r.Client
 }
 

--- a/tests/e2e/testfiles/storage_csm_powerscale_observability_auth.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_observability_auth.yaml
@@ -1,0 +1,352 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: test-isilon
+  namespace: test-isilon
+spec:
+  driver:
+    csiDriverType: "isilon" 
+    csiDriverSpec:
+      # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+      # Allowed values: ReadWriteOnceWithFSType, File , None
+      # Default value: ReadWriteOnceWithFSType
+      fSGroupPolicy: "ReadWriteOnceWithFSType"
+    # Config version for CSI PowerScale v2.4.0 driver
+    configVersion: v2.4.0
+    authSecret: test-isilon-creds-auth
+    replicas: 2
+    dnsPolicy: ClusterFirstWithHostNet
+    # Uninstall CSI Driver and/or modules when CR is deleted
+    forceRemoveDriver: true
+    common:
+      # Image for CSI PowerScale driver v2.4.0
+      image: "dellemc/csi-isilon:v2.4.0"
+      imagePullPolicy: IfNotPresent
+      envs:
+        # X_CSI_VERBOSE: Indicates what content of the OneFS REST API message should be logged in debug level logs
+        # Allowed Values:
+        #   0: log full content of the HTTP request and response
+        #   1: log without the HTTP response body
+        #   2: log only 1st line of the HTTP request and response
+        # Default value: 0
+        - name: X_CSI_VERBOSE
+          value: "1"
+
+        # X_CSI_ISI_PORT: Specify the HTTPs port number of the PowerScale OneFS API server
+        # This value acts as a default value for endpointPort, if not specified for a cluster config in secret
+        # Allowed value: valid port number
+        # Default value: 8080	
+        - name: X_CSI_ISI_PORT
+          value: "8080"
+
+        # X_CSI_ISI_PATH: The base path for the volumes to be created on PowerScale cluster.
+        # This value acts as a default value for isiPath, if not specified for a cluster config in secret
+        # Ensure that this path exists on PowerScale cluster.
+        # Allowed values: unix absolute path
+        # Default value: /ifs
+        # Examples: /ifs/data/csi, /ifs/engineering
+        - name: X_CSI_ISI_PATH
+          value: "/ifs/data/csi"
+
+        # X_CSI_ISI_NO_PROBE_ON_START: Indicates whether the controller/node should probe all the PowerScale clusters during driver initialization
+        # Allowed values:
+        #   true : do not probe all PowerScale clusters during driver initialization	
+        #   false: probe all PowerScale clusters during driver initialization
+        # Default value: false
+        - name: X_CSI_ISI_NO_PROBE_ON_START
+          value: "false"
+
+        # X_CSI_ISI_AUTOPROBE: automatically probe the PowerScale cluster if not done already during CSI calls.
+        # Allowed values:
+        #   true : enable auto probe.
+        #   false: disable auto probe.
+        # Default value: false
+        - name: X_CSI_ISI_AUTOPROBE
+          value: "true"
+
+        # X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION: Specify whether the PowerScale OneFS API server's certificate chain and host name should be verified.
+        # Formerly this attribute was named as "X_CSI_ISI_INSECURE"
+        # This value acts as a default value for skipCertificateValidation, if not specified for a cluster config in secret
+        # Allowed values:
+        #   true: skip OneFS API server's certificate verification
+        #   false: verify OneFS API server's certificates 
+        # Default value: true	
+        - name: X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION
+          value: "true"
+
+        # X_CSI_CUSTOM_TOPOLOGY_ENABLED: Specify if custom topology label <provisionerName>.dellemc.com/<powerscalefqdnorip>:<provisionerName>
+        # has to be used for making connection to backend PowerScale Array.
+        # If X_CSI_CUSTOM_TOPOLOGY_ENABLED is set to true, then do not specify allowedTopologies in storage class.
+        # Allowed values:
+        #   true : enable custom topology
+        #   false: disable custom topology
+        # Default value: false
+        - name: X_CSI_CUSTOM_TOPOLOGY_ENABLED
+          value: "false"
+
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: None
+        - name: KUBELET_CONFIG_DIR
+          value: "/var/lib/kubelet"
+        
+        # certSecretCount: Represents number of certificate secrets, which user is going to create for
+        # ssl authentication. (isilon-cert-0..isilon-cert-n)
+        # Allowed values: n, where n > 0
+        # Default value: None
+        - name: "CERT_SECRET_COUNT"
+          value: "1"
+
+        # CSI driver log level
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "debug"
+        - name: "CSI_LOG_LEVEL"
+          value: "debug"
+
+    controller:
+      envs:
+      # X_CSI_ISI_QUOTA_ENABLED: Indicates whether the provisioner should attempt to set (later unset) quota
+      # on a newly provisioned volume.
+      # This requires SmartQuotas to be enabled on PowerScale cluster.
+      # Allowed values:
+      #   true: set quota for volume
+      #   false: do not set quota for volume
+      - name: X_CSI_ISI_QUOTA_ENABLED
+        value: "true"
+
+      # X_CSI_ISI_ACCESS_ZONE: The name of the access zone a volume can be created in.
+      # If storageclass is missing with AccessZone parameter, then value of X_CSI_ISI_ACCESS_ZONE is used for the same.
+      # Default value: System
+      # Examples: System, zone1
+      - name: X_CSI_ISI_ACCESS_ZONE
+        value: "System"
+
+      # X_CSI_ISI_VOLUME_PATH_PERMISSIONS: The permissions for isi volume directory path
+      # This value acts as a default value for isiVolumePathPermissions, if not specified for a cluster config in secret
+      # Allowed values: valid octal mode number
+      # Default value: "0777"
+      # Examples: "0777", "777", "0755"
+      - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
+        value: "0777"
+
+      # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
+      # Install the 'external-health-monitor' sidecar accordingly.
+      # Allowed values:
+      #   true: enable checking of health condition of CSI volumes
+      #   false: disable checking of health condition of CSI volumes
+      # Default value: false
+      - name: X_CSI_HEALTH_MONITOR_ENABLED
+        value: "false"
+
+      # nodeSelector: Define node selection constraints for pods of controller deployment.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the controller deployment, if required.
+      # Default value: None
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      tolerations:
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # tolerations:
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+
+    node:
+      envs:
+      # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
+      # If value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node.
+      # This limit is applicable to all the nodes in the cluster for which node label 'max-isilon-volumes-per-node' is not set.
+      # Allowed values: n, where n >= 0
+      # Default value: 0
+      - name: X_CSI_MAX_VOLUMES_PER_NODE
+        value: "0"
+
+      # X_CSI_ALLOWED_NETWORKS: Custom networks for PowerScale export
+      # Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
+      # Allowed values: list of one or more networks
+      # Default value: None
+      # Provide them in the following format: "[net1, net2]"
+      # CIDR format should be used
+      # eg: "[192.168.1.0/24, 192.168.100.0/22]"
+      - name: X_CSI_ALLOWED_NETWORKS
+        value: ""
+
+      # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
+      # Install the 'external-health-monitor' sidecar accordingly.
+      # Allowed values:
+      #   true: enable checking of health condition of CSI volumes
+      #   false: disable checking of health condition of CSI volumes
+      # Default value: false
+      - name: X_CSI_HEALTH_MONITOR_ENABLED
+        value: "false"
+
+      # nodeSelector: Define node selection constraints for pods of node daemonset
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the node daemonset, if required.
+      # Default value: None
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      tolerations:
+      #  - key: "node.kubernetes.io/memory-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # tolerations:
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+
+    sideCars:
+      - name: provisioner
+        args: ["--volume-name-prefix=csipscale"]
+      # health monitor is disabled by default, refer to driver documentation before enabling it
+      - name: external-health-monitor
+        enabled: false
+        args: ["--monitor-interval=60s"]
+
+  modules:
+    # Authorization: enable csm-authorization for RBAC
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: true
+      configVersion: v1.4.0
+      components:
+      - name: karavi-authorization-proxy
+        image: dellemc/csm-authorization-sidecar:v1.4.0
+        envs:
+          # proxyHost: hostname of the csm-authorization server
+          - name: "PROXY_HOST"
+            value: ""
+        
+          # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server       
+          - name: "SKIP_CERTIFICATE_VALIDATION"
+            value: "true"
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: true
+      configVersion: v1.3.0
+      components: 
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: true
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-topology:v1.3.0
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"           
+
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: true
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: otel/opentelemetry-collector:0.42.0
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.20"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.20"
+
+        - name: metrics-powerscale
+          # enabled: Enable/Disable PowerScale metrics
+          enabled: true
+          # image: Defines PowerScale metrics image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-metrics-powerscale:v1.0.0
+          envs:
+            # POWERSCALE_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerScale
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERSCALE_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERSCALE_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_PERFORMANCE_METRICS_ENABLED: enable/disable collection of performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY: set polling frequency to get cluster capacity metrics data
+            # Allowed values: int
+            # Default value: 30
+            - name: "POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get cluster performance metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY"
+              value: "20"
+            # POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY: set polling frequency to get Quota capacity metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # ISICLIENT_INSECURE: set true/false to skip/verify OneFS API server's certificates
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_INSECURE"
+              value: "true"
+            # ISICLIENT_AUTH_TYPE: set 0/1 to enables session-based/basic Authentication
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_AUTH_TYPE"
+              value: "1"
+            # ISICLIENT_VERBOSE: set 0/1/2 decide High/Medium/Low content of the OneFS REST API message should be logged in debug level logs
+            # Allowed values: 0,1,2
+            # Default value: 0
+            - name: "ISICLIENT_VERBOSE"
+              value: "0"
+            # PowerScale metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERSCALE_LOG_LEVEL"
+              value: "INFO"
+            # PowerScale Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERSCALE_LOG_FORMAT"
+              value: "TEXT"
+            # Otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"

--- a/tests/e2e/testfiles/values.yaml
+++ b/tests/e2e/testfiles/values.yaml
@@ -198,6 +198,102 @@
     - "Enable forceRemoveDriver on CR"
     - "Delete resources"
 
+- scenario: "Install PowerScale Driver(With Authorization and Observability)"
+  path: "testfiles/storage_csm_powerscale_observability_auth.yaml"
+  modules:
+    - "observability"
+    - "authorization"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resources"
+    - "Validate custom resources"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is installed"
+    - "Validate [observability] module is installed"
+    - "Run custom test"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR"
+    - "Delete resources"
+  customTest:
+    name: Cert CSI
+    run: ./cert-csi test vio --sc isilon --chainNumber 2 --chainLength 2
+
+- scenario: "Install PowerScale Driver(Standalone), Enable Authorization, Enable Observability"
+  path: "testfiles/storage_csm_powerscale.yaml"
+  modules:
+    - "observability"
+    - "authorization"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resources"
+    - "Validate custom resources"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is not installed"
+    - "Validate [observability] module is not installed"
+    - "Enable [authorization] module"
+    - "Set Driver secret to [test-isilon-creds-auth]"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is installed"
+    - "Validate [observability] module is not installed"
+    - "Enable [observability] module"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is installed"
+    - "Validate [observability] module is installed"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR"
+    - "Delete resources"
+
+- scenario: Install PowerScale Driver(With Authorization and Observability), Disable Observability module, Disable Authorization module"
+  path: "testfiles/storage_csm_powerscale_observability_auth.yaml"
+  modules:
+    - "observability"
+    - "authorization"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resources"
+    - "Validate custom resources"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is installed"
+    - "Validate [observability] module is installed"
+    - "Disable [observability] module"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is installed"
+    - "Validate [observability] module is not installed"
+    - "Disable [authorization] module"
+    - "Set Driver secret to [test-isilon-creds]"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is not installed"
+    - "Validate [observability] module is not installed"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR"
+    - "Delete resources"
+
+- scenario: Install PowerScale Driver(With Authorization and Observability), Disable Authorization module, Disable Observability module"
+  path: "testfiles/storage_csm_powerscale_observability_auth.yaml"
+  modules:
+    - "observability"
+    - "authorization"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resources"
+    - "Validate custom resources"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is installed"
+    - "Validate [observability] module is installed"
+    - "Disable [authorization] module"
+    - "Set Driver secret to [test-isilon-creds]"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is not installed"
+    - "Validate [observability] module is installed"
+    - "Disable [observability] module"
+    - "Validate [powerscale] driver is installed"
+    - "Validate [authorization] module is not installed"
+    - "Validate [observability] module is not installed"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR"
+    - "Delete resources"
+
+
 - scenario: "Install PowerFlex Driver(Standalone)"
   path: "testfiles/storage_csm_powerflex.yaml"
   modules:


### PR DESCRIPTION
# Description
enable authorization for observability metrics-powerscale.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/488|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] unit test

```
~/csm-operator/controllers# go test ./... -coverprofile cover.out
ok      github.com/dell/csm-operator/controllers        0.884s  coverage: 89.0% of statements
~/csm-operator/pkg/modules# go test ./... -coverprofile cover.out
ok      github.com/dell/csm-operator/pkg/modules        0.153s  coverage: 89.3% of statements

```

- [x] e2e test
Passed: enable both modules observability and authorization
output:
 ```
 ~/csm-operator/tests/e2e
Oct 23 09:55:31.811: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
W1023 09:55:31.811132 3547715 test_context.go:460] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
Running Suite: CSM Operator End-to-End Tests
============================================
Random Seed:   1666533327   - Will randomize all specs
Will run   1   of   1   specs

  STEP  : Getting test environment variables
  STEP  : Reading values file
  STEP  : Getting a k8s client
  [run-e2e-test]E2E Testing   
    Running all test Given Test Scenarios  
   [37m ~/csm-operator/tests/e2e/e2e_test.go:110  
[It] Running all test Given Test Scenarios
   ~/csm-operator/tests/e2e/e2e_test.go:110
  STEP  : Starting: Install PowerScale Driver(Standalone) 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 09:55:32.199: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 09:55:32.428: INFO: stderr: ""
Oct 23 09:55:32.428: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Run custom test
Oct 23 09:55:42.446: INFO: Running ./cert-csi [test vio --sc isilon --chainNumber 2 --chainLength 2]
[2022-10-23 09:55:42]  INFO Starting cert-csi; ver. 0.8.1
[2022-10-23 09:55:42]  INFO Using EVENT observer type
[2022-10-23 09:55:42]  INFO Using config from /etc/kubernetes/admin.conf
[2022-10-23 09:55:42]  INFO Successfully loaded config. Host: https://10.225.108.156:6443
[2022-10-23 09:55:42]  INFO Created new KubeClient
[2022-10-23 09:55:42]  INFO Running 1 iteration(s)
[2022-10-23 09:55:42]  INFO 	*** ITERATION NUMBER 1 ***	
[2022-10-23 09:55:42]  INFO Starting VolumeIoSuite with isilon storage class
[2022-10-23 09:55:42]  INFO Successfully created namespace volumeio-test-fa67952c
[2022-10-23 09:55:42]  INFO Using default number of volumes
[2022-10-23 09:55:42]  INFO Creating IO pod
[2022-10-23 09:56:20]  INFO Waiting for pod iowriter-test-974fh to be READY
[2022-10-23 09:56:32]  INFO Waiting for pod iowriter-test-jrwhs to be READY
[2022-10-23 09:56:32]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2022-10-23 09:56:37]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2022-10-23 09:56:38]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2022-10-23 09:56:44]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2022-10-23 09:56:46]  INFO Waiting until no Volume Attachments with PV csipscale-95aca83125 left
[2022-10-23 09:56:48]  INFO VolumeAttachment deleted
[2022-10-23 09:56:48]  INFO Waiting for pod iowriter-test-4s7l7 to be READY
[2022-10-23 09:56:52]  INFO Waiting until no Volume Attachments with PV csipscale-2b7af66be5 left
[2022-10-23 09:56:58]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-0.sha512]
[2022-10-23 09:57:00]  INFO VolumeAttachment deleted
[2022-10-23 09:57:00]  INFO Waiting for pod iowriter-test-v8sbh to be READY
[2022-10-23 09:57:01]  INFO Hashes match
[2022-10-23 09:57:01]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2022-10-23 09:57:06]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2022-10-23 09:57:10]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-1.sha512]
[2022-10-23 09:57:11]  INFO Waiting until no Volume Attachments with PV csipscale-95aca83125 left
[2022-10-23 09:57:12]  INFO Hashes match
[2022-10-23 09:57:12]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2022-10-23 09:57:18]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2022-10-23 09:57:19]  INFO VolumeAttachment deleted
[2022-10-23 09:57:22]  INFO Waiting until no Volume Attachments with PV csipscale-2b7af66be5 left
[2022-10-23 09:57:30]  INFO VolumeAttachment deleted
[2022-10-23 09:57:30]  INFO Deleting all resources in namespace volumeio-test-fa67952c
[2022-10-23 09:57:42]  INFO Namespace volumeio-test-fa67952c was deleted in 12.015886287s
[2022-10-23 09:57:47]  INFO SUCCESS: VolumeIoSuite in 2m5.077024806s
[2022-10-23 09:57:47]  INFO Started generating reports...
Collecting metrics
1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sCollecting metrics
[2022-10-23 09:57:47]  INFO Started generating reports...
Generating plots
1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [------------------------------------------------------------------------------------------------------------------------------------------------------>] 100.00% ? p/s1 / 1 [------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 21 p/s[2022-10-23 09:57:47]  WARN No ResourceUsageMetrics provided
[2022-10-23 09:57:47] ERROR no ResourceUsageMetrics provided
report-test-run-43824440:
Name: test-run-43824440
Host: https://10.225.108.156:6443
StorageClass: isilon
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-43824440/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-43824440/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-43824440/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-43824440/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-43824440/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2022-10-23 09:55:42.545392555 -0400 -0400
            Ended:     2022-10-23 09:57:47.623276553 -0400 -0400
            Result:    SUCCESS

            Stage metrics:
		    PVCBind:
			Avg: 23.740897195s
			Min: 10.132964038s
			Max: 37.348830352s
			Histogram:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PVCBind.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PVCBind_boxplot.png
		    PVCCreation:
			Avg: 45.534158935s
			Min: 44.284423124s
			Max: 46.783894747s
			Histogram:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PVCCreation.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PVCCreation_boxplot.png
		    PVCDeletion:
			Avg: 23.800857ms
			Min: 17.941641ms
			Max: 29.660074ms
			Histogram:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PVCDeletion.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PVCDeletion_boxplot.png
		    PVCUnattachment:
			Avg: 16.78805296s
			Min: 800.903548ms
			Max: 32.775202373s
			Histogram:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PVCUnattachment.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PVCUnattachment_boxplot.png
		    PodCreation:
			Avg: 9.206112645s
			Min: 6.000885827s
			Max: 10.968545569s
			Histogram:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PodCreation.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PodCreation_boxplot.png
		    PodDeletion:
			Avg: 1.419811064s
			Min: 1.244041746s
			Max: 1.756091176s
			Histogram:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PodDeletion.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/PodDeletion_boxplot.png
			EntityNumberOverTime:
	/root/.cert-csi/reports/test-run-43824440/VolumeIoSuite11/EntityNumberOverTime.png

[2022-10-23 09:57:48]  INFO Avg time of a run:	 108.32s
[2022-10-23 09:57:48]  INFO Avg time of a del:	 12.02s
[2022-10-23 09:57:48]  INFO Avg time of all:	 125.08s
[2022-10-23 09:57:48]  INFO During this run 100.0% of suites succeeded
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(Standalone)

  STEP  : Starting: Install PowerScale Driver(With Authorization) 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 09:57:53.254: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 09:57:53.512: INFO: stderr: ""
Oct 23 09:57:53.512: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
  STEP  :      Executing  Run custom test
Oct 23 09:58:03.579: INFO: Running ./cert-csi [test vio --sc isilon --chainNumber 2 --chainLength 2]
[2022-10-23 09:58:03]  INFO Starting cert-csi; ver. 0.8.1
[2022-10-23 09:58:03]  INFO Using EVENT observer type
[2022-10-23 09:58:03]  INFO Using config from /etc/kubernetes/admin.conf
[2022-10-23 09:58:03]  INFO Successfully loaded config. Host: https://10.225.108.156:6443
[2022-10-23 09:58:03]  INFO Created new KubeClient
[2022-10-23 09:58:03]  INFO Running 1 iteration(s)
[2022-10-23 09:58:03]  INFO 	*** ITERATION NUMBER 1 ***	
[2022-10-23 09:58:03]  INFO Starting VolumeIoSuite with isilon storage class
[2022-10-23 09:58:03]  INFO Successfully created namespace volumeio-test-93a91998
[2022-10-23 09:58:03]  INFO Using default number of volumes
[2022-10-23 09:58:03]  INFO Creating IO pod
[2022-10-23 09:58:47]  INFO Waiting for pod iowriter-test-trfml to be READY
[2022-10-23 09:59:07]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2022-10-23 09:59:07]  INFO Waiting for pod iowriter-test-wtkpr to be READY
[2022-10-23 09:59:14]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2022-10-23 09:59:15]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2022-10-23 09:59:21]  INFO Waiting until no Volume Attachments with PV csipscale-abccd243d2 left
[2022-10-23 09:59:21]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2022-10-23 09:59:25]  INFO VolumeAttachment deleted
[2022-10-23 09:59:25]  INFO Waiting for pod iowriter-test-nrkhf to be READY
[2022-10-23 09:59:27]  INFO Waiting until no Volume Attachments with PV csipscale-38fcee8488 left
[2022-10-23 09:59:33]  INFO VolumeAttachment deleted
[2022-10-23 09:59:33]  INFO Waiting for pod iowriter-test-8dmzc to be READY
[2022-10-23 09:59:35]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-0.sha512]
[2022-10-23 09:59:38]  INFO Hashes match
[2022-10-23 09:59:38]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2022-10-23 09:59:43]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2022-10-23 09:59:45]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-1.sha512]
[2022-10-23 09:59:47]  INFO Hashes match
[2022-10-23 09:59:47]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2022-10-23 09:59:49]  INFO Waiting until no Volume Attachments with PV csipscale-abccd243d2 left
[2022-10-23 09:59:52]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2022-10-23 09:59:55]  INFO VolumeAttachment deleted
[2022-10-23 09:59:57]  INFO Waiting until no Volume Attachments with PV csipscale-38fcee8488 left
[2022-10-23 10:00:05]  INFO VolumeAttachment deleted
[2022-10-23 10:00:05]  INFO Deleting all resources in namespace volumeio-test-93a91998
[2022-10-23 10:00:17]  INFO Namespace volumeio-test-93a91998 was deleted in 12.020767542s
[2022-10-23 10:00:18]  INFO SUCCESS: VolumeIoSuite in 2m15.092300503s
[2022-10-23 10:00:18]  INFO Started generating reports...
Collecting metrics
1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2022-10-23 10:00:18]  INFO Started generating reports...
Collecting metrics
1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sGenerating plots
1 / 1 [------------------------------------------------------------------------------------------------------------------------------------------------------>] 100.00% ? p/s1 / 1 [------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 27 p/s[2022-10-23 10:00:19]  WARN No ResourceUsageMetrics provided
[2022-10-23 10:00:19] ERROR no ResourceUsageMetrics provided
report-test-run-8dddbe10:
Name: test-run-8dddbe10
Host: https://10.225.108.156:6443
StorageClass: isilon
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-8dddbe10/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-8dddbe10/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-8dddbe10/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-8dddbe10/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-8dddbe10/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2022-10-23 09:58:03.692482614 -0400 -0400
            Ended:     2022-10-23 10:00:18.785455639 -0400 -0400
            Result:    SUCCESS

            Stage metrics:
		    PVCBind:
			Avg: 30.89630485s
			Min: 18.500086645s
			Max: 43.292523056s
			Histogram:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PVCBind.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PVCBind_boxplot.png
		    PVCCreation:
			Avg: 43.65899967s
			Min: 25.937414936s
			Max: 1m1.380584405s
			Histogram:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PVCCreation.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PVCCreation_boxplot.png
		    PVCDeletion:
			Avg: 21.172747ms
			Min: 17.031217ms
			Max: 25.314278ms
			Histogram:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PVCDeletion.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PVCDeletion_boxplot.png
		    PVCUnattachment:
			Avg: 33.495036898s
			Min: 33.351750723s
			Max: 33.638323074s
			Histogram:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PVCUnattachment.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PVCUnattachment_boxplot.png
		    PodCreation:
			Avg: 11.416881982s
			Min: 7.875238426s
			Max: 18.862580617s
			Histogram:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PodCreation.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PodCreation_boxplot.png
		    PodDeletion:
			Avg: 1.739553999s
			Min: 1.360531755s
			Max: 2.270395061s
			Histogram:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PodDeletion.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/PodDeletion_boxplot.png
			EntityNumberOverTime:
	/root/.cert-csi/reports/test-run-8dddbe10/VolumeIoSuite12/EntityNumberOverTime.png

[2022-10-23 10:00:19]  INFO Avg time of a run:	 121.67s
[2022-10-23 10:00:19]  INFO Avg time of a del:	 12.02s
[2022-10-23 10:00:19]  INFO Avg time of all:	 135.09s
[2022-10-23 10:00:19]  INFO During this run 100.0% of suites succeeded
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(With Authorization)

  STEP  : Starting: Install PowerScale Driver(Standalone), Enable Authorization 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:00:24.385: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:00:24.620: INFO: stderr: ""
Oct 23 10:00:24.620: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is not installed
  STEP  :      Executing  Enable [authorization] module
  STEP  :      Executing  Set Driver secret to [test-isilon-creds-auth]
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is installed
map[deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:2]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:2]
  STEP  :      Executing  Run custom test
Oct 23 10:00:44.834: INFO: Running echo [Hello && echo World]
Hello && echo World
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(Standalone), Enable Authorization

  STEP  : Starting: Uninstall PowerScale Driver 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:00:49.886: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:00:50.173: INFO: stderr: ""
Oct 23 10:00:50.173: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  :      Executing  Validate [powerscale] driver is not installed
  STEP  : Ending: Uninstall PowerScale Driver

  STEP  : Starting: Install PowerScale Driver(With Authorization), Disable Authorization module" 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:01:15.265: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:01:15.584: INFO: stderr: ""
Oct 23 10:01:15.584: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
  STEP  :      Executing  Disable [authorization] module
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is not installed
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(With Authorization), Disable Authorization module"

  STEP  : Starting: Install PowerScale Driver(With Observability) 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:01:40.765: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:01:40.960: INFO: stderr: ""
Oct 23 10:01:40.960: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [observability] module is installed
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(With Observability)

  STEP  : Starting: Install PowerScale Driver(Standalone), Enable Observability 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:01:56.049: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:01:56.277: INFO: stderr: ""
Oct 23 10:01:56.277: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [observability] module is not installed
  STEP  :      Executing  Enable [observability] module
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [observability] module is installed
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(Standalone), Enable Observability

  STEP  : Starting: Install PowerScale Driver(With Observability), Disable Observability module" 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:02:21.504: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:02:21.786: INFO: stderr: ""
Oct 23 10:02:21.786: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [observability] module is installed
  STEP  :      Executing  Disable [observability] module
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [observability] module is not installed
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(With Observability), Disable Observability module"

  STEP  : Starting: Install PowerScale Driver(With Authorization and Observability) 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:02:46.965: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:02:47.244: INFO: stderr: ""
Oct 23 10:02:47.244: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
  STEP  :      Executing  Validate [observability] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
  STEP  :      Executing  Run custom test
Oct 23 10:03:07.376: INFO: Running ./cert-csi [test vio --sc isilon --chainNumber 2 --chainLength 2]
[2022-10-23 10:03:07]  INFO Starting cert-csi; ver. 0.8.1
[2022-10-23 10:03:07]  INFO Using EVENT observer type
[2022-10-23 10:03:07]  INFO Using config from /etc/kubernetes/admin.conf
[2022-10-23 10:03:07]  INFO Successfully loaded config. Host: https://10.225.108.156:6443
[2022-10-23 10:03:07]  INFO Created new KubeClient
[2022-10-23 10:03:07]  INFO Running 1 iteration(s)
[2022-10-23 10:03:07]  INFO 	*** ITERATION NUMBER 1 ***	
[2022-10-23 10:03:07]  INFO Starting VolumeIoSuite with isilon storage class
[2022-10-23 10:03:07]  INFO Successfully created namespace volumeio-test-ce698c1d
[2022-10-23 10:03:07]  INFO Using default number of volumes
[2022-10-23 10:03:07]  INFO Creating IO pod
[2022-10-23 10:03:37]  INFO Waiting for pod iowriter-test-d4rzr to be READY
[2022-10-23 10:03:45]  INFO Waiting for pod iowriter-test-g6trw to be READY
[2022-10-23 10:03:49]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2022-10-23 10:03:53]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2022-10-23 10:03:54]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2022-10-23 10:03:58]  INFO Waiting until no Volume Attachments with PV csipscale-3cdc1bbc37 left
[2022-10-23 10:03:59]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2022-10-23 10:04:02]  INFO Waiting until no Volume Attachments with PV csipscale-267cc30467 left
[2022-10-23 10:04:08]  INFO VolumeAttachment deleted
[2022-10-23 10:04:08]  INFO Waiting for pod iowriter-test-p7s6j to be READY
[2022-10-23 10:04:14]  INFO VolumeAttachment deleted
[2022-10-23 10:04:14]  INFO Waiting for pod iowriter-test-r6hw2 to be READY
[2022-10-23 10:04:18]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-0.sha512]
[2022-10-23 10:04:20]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-1.sha512]
[2022-10-23 10:04:20]  INFO Hashes match
[2022-10-23 10:04:20]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2022-10-23 10:04:24]  INFO Hashes match
[2022-10-23 10:04:24]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2022-10-23 10:04:25]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2022-10-23 10:04:31]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2022-10-23 10:04:31]  INFO Waiting until no Volume Attachments with PV csipscale-3cdc1bbc37 left
[2022-10-23 10:04:39]  INFO Waiting until no Volume Attachments with PV csipscale-267cc30467 left
[2022-10-23 10:04:39]  INFO VolumeAttachment deleted
[2022-10-23 10:04:41]  INFO VolumeAttachment deleted
[2022-10-23 10:04:41]  INFO Deleting all resources in namespace volumeio-test-ce698c1d
[2022-10-23 10:04:53]  INFO Namespace volumeio-test-ce698c1d was deleted in 12.018967084s
[2022-10-23 10:04:57]  INFO SUCCESS: VolumeIoSuite in 1m50.072058339s
[2022-10-23 10:04:57]  INFO Started generating reports...
Collecting metrics
1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2022-10-23 10:04:57]  INFO Started generating reports...
Collecting metrics
1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sGenerating plots
1 / 1 [------------------------------------------------------------------------------------------------------------------------------------------------------>] 100.00% ? p/s1 / 1 [------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 28 p/s[2022-10-23 10:04:57]  WARN No ResourceUsageMetrics provided
[2022-10-23 10:04:57] ERROR no ResourceUsageMetrics provided
report-test-run-12afc809:
Name: test-run-12afc809
Host: https://10.225.108.156:6443
StorageClass: isilon
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-12afc809/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-12afc809/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-12afc809/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-12afc809/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-12afc809/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2022-10-23 10:03:07.481436207 -0400 -0400
            Ended:     2022-10-23 10:04:57.553923969 -0400 -0400
            Result:    SUCCESS

            Stage metrics:
		    PVCBind:
			Avg: 17.955256848s
			Min: 7.801567583s
			Max: 28.108946114s
			Histogram:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PVCBind.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PVCBind_boxplot.png
		    PVCCreation:
			Avg: 24.372759581s
			Min: 13.660487908s
			Max: 35.085031255s
			Histogram:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PVCCreation.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PVCCreation_boxplot.png
		    PVCDeletion:
			Avg: 23.675786ms
			Min: 16.910179ms
			Max: 30.441394ms
			Histogram:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PVCDeletion.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PVCDeletion_boxplot.png
		    PVCUnattachment:
			Avg: 31.999781166s
			Min: 31.521820559s
			Max: 32.477741774s
			Histogram:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PVCUnattachment.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PVCUnattachment_boxplot.png
		    PodCreation:
			Avg: 8.036682477s
			Min: 5.377463448s
			Max: 10.650118581s
			Histogram:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PodCreation.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PodCreation_boxplot.png
		    PodDeletion:
			Avg: 2.350323355s
			Min: 1.366178644s
			Max: 4.661823582s
			Histogram:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PodDeletion.png
			BoxPlot:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/PodDeletion_boxplot.png
			EntityNumberOverTime:
	/root/.cert-csi/reports/test-run-12afc809/VolumeIoSuite13/EntityNumberOverTime.png

[2022-10-23 10:04:58]  INFO Avg time of a run:	 94.31s
[2022-10-23 10:04:58]  INFO Avg time of a del:	 12.02s
[2022-10-23 10:04:58]  INFO Avg time of all:	 110.07s
[2022-10-23 10:04:58]  INFO During this run 100.0% of suites succeeded
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(With Authorization and Observability)

  STEP  : Starting: Install PowerScale Driver(Standalone), Enable Authorization, Enable Observability 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:05:03.233: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:05:03.493: INFO: stderr: ""
Oct 23 10:05:03.493: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is not installed
  STEP  :      Executing  Validate [observability] module is not installed
  STEP  :      Executing  Enable [authorization] module
  STEP  :      Executing  Set Driver secret to [test-isilon-creds-auth]
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is installed
map[deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:2]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:2]
  STEP  :      Executing  Validate [observability] module is not installed
  STEP  :      Executing  Enable [observability] module
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:2]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:2]
  STEP  :      Executing  Validate [observability] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(Standalone), Enable Authorization, Enable Observability

  STEP  : Starting: Install PowerScale Driver(With Authorization and Observability), Disable Observability module, Disable Authorization module" 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:05:38.901: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:05:39.221: INFO: stderr: ""
Oct 23 10:05:39.221: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
  STEP  :      Executing  Validate [observability] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
  STEP  :      Executing  Disable [observability] module
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
  STEP  :      Executing  Validate [observability] module is not installed
  STEP  :      Executing  Disable [authorization] module
  STEP  :      Executing  Set Driver secret to [test-isilon-creds]
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is not installed
  STEP  :      Executing  Validate [observability] module is not installed
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(With Authorization and Observability), Disable Observability module, Disable Authorization module"

  STEP  : Starting: Install PowerScale Driver(With Authorization and Observability), Disable Authorization module, Disable Observability module" 
  STEP  :      Executing  Given an environment with k8s or openshift, and CSM operator installed
  STEP  :      Executing  Apply custom resources
Oct 23 10:06:24.590: INFO: Running '/usr/bin/kubectl --namespace=test-isilon apply --validate=true -f -'
Oct 23 10:06:24.841: INFO: stderr: ""
Oct 23 10:06:24.841: INFO: stdout: "containerstoragemodule.storage.dell.com/test-isilon created\n"
  STEP  :      Executing  Validate custom resources
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
  STEP  :      Executing  Validate [observability] module is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
  STEP  :      Executing  Disable [authorization] module
  STEP  :      Executing  Set Driver secret to [test-isilon-creds]
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is not installed
  STEP  :      Executing  Validate [observability] module is installed
  STEP  :      Executing  Disable [observability] module
  STEP  :      Executing  Validate [powerscale] driver is installed
  STEP  :      Executing  Validate [authorization] module is not installed
  STEP  :      Executing  Validate [observability] module is not installed
  STEP  :      Executing  Enable forceRemoveDriver on CR
  STEP  :      Executing  Delete resources
  STEP  : Ending: Install PowerScale Driver(With Authorization and Observability), Disable Authorization module, Disable Observability module"


 [32m• [SLOW TEST:688.091 seconds]  
[run-e2e-test]E2E Testing
 [90m ~/csm-operator/tests/e2e/e2e_test.go:109  
  Running all test Given Test Scenarios
   [90m ~/csm-operator/tests/e2e/e2e_test.go:110  
 [90m------------------------------  

   [32mRan 1 of 1 Specs in 688.473 seconds  
   [32mSUCCESS!   --  [32m  1 Passed   |  [91m  0 Failed   |  [33m  0 Pending   |  [36m  0 Skipped  
PASS

Ginkgo ran 1 suite in 11m32.85578848s
Test Suite Passed

```
- [x] manual test
Grafana UI display correctly

![image](https://user-images.githubusercontent.com/88763781/197398666-c06f0238-e36d-4352-8926-708189b8b661.png)

![image](https://user-images.githubusercontent.com/88763781/197398680-2885bc7f-aaae-48b3-b2dc-55cc1ce8cbef.png)

