### PR TITLE
Changing the time to call reconcile after 4min

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -465,7 +465,7 @@ func (r *ContainerStorageModuleReconciler) handleDaemonsetUpdate(oldObj interfac
 // ContentWatch - watch updates on deployment and deamonset
 func (r *ContainerStorageModuleReconciler) ContentWatch() error {
 
-	sharedInformerFactory := sinformer.NewSharedInformerFactory(r.K8sClient, time.Duration(15*time.Minute))
+	sharedInformerFactory := sinformer.NewSharedInformerFactory(r.K8sClient, time.Duration(4*time.Minute))
 
 	daemonsetInformer := sharedInformerFactory.Apps().V1().DaemonSets().Informer()
 	daemonsetInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -465,7 +465,7 @@ func (r *ContainerStorageModuleReconciler) handleDaemonsetUpdate(oldObj interfac
 // ContentWatch - watch updates on deployment and deamonset
 func (r *ContainerStorageModuleReconciler) ContentWatch() error {
 
-	sharedInformerFactory := sinformer.NewSharedInformerFactory(r.K8sClient, time.Duration(time.Hour))
+	sharedInformerFactory := sinformer.NewSharedInformerFactory(r.K8sClient, time.Duration(15*time.Minute))
 
 	daemonsetInformer := sharedInformerFactory.Apps().V1().DaemonSets().Informer()
 	daemonsetInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -465,7 +465,7 @@ func (r *ContainerStorageModuleReconciler) handleDaemonsetUpdate(oldObj interfac
 // ContentWatch - watch updates on deployment and deamonset
 func (r *ContainerStorageModuleReconciler) ContentWatch() error {
 
-	sharedInformerFactory := sinformer.NewSharedInformerFactory(r.K8sClient, time.Duration(4*time.Minute))
+	sharedInformerFactory := sinformer.NewSharedInformerFactory(r.K8sClient, time.Duration(15*time.Minute))
 
 	daemonsetInformer := sharedInformerFactory.Apps().V1().DaemonSets().Informer()
 	daemonsetInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	timeout          = time.Minute * 10
+	timeout          = time.Minute * 20
 	interval         = time.Second * 10
 	valuesFileEnvVar = "E2E_VALUES_FILE"
 )


### PR DESCRIPTION
# Description
Changing the time to 4min for calling reconcile to update the CSM-object.  There is no issue with the pods, they are up and running after few seconds. Ran e2e tests #344 in jenkins with this changes. Csm-object updated after 4min of pods being up.
Also, setting it to 4 is not the only solution. Any number of minutes from 3 to 6 would be an ideal choice.

| Issue # |
|  |


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

