### PR TITLE
enable authorization for observability metrics-powerflex

### DIFF
--- a/operatorconfig/moduleconfig/observability/v1.3.0/karavi-metrics-powerflex.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.3.0/karavi-metrics-powerflex.yaml
@@ -78,6 +78,18 @@ data:
 
 ---
 
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: karavi
+data:
+  driver-config-params.yaml: |
+    CSI_LOG_LEVEL: debug
+    CSI_LOG_FORMAT: TEXT
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -134,5 +146,8 @@ spec:
         - name: karavi-metrics-powerflex-configmap
           configMap:
             name: karavi-metrics-powerflex-configmap
+        - name: vxflexos-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
       restartPolicy: Always
 status: {}

--- a/pkg/modules/observability_test.go
+++ b/pkg/modules/observability_test.go
@@ -14,15 +14,20 @@ import (
 
 	csmv1 "github.com/dell/csm-operator/api/v1"
 	utils "github.com/dell/csm-operator/pkg/utils"
+	"github.com/dell/csm-operator/tests/shared"
 	"github.com/dell/csm-operator/tests/shared/clientgoclient"
+	"github.com/dell/csm-operator/tests/shared/crclient"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlClientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+var ctx = context.Background()
 
 func TestObservabilityPrecheck(t *testing.T) {
 	type fakeControllerRuntimeClientWrapper func(clusterConfigData []byte) (ctrlClient.Client, error)
@@ -34,7 +39,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "test-isilon-creds")
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
 
 			tmpCR := customResource
 			observability := tmpCR.Spec.Modules[0]
@@ -54,7 +59,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "test-isilon-creds")
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
 
 			tmpCR := customResource
 			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
@@ -75,7 +80,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			vxflexosCreds := getSecret("karavi", "test-vxflexos-config")
+			vxflexosCreds := getSecret(customResource.Namespace, "test-vxflexos-config")
 
 			tmpCR := customResource
 			tmpCR.Spec.Driver.CSIDriverType = "powerflex"
@@ -96,7 +101,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "test-isilon-creds")
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
 
 			tmpCR := customResource
 			observability := tmpCR.Spec.Modules[0]
@@ -117,9 +122,9 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "test-isilon-creds")
-			karaviAuthconfig := getSecret("karavi", "karavi-authorization-config")
-			proxyAuthzTokens := getSecret("karavi", "proxy-authz-tokens")
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
 
 			tmpCR := customResource
 			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
@@ -142,7 +147,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "test-isilon-creds")
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
 
 			tmpCR := customResource
 			observability := tmpCR.Spec.Modules[0]
@@ -163,7 +168,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			isilonCreds := getSecret("karavi", "test-isilon-creds")
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
 
 			tmpCR := customResource
 			tmpCR.Spec.Driver.CSIDriverType = "unsupported-driver"
@@ -176,81 +181,6 @@ func TestObservabilityPrecheck(t *testing.T) {
 			}
 
 			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
