### PR TITLE
Update Authorization Ingresses

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -124,7 +124,7 @@ type Module struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name"
 	Name ModuleType `json:"name" yaml:"name"`
 
-	// Enabled is used to indicate wether or not to deploy a module
+	// Enabled is used to indicate whether or not to deploy a module
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enabled"
 	Enabled bool `json:"enabled" yaml:"enabled"`
 

--- a/config/crd/bases/storage.dell.com_containerstoragemodules.yaml
+++ b/config/crd/bases/storage.dell.com_containerstoragemodules.yaml
@@ -1273,7 +1273,7 @@ spec:
                         module
                       type: string
                     enabled:
-                      description: Enabled is used to indicate wether or not to deploy
+                      description: Enabled is used to indicate whether or not to deploy
                         a module
                       type: boolean
                     forceRemoveModule:

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -789,10 +789,6 @@ func (r *ContainerStorageModuleReconciler) reconcileAuthorization(ctx context.Co
 			return fmt.Errorf("unable to reconcile authorization proxy server: %v", err)
 		}
 
-		if err := modules.AuthorizationIngress(ctx, isDeleting, op, cr, ctrlClient); err != nil {
-			return fmt.Errorf("unable to reconcile authorization ingress rules: %v", err)
-		}
-
 		if err := modules.InstallPolicies(ctx, isDeleting, op, cr, ctrlClient); err != nil {
 			return fmt.Errorf("unable to install policies: %v", err)
 		}
@@ -811,6 +807,15 @@ func (r *ContainerStorageModuleReconciler) reconcileAuthorization(ctx context.Co
 			return fmt.Errorf("unable to reconcile nginx ingress controller for authorization: %v", err)
 		}
 	}
