### PR TITLE
[bug-654]: Add zero quota policy to powermax

### DIFF
--- a/operatorconfig/moduleconfig/authorization/v1.6.0/policies.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.6.0/policies.yaml
@@ -181,6 +181,18 @@ data:
       common.roles[v].system_types[input.systemtype].system_ids[input.storagesystemid].pool_quotas[input.storagepool] >= to_number(input.request.volumeSizeInKb)
       y := to_number(common.roles[v].system_types[input.systemtype].system_ids[input.storagesystemid].pool_quotas[input.storagepool])
     }
+
+    permitted_roles[v] = y {
+      claimed_roles := split(input.claims.roles, ",")
+
+      some i
+      a := claimed_roles[i]
+      common.roles[a]
+
+      v := claimed_roles[i]
+      common.roles[v].system_types[input.systemtype].system_ids[input.storagesystemid].pool_quotas[input.storagepool] == 0
+      y := to_number(common.roles[v].system_types[input.systemtype].system_ids[input.storagesystemid].pool_quotas[input.storagepool])
+    }
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
# Description

Updates the powermax-volume-create policy to allow zero quota.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/654 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Manually deployed Authorization and verified policies are expected.