-		},
-
-		"Fail - isilon secrets not provided": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
-			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
-			if err != nil {
-				panic(err)
-			}
-
-			tmpCR := customResource
-			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
-			observability := tmpCR.Spec.Modules[0]
-
-			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
-
-			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
-				return ctrlClientFake.NewClientBuilder().WithObjects().Build(), nil
-			}
-
-			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
-		},
-
-		"Fail - auth secrets not provided": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
-			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
-			if err != nil {
-				panic(err)
-			}
-
-			isilonCreds := getSecret("karavi", "test-isilon-creds")
-
-			tmpCR := customResource
-			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
-			observability := tmpCR.Spec.Modules[0]
-			auth := &tmpCR.Spec.Modules[1]
-			auth.Enabled = true
-
-			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds).Build()
-
-			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
-				return ctrlClientFake.NewClientBuilder().WithObjects().Build(), nil
-			}
-
-			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
-		},
-
-		"Fail - SKIP_CERTIFICATE_VALIDATION is false but no cert": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
-			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
-			if err != nil {
-				panic(err)
-			}
-
-			isilonCreds := getSecret("karavi", "test-isilon-creds")
-			karaviAuthconfig := getSecret("karavi", "karavi-authorization-config")
-			proxyAuthzTokens := getSecret("karavi", "proxy-authz-tokens")
-
-			tmpCR := customResource
-			tmpCR.Spec.Driver.CSIDriverType = "powerscale"
-			observability := tmpCR.Spec.Modules[0]
-			auth := &tmpCR.Spec.Modules[1]
-			auth.Enabled = true
-
-			// set skipCertificateValidation to false
-			for i, env := range auth.Components[0].Envs {
-				if env.Name == "SKIP_CERTIFICATE_VALIDATION" {
-					auth.Components[0].Envs[i].Value = "false"
-				}
-			}
-
-			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds, karaviAuthconfig, proxyAuthzTokens).Build()
-
-			fakeControllerRuntimeClient := func(clusterConfigData []byte) (ctrlClient.Client, error) {
-				return ctrlClientFake.NewClientBuilder().WithObjects().Build(), nil
-			}
-
-			return false, observability, tmpCR, sourceClient, fakeControllerRuntimeClient
-
 		},
 	}
 	for name, tc := range tests {
@@ -273,7 +203,7 @@ func TestObservabilityPrecheck(t *testing.T) {
 				K8sClient: fake.NewSimpleClientset(),
 			}
 
-			err := ObservabilityPrecheck(context.TODO(), operatorConfig, observability, tmpCR, &fakeReconcile)
+			err := ObservabilityPrecheck(ctx, operatorConfig, observability, tmpCR, &fakeReconcile)
 			if success {
 				assert.NoError(t, err)
 
@@ -341,7 +271,7 @@ func TestObservabilityTopologyController(t *testing.T) {
 
 			success, isDeleting, cr, sourceClient, op := tc(t)
 
-			err := ObservabilityTopology(context.TODO(), isDeleting, op, cr, sourceClient)
+			err := ObservabilityTopology(ctx, isDeleting, op, cr, sourceClient)
 			if success {
 				assert.NoError(t, err)
 
@@ -360,6 +290,7 @@ func TestPowerScaleMetrics(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
 
 			tmpCR := customResource
 
@@ -372,7 +303,7 @@ func TestPowerScaleMetrics(t *testing.T) {
 				},
 			}
 
-			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(cr).Build()
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(cr, isilonCreds).Build()
 
 			return true, true, tmpCR, sourceClient, operatorConfig
 		},
@@ -382,6 +313,10 @@ func TestPowerScaleMetrics(t *testing.T) {
 				panic(err)
 			}
 
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+
 			tmpCR := customResource
 			auth := &tmpCR.Spec.Modules[1]
 			auth.Enabled = true
@@ -395,7 +330,31 @@ func TestPowerScaleMetrics(t *testing.T) {
 				},
 			}
 
-			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(cr).Build()
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(cr, isilonCreds, karaviAuthconfig, proxyAuthzTokens).Build()
+
+			return true, true, tmpCR, sourceClient, operatorConfig
+		},
+		"success - deleting with auth after one cycle": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds, karaviAuthconfig, proxyAuthzTokens).Build()
+			k8sClient := clientgoclient.NewFakeClient(sourceClient)
+
+			//pre-run to generate objects
+			err = PowerScaleMetrics(ctx, false, operatorConfig, tmpCR, sourceClient, k8sClient)
+			if err != nil {
+				panic(err)
+			}
 
 			return true, true, tmpCR, sourceClient, operatorConfig
 		},
@@ -404,10 +363,11 @@ func TestPowerScaleMetrics(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
 
 			tmpCR := customResource
 
-			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds).Build()
 
 			return true, false, tmpCR, sourceClient, operatorConfig
 		},
@@ -416,14 +376,76 @@ func TestPowerScaleMetrics(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
 
 			tmpCR := customResource
 			auth := &tmpCR.Spec.Modules[1]
 			auth.Enabled = true
 
-			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds, karaviAuthconfig, proxyAuthzTokens).Build()
 
 			return true, false, tmpCR, sourceClient, operatorConfig
+		},
+		"success - update objects": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+
+			objects := map[shared.StorageKey]runtime.Object{}
+			fakeClient := crclient.NewFakeClientNoInjector(objects)
+			fakeClient.Create(ctx, isilonCreds)
+			fakeClient.Create(ctx, karaviAuthconfig)
+			fakeClient.Create(ctx, proxyAuthzTokens)
+			k8sClient := clientgoclient.NewFakeClient(fakeClient)
+			//pre-run to generate objects
+			err = PowerScaleMetrics(ctx, false, operatorConfig, customResource, fakeClient, k8sClient)
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			return true, false, tmpCR, fakeClient, operatorConfig
+		},
+		"success - copy secrets when secrets already existed": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
+			isilonKaraviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			isilonProxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+			karaviIsilonCreds := getSecret("karavi", "test-isilon-creds")
+			karaviAuthconfig := getSecret("karavi", "isilon-karavi-authorization-config")
+			proxyAuthzTokens := getSecret("karavi", "isilon-proxy-authz-tokens")
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds, isilonKaraviAuthconfig, isilonProxyAuthzTokens, karaviIsilonCreds, karaviAuthconfig, proxyAuthzTokens).Build()
+
+			return true, false, tmpCR, sourceClient, operatorConfig
+		},
+		"Fail - no secrets in test-isilon namespace": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+
+			return false, false, tmpCR, sourceClient, operatorConfig
 		},
 		"Fail - wrong module name": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
 			customResource, err := getCustomResource("./testdata/cr_powerscale_replica.yaml")
@@ -437,6 +459,29 @@ func TestPowerScaleMetrics(t *testing.T) {
 
 			return false, false, tmpCR, sourceClient, operatorConfig
 		},