+
+	// Authorization Ingress rules are applied after NGINX ingress controller is installed
+	if utils.IsAuthorizationComponentEnabled(ctx, cr, r, csmv1.AuthorizationServer, modules.AuthProxyServerComponent) {
+		log.Infow("Reconcile authorization Ingresses")
+		if err := modules.AuthorizationIngress(ctx, isDeleting, op, cr, r, ctrlClient); err != nil {
+			return fmt.Errorf("unable to reconcile authorization ingress rules: %v", err)
+		}
+	}
+
 	return nil
 }
 

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -172,7 +172,7 @@ func (suite *CSMControllerTestSuite) TestReconcile() {
 
 func (suite *CSMControllerTestSuite) TestAuthorizationServerReconcile() {
 	suite.makeFakeAuthServerCSM(csmName, suite.namespace, getAuthProxyServer())
-	suite.runFakeAuthCSMManager("", false)
+	suite.runFakeAuthCSMManager("timed out waiting for the condition", false)
 	suite.deleteCSM(csmName)
 	suite.runFakeAuthCSMManager("", true)
 }
@@ -901,12 +901,12 @@ func (suite *CSMControllerTestSuite) handleDaemonsetTest(r *ContainerStorageModu
 }
 
 func (suite *CSMControllerTestSuite) handleDeploymentTest(r *ContainerStorageModuleReconciler, name string) {
-	deployement := &appsv1.Deployment{}
-	err := suite.fakeClient.Get(ctx, client.ObjectKey{Namespace: suite.namespace, Name: name}, deployement)
+	deployment := &appsv1.Deployment{}
+	err := suite.fakeClient.Get(ctx, client.ObjectKey{Namespace: suite.namespace, Name: name}, deployment)
 	assert.Nil(suite.T(), err)
-	deployement.Spec.Template.Labels = map[string]string{"csm": "csm"}
+	deployment.Spec.Template.Labels = map[string]string{"csm": "csm"}
 
-	r.handleDeploymentUpdate(deployement, deployement)
+	r.handleDeploymentUpdate(deployment, deployment)
 
 	//Make Pod and set pod status
 	pod := shared.MakePod(name, suite.namespace)

--- a/deploy/crds/storage.dell.com_containerstoragemodules.yaml
+++ b/deploy/crds/storage.dell.com_containerstoragemodules.yaml
@@ -890,7 +890,7 @@ spec:
                       description: ConfigVersion is the configuration version of the module
                       type: string
                     enabled:
-                      description: Enabled is used to indicate wether or not to deploy a module
+                      description: Enabled is used to indicate whether or not to deploy a module
                       type: boolean
                     forceRemoveModule:
                       description: ForceRemoveModule is the boolean flag used to remove authorization proxy server deployment when CR is deleted

--- a/pkg/modules/authorization_test.go
+++ b/pkg/modules/authorization_test.go
@@ -562,8 +562,11 @@ func TestAuthorizationIngressRules(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			success, isDeleting, cr, sourceClient, op := tc(t)
-
-			err := AuthorizationIngress(context.TODO(), isDeleting, op, cr, sourceClient)
+			fakeReconcile := utils.FakeReconcileCSM{
+				Client:    sourceClient,
+				K8sClient: fake.NewSimpleClientset(),
+			}
+			err := AuthorizationIngress(context.TODO(), isDeleting, op, cr, &fakeReconcile, sourceClient)
 			if success {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/modules/testdata/cr_auth_proxy.yaml
+++ b/pkg/modules/testdata/cr_auth_proxy.yaml
@@ -52,7 +52,7 @@ spec:
           # Default value: nginx
           - name: "PROXY_INGRESS_CLASSNAME"
             value: "nginx"
-          # Additional host rules for the proxy-server ingress
+          # An additional host rule for the proxy-server ingress
           # Default value: authorization-ingress-nginx-controller.namespace.svc.cluster.local
           - name: "PROXY_INGRESS_HOST"
             value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"

--- a/pkg/modules/testdata/cr_auth_proxy.yaml
+++ b/pkg/modules/testdata/cr_auth_proxy.yaml
@@ -54,7 +54,7 @@ spec:
             value: "nginx"
           # Additional host rules for the proxy-server ingress
           # Default value: authorization-ingress-nginx-controller.namespace.svc.cluster.local
-          - name: "PROXY_INGRESS_HOSTS"
+          - name: "PROXY_INGRESS_HOST"
             value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"
 
           # Tenant-service ingress configuration

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -338,6 +338,7 @@ func HandleSuccess(ctx context.Context, instance *csmv1.ContainerStorageModule, 
 	return LogBannerAndReturn(reconcile.Result{}, nil)
 }
 
+// GetNginxControllerStatus - gets deployment status of the NGINX ingress controller
 func GetNginxControllerStatus(ctx context.Context, instance csmv1.ContainerStorageModule, r ReconcileCSM) wait.ConditionFunc {
 	return func() (bool, error) {
 		deployment := &appsv1.Deployment{}
@@ -376,6 +377,7 @@ func GetNginxControllerStatus(ctx context.Context, instance csmv1.ContainerStora
 	}
 }
 
+// WaitForNginxController - polls deployment status
 func WaitForNginxController(ctx context.Context, instance csmv1.ContainerStorageModule, r ReconcileCSM, timeout time.Duration) error {
 	log := logger.GetLogger(ctx)
 	log.Infow("Polling status of NGINX ingress controller")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -938,7 +938,7 @@ func GetProxyIngressHost(auth csmv1.Module) string {
 	for _, comp := range auth.Components {
 		if comp.Name == AuthProxyServerComponent {
 			for _, env := range comp.Envs {
-				if env.Name == "PROXY_INGRESS_HOSTS" && env.Value != "" {
+				if env.Name == "PROXY_INGRESS_HOST" && env.Value != "" {
 					ingressHost = env.Value
 					break
 				}

--- a/samples/authorization/csm_authorization_proxy_server.yaml
+++ b/samples/authorization/csm_authorization_proxy_server.yaml
@@ -13,6 +13,7 @@ spec:
       forceRemoveModule: true
       components:
       - name: karavi-authorization-proxy-server
+        # enable: Enable/Disable csm-authorization proxy server
         enabled: true
         image: dellemc/csm-authorization-proxy:v1.4.0
         image: dellemc/csm-authorization-tenant:v1.4.0
@@ -54,7 +55,7 @@ spec:
             value: "nginx"
           # Additional host rules for the proxy-server ingress
           # Default value: authorization-ingress-nginx-controller.namespace.svc.cluster.local
-          - name: "PROXY_INGRESS_HOSTS"
+          - name: "PROXY_INGRESS_HOST"
             value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"
 
           # Tenant-service ingress configuration
@@ -72,9 +73,10 @@ spec:
           - name: "STORAGE_INGRESS_CLASSNAME"
             value: "nginx" 
 
-          # Specify storage class for redis. Otherwise, default storage class is used
+          # Specify storage class for redis. Otherwise, default storage class is used.
+          # Default value: None
           - name: "REDIS_STORAGE_CLASS"
-            value: "local-storage"
+            value: ""
 
       # enabled: Enable/Disable nginx ingress
       # Allowed values:

--- a/samples/authorization/csm_authorization_proxy_server.yaml
+++ b/samples/authorization/csm_authorization_proxy_server.yaml
@@ -53,7 +53,7 @@ spec:
           # Default value: nginx
           - name: "PROXY_INGRESS_CLASSNAME"
             value: "nginx"
-          # Additional host rules for the proxy-server ingress
+          # An additional host rule for the proxy-server ingress
           # Default value: authorization-ingress-nginx-controller.namespace.svc.cluster.local
           - name: "PROXY_INGRESS_HOST"
             value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"

--- a/tests/e2e/testfiles/csm_authorization_proxy_server.yaml
+++ b/tests/e2e/testfiles/csm_authorization_proxy_server.yaml
@@ -52,9 +52,9 @@ spec:
           # Default value: nginx
           - name: "PROXY_INGRESS_CLASSNAME"
             value: "nginx"
-          # Additional host rules for the proxy-server ingress
+          # An additional host rule for the proxy-server ingress
           # Default value: authorization-ingress-nginx-controller.namespace.svc.cluster.local
-          - name: "PROXY_INGRESS_HOSTS"
+          - name: "PROXY_INGRESS_HOST"
             value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"
 
           # Tenant-service ingress configuration

--- a/tests/shared/crclient/client.go
+++ b/tests/shared/crclient/client.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	"github.com/dell/csm-operator/tests/shared"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -98,6 +99,8 @@ func (f Client) List(ctx context.Context, list client.ObjectList, opts ...client
 	switch list.(type) {
 	case *corev1.PodList:
 		return f.listPodList(list.(*corev1.PodList))
+	case *appsv1.DeploymentList:
+		return f.listDeploymentList(ctx, &appsv1.DeploymentList{})
 	default:
 		return fmt.Errorf("fake client unknown type: %s", reflect.TypeOf(list))
 	}
@@ -107,6 +110,15 @@ func (f Client) listPodList(list *corev1.PodList) error {
 	for k, v := range f.Objects {
 		if k.Kind == "Pod" {
 			list.Items = append(list.Items, *v.(*corev1.Pod))
+		}
+	}
+	return nil
+}
+
+func (f Client) listDeploymentList(ctx context.Context, list *appsv1.DeploymentList) error {
+	for k, v := range f.Objects {
+		if k.Kind == "Deployment" {
+			list.Items = append(list.Items, *v.(*appsv1.Deployment))
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description
PR to address a timing issue when creating Ingresses using the NGINX ingress controller. Ingresses are created only after the NGINX ingress controller deployment is running to ensure the `ingress-nginx-admission` webhook can validate Ingress definitions.

A `timed out waiting for the condition` is expected as we will only poll the status of the NGINX ingress controller deployment at 10 second intervals before reconciling again.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/511 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested deployment of Authorization Proxy Server
![Capture](https://user-images.githubusercontent.com/66699024/201971019-64613a7a-7630-4799-bb6c-1fd4c4aef97b.PNG)

![Capture](https://user-images.githubusercontent.com/66699024/201971263-6c47ea40-3434-495c-aa38-072c4fdf5cd6.PNG)
