### PR TITLE
Correct Powerflex config map name in manifests

### DIFF
--- a/samples/storage_csm_powerflex_v230.yaml
+++ b/samples/storage_csm_powerflex_v230.yaml
@@ -244,7 +244,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vxflexos-config-params
+  name: test-vxflexos-config-params
   namespace: test-vxflexos
 data:
   driver-config-params.yaml: |


### PR DESCRIPTION
# Description
This PR corrects Powerflex config map name in samples and test files

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/491 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