+		"Fail - skipCertificateValidation is false but no cert": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			isilonCreds := getSecret(customResource.Namespace, "test-isilon-creds")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+			// set skipCertificateValidation to false
+			for i, env := range auth.Components[0].Envs {
+				if env.Name == "SKIP_CERTIFICATE_VALIDATION" {
+					auth.Components[0].Envs[i].Value = "false"
+				}
+			}
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(isilonCreds, karaviAuthconfig, proxyAuthzTokens).Build()
+
+			return false, false, tmpCR, sourceClient, operatorConfig
+		},
 	}
 
 	for name, tc := range tests {
@@ -444,7 +489,7 @@ func TestPowerScaleMetrics(t *testing.T) {
 
 			success, isDeleting, cr, sourceClient, op := tc(t)
 			k8sClient := clientgoclient.NewFakeClient(sourceClient)
-			err := PowerScaleMetrics(context.TODO(), isDeleting, op, cr, sourceClient, k8sClient)
+			err := PowerScaleMetrics(ctx, isDeleting, op, cr, sourceClient, k8sClient)
 			if success {
 				assert.NoError(t, err)
 
@@ -511,7 +556,7 @@ func TestOtelCollector(t *testing.T) {
 
 			success, isDeleting, cr, sourceClient, op := tc(t)
 
-			err := OtelCollector(context.TODO(), isDeleting, op, cr, sourceClient)
+			err := OtelCollector(ctx, isDeleting, op, cr, sourceClient)
 			if success {
 				assert.NoError(t, err)
 
@@ -530,6 +575,7 @@ func TestPowerFlexMetrics(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
+			vxflexosCreds := getSecret(customResource.Namespace, "test-vxflexos-config")
 
 			tmpCR := customResource
 
@@ -542,13 +588,140 @@ func TestPowerFlexMetrics(t *testing.T) {
 				},
 			}
 
-			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(cr).Build()
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(cr, vxflexosCreds).Build()
 
 			return true, true, tmpCR, sourceClient, operatorConfig
 		},
+		"success - deleting with auth": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerflex_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
 
+			vxflexosCreds := getSecret(customResource.Namespace, "test-vxflexos-config")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			cr := &rbacv1.ClusterRole{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ClusterRole",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "karavi-metrics-powerscale-controller",
+				},
+			}
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(cr, vxflexosCreds, karaviAuthconfig, proxyAuthzTokens).Build()
+
+			return true, true, tmpCR, sourceClient, operatorConfig
+		},
+		"success - deleting with auth after one cycle": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerflex_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+			vxflexosCreds := getSecret(customResource.Namespace, "test-vxflexos-config")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(vxflexosCreds, karaviAuthconfig, proxyAuthzTokens).Build()
+			k8sClient := clientgoclient.NewFakeClient(sourceClient)
+
+			//pre-run to generate objects
+			err = PowerFlexMetrics(ctx, false, operatorConfig, tmpCR, sourceClient, k8sClient)
+			if err != nil {
+				panic(err)
+			}
+
+			return true, true, tmpCR, sourceClient, operatorConfig
+		},
 		"success - creating": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
 			customResource, err := getCustomResource("./testdata/cr_powerflex_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+			vxflexosCreds := getSecret(customResource.Namespace, "test-vxflexos-config")
+
+			tmpCR := customResource
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(vxflexosCreds).Build()
+
+			return true, false, tmpCR, sourceClient, operatorConfig
+		},
+		"success - creating with auth": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerflex_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+			vxflexosCreds := getSecret(customResource.Namespace, "test-vxflexos-config")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(vxflexosCreds, karaviAuthconfig, proxyAuthzTokens).Build()
+
+			return true, false, tmpCR, sourceClient, operatorConfig
+		},
+		"success - update objects": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerflex_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			vxflexosCreds := getSecret(customResource.Namespace, "test-vxflexos-config")
+			karaviAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			proxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+
+			objects := map[shared.StorageKey]runtime.Object{}
+			fakeClient := crclient.NewFakeClientNoInjector(objects)
+			fakeClient.Create(ctx, vxflexosCreds)
+			fakeClient.Create(ctx, karaviAuthconfig)
+			fakeClient.Create(ctx, proxyAuthzTokens)
+			k8sClient := clientgoclient.NewFakeClient(fakeClient)
+			//pre-run to generate objects
+			err = PowerFlexMetrics(ctx, false, operatorConfig, customResource, fakeClient, k8sClient)
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			return true, false, tmpCR, fakeClient, operatorConfig
+		},
+		"success - copy secrets when secrets already existed": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerflex_observability.yaml")
+			if err != nil {
+				panic(err)
+			}
+			vxflexosCreds := getSecret(customResource.Namespace, "test-vxflexos-config")
+			vxflexosAuthconfig := getSecret(customResource.Namespace, "karavi-authorization-config")
+			vxflexosProxyAuthzTokens := getSecret(customResource.Namespace, "proxy-authz-tokens")
+			karaviVxflexosCreds := getSecret("karavi", "test-vxflexos-config")
+			karaviAuthconfig := getSecret("karavi", "powerflex-karavi-authorization-config")
+			proxyAuthzTokens := getSecret("karavi", "powerflex-proxy-authz-tokens")
+			tmpCR := customResource
+			auth := &tmpCR.Spec.Modules[1]
+			auth.Enabled = true
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(vxflexosCreds, karaviAuthconfig, proxyAuthzTokens, karaviVxflexosCreds, vxflexosAuthconfig, vxflexosProxyAuthzTokens).Build()
+
+			return true, false, tmpCR, sourceClient, operatorConfig
+		},
+		"Fail - wrong module name": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerscale_replica.yaml")
 			if err != nil {
 				panic(err)
 			}
