### PR TITLE
Reverting UBI back to 8.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ COPY tests/ tests/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Tag corresponding to digest 2db613439c1708842f3fd6104a6b7b831f1f9b1c223c225101649e6bc4ae2983 is 8.7-923
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:2db613439c1708842f3fd6104a6b7b831f1f9b1c223c225101649e6bc4ae2983
+# Tag corresponding to digest c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 is 8.6-994
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45
 
 RUN microdnf install yum \
     && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \


### PR DESCRIPTION
# Description
Reverting UBI image back to 8.6 for consistency

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
