### PR TITLE
Volume mount fails for NFS mounts for csi-powerstore deployed using csm-operator

### DIFF
--- a/config/samples/storage_v1_csm_powerstore.yaml
+++ b/config/samples/storage_v1_csm_powerstore.yaml
@@ -82,6 +82,11 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+        # X_CSI_POWERSTORE_EXTERNAL_ACCESS: Allows to specify additional entries for hostAccess of NFS volumes. Both single IP address and subnet are valid entries.
+        # Allowed Values: x.x.x.x/xx or x.x.x.x
+        # Default Value: 
+        - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
+          value: 
 
       # nodeSelector: Define node selection constraints for controller pods.
       # For the pod to be eligible to run on a node, the node must have each

--- a/operatorconfig/driverconfig/powerstore/v2.4.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.4.0/controller.yaml
@@ -227,7 +227,7 @@ spec:
             - name: X_CSI_DRIVER_NAME
               value: "csi-powerstore.dellemc.com"
             - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
-              value: "None"
+              value: <X_CSI_POWERSTORE_EXTERNAL_ACCESS>
             - name: X_CSI_NFS_ACLS
               value: "<X_CSI_NFS_ACLS>"
             - name: X_CSI_POWERSTORE_CONFIG_PATH

--- a/operatorconfig/driverconfig/powerstore/v2.5.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.5.0/controller.yaml
@@ -240,7 +240,7 @@ spec:
             - name: X_CSI_DRIVER_NAME
               value: "csi-powerstore.dellemc.com"
             - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
-              value: "None"
+              value: <X_CSI_POWERSTORE_EXTERNAL_ACCESS>
             - name: X_CSI_NFS_ACLS
               value: "<X_CSI_NFS_ACLS>"
             - name: X_CSI_POWERSTORE_CONFIG_PATH

--- a/pkg/drivers/powerstore.go
+++ b/pkg/drivers/powerstore.go
@@ -48,6 +48,9 @@ const (
 
 	// CsiPowerstoreEnableChap -  CHAP flag
 	CsiPowerstoreEnableChap = "<X_CSI_POWERSTORE_ENABLE_CHAP>"
+
+	// CsiPowerstoreExternalAccess -  External Access flag
+	CsiPowerstoreExternalAccess = "<X_CSI_POWERSTORE_EXTERNAL_ACCESS>"
 )
 
 // PrecheckPowerStore do input validation
@@ -88,6 +91,7 @@ func ModifyPowerstoreCR(yamlString string, cr csmv1.ContainerStorageModule, file
 	healthMonitorController := ""
 	chap := ""
 	healthMonitorNode := ""
+	powerstoreExternalAccess := ""
 
 	switch fileType {
 	case "Node":
@@ -119,9 +123,13 @@ func ModifyPowerstoreCR(yamlString string, cr csmv1.ContainerStorageModule, file
 			if env.Name == "X_CSI_HEALTH_MONITOR_ENABLED" {
 				healthMonitorController = env.Value
 			}
+			if env.Name == "X_CSI_POWERSTORE_EXTERNAL_ACCESS" {
+				powerstoreExternalAccess = env.Value
+			}
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiNfsAcls, nfsAcls)
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorController)
+		yamlString = strings.ReplaceAll(yamlString, CsiPowerstoreExternalAccess, powerstoreExternalAccess)
 	}
 	return yamlString
 }

--- a/samples/storage_csm_powerstore_v240.yaml
+++ b/samples/storage_csm_powerstore_v240.yaml
@@ -114,6 +114,11 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+        # X_CSI_POWERSTORE_EXTERNAL_ACCESS: Allows to specify additional entries for hostAccess of NFS volumes. Both single IP address and subnet are valid entries.
+        # Allowed Values: x.x.x.x/xx or x.x.x.x
+        # Default Value: 
+        - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
+          value: 
 
       # nodeSelector: Define node selection constraints for node pods.
       # For the pod to be eligible to run on a node, the node must have each

--- a/samples/storage_csm_powerstore_v250.yaml
+++ b/samples/storage_csm_powerstore_v250.yaml
@@ -81,6 +81,11 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+        # X_CSI_POWERSTORE_EXTERNAL_ACCESS: Allows to specify additional entries for hostAccess of NFS volumes. Both single IP address and subnet are valid entries.
+        # Allowed Values: x.x.x.x/xx or x.x.x.x
+        # Default Value: 
+        - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
+          value: 
 
       # nodeSelector: Define node selection constraints for controller pods.
       # For the pod to be eligible to run on a node, the node must have each


### PR DESCRIPTION
# Description
Volume mount fails for NFS mounts for csi-powerstore deployed using csm-operator

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|  https://github.com/dell/csm/issues/613 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