@@ -557,10 +730,10 @@ func TestPowerFlexMetrics(t *testing.T) {
 
 			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
 
-			return true, false, tmpCR, sourceClient, operatorConfig
+			return false, false, tmpCR, sourceClient, operatorConfig
 		},
-		"Fail - wrong module name": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
-			customResource, err := getCustomResource("./testdata/cr_powerscale_replica.yaml")
+		"Fail - no secrets in test-vxflexos namespace": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_powerflex_observability.yaml")
 			if err != nil {
 				panic(err)
 			}
@@ -578,7 +751,7 @@ func TestPowerFlexMetrics(t *testing.T) {
 
 			success, isDeleting, cr, sourceClient, op := tc(t)
 			k8sClient := clientgoclient.NewFakeClient(sourceClient)
-			err := PowerFlexMetrics(context.TODO(), isDeleting, op, cr, sourceClient, k8sClient)
+			err := PowerFlexMetrics(ctx, isDeleting, op, cr, sourceClient, k8sClient)
 			if success {
 				assert.NoError(t, err)
 

--- a/pkg/modules/testdata/cr_powerflex_observability.yaml
+++ b/pkg/modules/testdata/cr_powerflex_observability.yaml
@@ -225,6 +225,20 @@ spec:
             # Default value: "otel-collector:55680"
             - name: "COLLECTOR_ADDRESS"
               value: "otel-collector:55680"
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: false
+      components:
+      - name: karavi-authorization-proxy
+        image: dellemc/csm-authorization-sidecar:v1.4.0
+        envs:
+          # proxyHost: hostname of the csm-authorization server
+          - name: "PROXY_HOST"
+            value: "testing-proxy-host"
+        
+          # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server       
+          - name: "SKIP_CERTIFICATE_VALIDATION"
+            value: "true"
 
 ---
 apiVersion: v1

--- a/samples/storage_csm_powerflex_v230.yaml
+++ b/samples/storage_csm_powerflex_v230.yaml
@@ -132,6 +132,23 @@ spec:
             value: "10.xx.xx.xx,10.xx.xx.xx"  #provide MDM value
 
   modules:
+    # Authorization: enable csm-authorization for RBAC
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: false
+      configVersion: v1.4.0
+      components:
+      - name: karavi-authorization-proxy
+        image: dellemc/csm-authorization-sidecar:v1.4.0
+        envs:
+          # proxyHost: hostname of the csm-authorization server
+          - name: "PROXY_HOST"
+            value: "csm-authorization.com"
+        
+          # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server       
+          - name: "SKIP_CERTIFICATE_VALIDATION"
+            value: "true"
+
     # observability: allows to configure observability
     - name: observability
       # enabled: Enable/Disable observability

--- a/tests/e2e/testfiles/storage_csm_powerflex_observability_auth.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_observability_auth.yaml
@@ -33,27 +33,26 @@ spec:
         # Default value: None
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
-        - name: "CERT_SECRET_COUNT"
-          value: "0"
+
 
     sideCars:
-    # sdc-monitor is disabled by default, due to high CPU usage 
+      # sdc-monitor is disabled by default, due to high CPU usage
       - name: sdc-monitor
         enabled: false
         image: dellemc/sdc:3.6
         envs:
-        - name: HOST_PID
-          value: "1"
-        - name: MDM
-          value: "10.xx.xx.xx,10.xx.xx.xx" #provide MDM value
+          - name: HOST_PID
+            value: "1"
+          - name: MDM
+            value: "10.x.x.x,10.x.x.x" #provide MDM value
 
-    # health monitor is disabled by default, refer to driver documentation before enabling it
-    # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED  to "true".
+      # health monitor is disabled by default, refer to driver documentation before enabling it
+      # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED  to "true".
       - name: csi-external-health-monitor-controller
         enabled: false
         args: ["--monitor-interval=60s"]
 
-    # vg-snapshotter is disabled by default, refer to driver documentation before enabling it
+      # vg-snapshotter is disabled by default, refer to driver documentation before enabling it
       - name: vg-snapshotter
         enabled: false
         image: dellemc/csi-volumegroup-snapshotter:v1.2.0
@@ -85,12 +84,12 @@ spec:
       # Leave as blank to install controller on worker nodes
       # Default value: None
       tolerations:
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint 
-      # - key: "node-role.kubernetes.io/master"   
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # - key: "node-role.kubernetes.io/master"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint 
-      # - key: "node-role.kubernetes.io/control-plane"   
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
 
@@ -121,11 +120,11 @@ spec:
       # Default value: None
       tolerations:
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-      # - key: "node-role.kubernetes.io/master"   
+      # - key: "node-role.kubernetes.io/master"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint 
-      # - key: "node-role.kubernetes.io/control-plane"   
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
 
@@ -135,13 +134,13 @@ spec:
         name: sdc
         envs:
           - name: MDM
-            value: "10.xx.xx.xx,10.xx.xx.xx"  #provide MDM value
+            value: "10.x.x.x,10.x.x.x"  #provide MDM value
 
   modules:
-    # Authorization: enable csm-authorization for RBAC
+      # Authorization: enable csm-authorization for RBAC
     - name: authorization
       # enable: Enable/Disable csm-authorization
-      enabled: false
+      enabled: true
       configVersion: v1.4.0
       components:
       - name: karavi-authorization-proxy
@@ -149,21 +148,20 @@ spec:
         envs:
           # proxyHost: hostname of the csm-authorization server
           - name: "PROXY_HOST"
-            value: "csm-authorization.com"
+            value: ""
         
           # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server       
           - name: "SKIP_CERTIFICATE_VALIDATION"
             value: "true"
-
     # observability: allows to configure observability
     - name: observability
       # enabled: Enable/Disable observability
-      enabled: false
+      enabled: true
       configVersion: v1.3.0
       components:
         - name: topology
           # enabled: Enable/Disable topology
-          enabled: false
+          enabled: true
           # image: Defines karavi-topology image. This shouldn't be changed
           # Allowed values: string
           image: dellemc/csm-topology:v1.3.0
@@ -176,7 +174,7 @@ spec:
 
         - name: otel-collector
           # enabled: Enable/Disable OpenTelemetry Collector
-          enabled: false
+          enabled: true
           # image: Defines otel-collector image. This shouldn't be changed
           # Allowed values: string
           image: otel/opentelemetry-collector:0.42.0
@@ -189,7 +187,7 @@ spec:
 
         - name: metrics-powerflex
           # enabled: Enable/Disable PowerFlex metrics
-          enabled: false
+          enabled: true
           # image: Defines PowerFlex metrics image. This shouldn't be changed
           image: dellemc/csm-metrics-powerflex:v1.3.0
           envs:

--- a/tests/e2e/testfiles/values.yaml
+++ b/tests/e2e/testfiles/values.yaml
@@ -173,7 +173,7 @@
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
 
-- scenario: "Install PowerScale Driver(Standalone), Enable Observability"
+- scenario: "Install PowerScale Driver(Standalone), Enable/Disable Observability"
   paths: 
     - "testfiles/storage_csm_powerscale.yaml"
   modules:
@@ -187,6 +187,9 @@
     - "Enable [observability] module from CR [1]"
     - "Validate [powerscale] driver from CR [1] is installed"
     - "Validate [observability] module from CR [1] is installed"
+    - "Disable [observability] module from CR [1]"
+    - "Validate [powerscale] driver from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is not installed"
     # Last two steps perform Clean Up
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
@@ -427,7 +430,7 @@
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
 
-- scenario: "Install PowerFlex Driver(Standalone), Enable Observability"
+- scenario: "Install PowerFlex Driver(Standalone), Enable/Disable Observability"
   paths: 
     - "testfiles/storage_csm_powerflex.yaml"
   modules:
@@ -441,6 +444,9 @@
     - "Enable [observability] module from CR [1]"
     - "Validate [powerflex] driver from CR [1] is installed"
     - "Validate [observability] module from CR [1] is installed"
+    - "Disable [observability] module from CR [1]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is not installed"
     # Last two steps perform Clean Up
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
@@ -462,6 +468,109 @@
     # Last two steps perform Clean Up
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
+
+- scenario: "Install PowerFlex Driver(With Authorization and Observability)"
+  paths: 
+    - "testfiles/storage_csm_powerflex_observability_auth.yaml"
+  modules:
+    - "observability"
+    - "authorization"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resource [1]"
+    - "Set secret for driver from CR [1] to [test-vxflexos-config-auth]"
+    - "Validate custom resource [1]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is installed"
+    - "Run custom test"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+  customTest:
+    name: Cert CSI
+    run: ./cert-csi test vio --sc vxflexos --chainNumber 2 --chainLength 2
+
+- scenario: "Install PowerFlex Driver(Standalone), Enable Authorization, Enable Observability"
+  paths: 
+    - "testfiles/storage_csm_powerflex.yaml"
+  modules:
+    - "observability"
+    - "authorization"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is not installed"
+    - "Validate [observability] module from CR [1] is not installed"
+    - "Enable [authorization] module from CR [1]"
+    - "Set secret for driver from CR [1] to [test-vxflexos-config-auth]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is not installed"
+    - "Enable [observability] module from CR [1]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is installed"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+
+- scenario: Install PowerFlex Driver(With Authorization and Observability), Disable Observability module, Disable Authorization module"
+  paths: 
+    - "testfiles/storage_csm_powerflex_observability_auth.yaml"
+  modules:
+    - "observability"
+    - "authorization"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resource [1]"
+    - "Set secret for driver from CR [1] to [test-vxflexos-config-auth]"
+    - "Validate custom resource [1]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is installed"
+    - "Disable [observability] module from CR [1]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is not installed"
+    - "Disable [authorization] module from CR [1]"
+    - "Set secret for driver from CR [1] to [test-vxflexos-config]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is not installed"
+    - "Validate [observability] module from CR [1] is not installed"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+
+- scenario: Install PowerFlex Driver(With Authorization and Observability), Disable Authorization module, Disable Observability module"
+  paths: 
+    - "testfiles/storage_csm_powerflex_observability_auth.yaml"
+  modules:
+    - "observability"
+    - "authorization"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resource [1]"
+    - "Set secret for driver from CR [1] to [test-vxflexos-config-auth]"
+    - "Validate custom resource [1]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is installed"
+    - "Disable [authorization] module from CR [1]"
+    - "Set secret for driver from CR [1] to [test-vxflexos-config]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is not installed"
+    - "Validate [observability] module from CR [1] is installed"
+    - "Disable [observability] module from CR [1]"
+    - "Validate [powerflex] driver from CR [1] is installed"
+    - "Validate [authorization] module from CR [1] is not installed"
+    - "Validate [observability] module from CR [1] is not installed"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+
 
 - scenario: "Install PowerScale Driver and PowerFlex Driver, uninstall PowerFlex Driver"
   paths:


### PR DESCRIPTION
# Description
enable authorization for observability metrics-powerflex:
  - add authorization module to the sample files of PowerFlex;
  - enable authorization for observability metrics-powerflex;
  - copy secrets from csi driver namespace to observability namespace;
  - add observability components control in oldStandAloneModuleCleanup;
  - change Annotation content of previously-applied-configuration in oldStandAloneModuleCleanup;
  - add related UT;
  - add related e2e;

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/488|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] unit test
```
~/csm-operator/controllers# go test ./... -coverprofile cover.out
ok      github.com/dell/csm-operator/controllers        1.209s  coverage: 88.5% of statements
~/csm-operator/pkg/modules# go test ./... -coverprofile cover.out
ok      github.com/dell/csm-operator/pkg/modules        0.383s  coverage: 87.9% of statements

```
- [x] e2e test
```
Running Suite: CSM Operator End-to-End Tests
============================================
Random Seed: 1668053591 - Will randomize all specs
Will run 1 of 1 specs

STEP: Getting test environment variables
STEP: Reading values file
STEP: Getting a k8s client
[run-e2e-test]E2E Testing
  Running all test Given Test Scenarios
   ~/csm-operator/tests/e2e/e2e_test.go:122
[It] Running all test Given Test Scenarios
   ~/csm-operator/tests/e2e/e2e_test.go:122
STEP: Starting: Install PowerFlex Driver(Standalone), Enable/Disable Observability
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resource [1]
Nov  9 23:13:16.287: INFO: Running '/usr/bin/kubectl --namespace=test-vxflexos apply --validate=true -f -'
Nov  9 23:13:16.534: INFO: stderr: ""
Nov  9 23:13:16.534: INFO: stdout: "containerstoragemodule.storage.dell.com/test-vxflexos created\nconfigmap/test-vxflexos-config-params created\n"
STEP:      Executing  Validate custom resource [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [observability] module from CR [1] is not installed
STEP:      Executing  Enable [observability] module from CR [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [observability] module from CR [1] is installed
STEP:      Executing  Disable [observability] module from CR [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [observability] module from CR [1] is not installed
STEP:      Executing  Enable forceRemoveDriver on CR [1]
STEP:      Executing  Delete custom resource [1]
STEP: Ending: Install PowerFlex Driver(Standalone), Enable/Disable Observability

STEP: Starting: Install PowerFlex Driver(With Authorization and Observability)
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resource [1]
Nov  9 23:13:51.769: INFO: Running '/usr/bin/kubectl --namespace=test-vxflexos apply --validate=true -f -'
Nov  9 23:13:51.990: INFO: stderr: ""
Nov  9 23:13:51.990: INFO: stdout: "containerstoragemodule.storage.dell.com/test-vxflexos created\nconfigmap/test-vxflexos-config-params created\n"
STEP:      Executing  Set secret for driver from CR [1] to [test-vxflexos-config-auth]
STEP:      Executing  Validate custom resource [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
STEP:      Executing  Validate [observability] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
STEP:      Executing  Run custom test
Nov  9 23:14:02.078: INFO: Running ./cert-csi [test vio --sc vxflexos --chainNumber 2 --chainLength 2]
[2022-11-09 23:14:02]  INFO Starting cert-csi; ver. 0.8.1
[2022-11-09 23:14:02]  INFO Using EVENT observer type
[2022-11-09 23:14:02]  INFO Using config from /etc/kubernetes/admin.conf
[2022-11-09 23:14:02]  INFO Successfully loaded config. Host: https://10.225.108.156:6443
[2022-11-09 23:14:02]  INFO Created new KubeClient
[2022-11-09 23:14:02]  INFO Running 1 iteration(s)
[2022-11-09 23:14:02]  INFO     *** ITERATION NUMBER 1 ***
[2022-11-09 23:14:02]  INFO Starting VolumeIoSuite with vxflexos storage class
[2022-11-09 23:14:02]  INFO Successfully created namespace volumeio-test-585e0e17
[2022-11-09 23:14:02]  INFO Using default number of volumes
[2022-11-09 23:14:02]  INFO Creating IO pod
[2022-11-09 23:14:02]  INFO Waiting for pod iowriter-test-sxmlp to be READY
[2022-11-09 23:14:02]  INFO Waiting for pod iowriter-test-2nwjl to be READY
[2022-11-09 23:14:40]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2022-11-09 23:14:41]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2022-11-09 23:14:44]  INFO Waiting until no Volume Attachments with PV  left
[2022-11-09 23:14:44]  INFO VolumeAttachment deleted
[2022-11-09 23:14:44]  INFO Waiting for pod iowriter-test-5564n to be READY
[2022-11-09 23:14:46]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2022-11-09 23:14:47]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2022-11-09 23:14:48]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-0.sha512]
[2022-11-09 23:14:49]  INFO Hashes match
[2022-11-09 23:14:49]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2022-11-09 23:14:50]  INFO Waiting until no Volume Attachments with PV  left
[2022-11-09 23:14:50]  INFO VolumeAttachment deleted
[2022-11-09 23:14:50]  INFO Waiting for pod iowriter-test-kkmgb to be READY
[2022-11-09 23:14:50]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2022-11-09 23:14:53]  INFO Waiting until no Volume Attachments with PV  left
[2022-11-09 23:14:53]  INFO VolumeAttachment deleted
[2022-11-09 23:14:56]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-1.sha512]
[2022-11-09 23:14:57]  INFO Hashes match
[2022-11-09 23:14:57]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2022-11-09 23:14:58]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2022-11-09 23:15:01]  INFO Waiting until no Volume Attachments with PV  left
[2022-11-09 23:15:01]  INFO VolumeAttachment deleted
[2022-11-09 23:15:01]  INFO Deleting all resources in namespace volumeio-test-585e0e17
[2022-11-09 23:15:13]  INFO Namespace volumeio-test-585e0e17 was deleted in 12.009570197s
[2022-11-09 23:15:17]  INFO SUCCESS: VolumeIoSuite in 1m15.062955436s
[2022-11-09 23:15:17]  INFO Started generating reports...
Collecting metrics
1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2022-11-09 23:15:17]  INFO Started generating reports...
Collecting metrics
1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sGenerating plots
1 / 1 [------------------------------------------------------------------------------------------------------------------------------------------------------>] 100.00% ? p/s1 / 1 [------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 33 p/s[2022-11-09 23:15:17]  WARN No ResourceUsageMetrics provided
[2022-11-09 23:15:17] ERROR no ResourceUsageMetrics provided
report-test-run-57e63470:
Name: test-run-57e63470
Host: https://10.225.108.156:6443
StorageClass: vxflexos
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-57e63470/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-57e63470/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-57e63470/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-57e63470/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-57e63470/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2022-11-09 23:14:02.160048486 -0500 -0500
            Ended:     2022-11-09 23:15:17.223039465 -0500 -0500
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 215.406744ms
                        Min: 209.440935ms
                        Max: 221.372554ms
                        Histogram:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 31.576135049s
                        Min: 31.569204974s
                        Max: 31.583065125s
                        Histogram:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 32.348161471s
                        Min: 32.33732737s
                        Max: 32.358995573s
                        Histogram:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 17.076875ms
                        Min: 12.900099ms
                        Max: 21.253651ms
                        Histogram:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 183.652343ms
                        Min: 176.414244ms
                        Max: 190.890442ms
                        Histogram:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 22.526812664s
                        Min: 3.987893784s
                        Max: 43.580538797s
                        Histogram:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.344595766s
                        Min: 1.071731457s
                        Max: 1.589052213s
                        Histogram:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-57e63470/VolumeIoSuite2/EntityNumberOverTime.png

[2022-11-09 23:15:17]  INFO Avg time of a run:   59.28s
[2022-11-09 23:15:17]  INFO Avg time of a del:   12.01s
[2022-11-09 23:15:17]  INFO Avg time of all:     75.06s
[2022-11-09 23:15:17]  INFO During this run 100.0% of suites succeeded
STEP:      Executing  Enable forceRemoveDriver on CR [1]
STEP:      Executing  Delete custom resource [1]
STEP: Ending: Install PowerFlex Driver(With Authorization and Observability)

STEP: Starting: Install PowerFlex Driver(Standalone), Enable Authorization, Enable Observability
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resource [1]
Nov  9 23:15:22.776: INFO: Running '/usr/bin/kubectl --namespace=test-vxflexos apply --validate=true -f -'
Nov  9 23:15:22.989: INFO: stderr: ""
Nov  9 23:15:22.989: INFO: stdout: "containerstoragemodule.storage.dell.com/test-vxflexos created\nconfigmap/test-vxflexos-config-params created\n"
STEP:      Executing  Validate custom resource [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is not installed
STEP:      Executing  Validate [observability] module from CR [1] is not installed
STEP:      Executing  Enable [authorization] module from CR [1]
STEP:      Executing  Set secret for driver from CR [1] to [test-vxflexos-config-auth]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:2]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:2]
STEP:      Executing  Validate [observability] module from CR [1] is not installed
STEP:      Executing  Enable [observability] module from CR [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:2]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:2]
STEP:      Executing  Validate [observability] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
STEP:      Executing  Enable forceRemoveDriver on CR [1]
STEP:      Executing  Delete custom resource [1]
STEP: Ending: Install PowerFlex Driver(Standalone), Enable Authorization, Enable Observability

STEP: Starting: Install PowerFlex Driver(With Authorization and Observability), Disable Observability module, Disable Authorization module"
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resource [1]
Nov  9 23:15:58.326: INFO: Running '/usr/bin/kubectl --namespace=test-vxflexos apply --validate=true -f -'
Nov  9 23:15:58.548: INFO: stderr: ""
Nov  9 23:15:58.548: INFO: stdout: "containerstoragemodule.storage.dell.com/test-vxflexos created\nconfigmap/test-vxflexos-config-params created\n"
STEP:      Executing  Set secret for driver from CR [1] to [test-vxflexos-config-auth]
STEP:      Executing  Validate custom resource [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
STEP:      Executing  Validate [observability] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
STEP:      Executing  Disable [observability] module from CR [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
STEP:      Executing  Validate [observability] module from CR [1] is not installed
STEP:      Executing  Disable [authorization] module from CR [1]
STEP:      Executing  Set secret for driver from CR [1] to [test-vxflexos-config]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is not installed
STEP:      Executing  Validate [observability] module from CR [1] is not installed
STEP:      Executing  Enable forceRemoveDriver on CR [1]
STEP:      Executing  Delete custom resource [1]
STEP: Ending: Install PowerFlex Driver(With Authorization and Observability), Disable Observability module, Disable Authorization module"

STEP: Starting: Install PowerFlex Driver(With Authorization and Observability), Disable Authorization module, Disable Observability module"
STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed
STEP:      Executing  Apply custom resource [1]
Nov  9 23:16:33.884: INFO: Running '/usr/bin/kubectl --namespace=test-vxflexos apply --validate=true -f -'
Nov  9 23:16:34.092: INFO: stderr: ""
Nov  9 23:16:34.092: INFO: stdout: "containerstoragemodule.storage.dell.com/test-vxflexos created\nconfigmap/test-vxflexos-config-params created\n"
STEP:      Executing  Set secret for driver from CR [1] to [test-vxflexos-config-auth]
STEP:      Executing  Validate custom resource [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
STEP:      Executing  Validate [observability] module from CR [1] is installed
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
STEP:      Executing  Disable [authorization] module from CR [1]
STEP:      Executing  Set secret for driver from CR [1] to [test-vxflexos-config]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is not installed
STEP:      Executing  Validate [observability] module from CR [1] is installed
STEP:      Executing  Disable [observability] module from CR [1]
STEP:      Executing  Validate [powerflex] driver from CR [1] is installed
STEP:      Executing  Validate [authorization] module from CR [1] is not installed
STEP:      Executing  Validate [observability] module from CR [1] is not installed
STEP:      Executing  Enable forceRemoveDriver on CR [1]
STEP:      Executing  Delete custom resource [1]
STEP: Ending: Install PowerFlex Driver(With Authorization and Observability), Disable Authorization module, Disable Observability module"


• [SLOW TEST:233.161 seconds]
[run-e2e-test]E2E Testing
 ~/csm-operator/tests/e2e/e2e_test.go:121
  Running all test Given Test Scenarios
   ~/csm-operator/tests/e2e/e2e_test.go:122
------------------------------

Ran 1 of 1 Specs in 233.525 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 3m58.014903309s
Test Suite Passed

```

- [x] manual test

<img width="907" alt="pflex_node" src="https://user-images.githubusercontent.com/88763781/200531355-a432d8ef-4a54-4495-964e-13eaecb2b327.PNG">

<img width="911" alt="pflex_volume" src="https://user-images.githubusercontent.com/88763781/200531401-b0b308a3-80de-4a89-afc3-053558dd2397.PNG">

<img width="902" alt="pflex_cap" src="https://user-images.githubusercontent.com/88763781/200531424-fa62b4ca-7f0b-45ec-88bd-a81f0eddc1d1.PNG">

