### PR TITLE
Add powerflex 2.6 features(ApproveSdc,RenameSdc) support to csm-operator

### DIFF
--- a/operatorconfig/driverconfig/powerflex/v2.6.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.6.0/node.yaml
@@ -101,6 +101,12 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: false
+            - name: X_CSI_APPROVE_SDC_ENABLED
+              value: "<X_CSI_APPROVE_SDC_ENABLED>"
+            - name: X_CSI_RENAME_SDC_ENABLED
+              value: "<X_CSI_RENAME_SDC_ENABLED>"
+            - name: X_CSI_RENAME_SDC_PREFIX
+              value: "<X_CSI_RENAME_SDC_PREFIX>"
           volumeMounts:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com

--- a/operatorconfig/driverconfig/powerflex/v2.6.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.6.0/node.yaml
@@ -102,11 +102,11 @@ spec:
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: false
             - name: X_CSI_APPROVE_SDC_ENABLED
-              value: "<X_CSI_APPROVE_SDC_ENABLED>"
+              value: <X_CSI_APPROVE_SDC_ENABLED>
             - name: X_CSI_RENAME_SDC_ENABLED
-              value: "<X_CSI_RENAME_SDC_ENABLED>"
+              value: <X_CSI_RENAME_SDC_ENABLED>
             - name: X_CSI_RENAME_SDC_PREFIX
-              value: "<X_CSI_RENAME_SDC_PREFIX>"
+              value: <X_CSI_RENAME_SDC_PREFIX>
           volumeMounts:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com

--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -164,6 +164,9 @@ func GetNode(ctx context.Context, cr csmv1.ContainerStorageModule, operatorConfi
 	if cr.Spec.Driver.CSIDriverType == "powerstore" {
 		YamlString = ModifyPowerstoreCR(YamlString, cr, "Node")
 	}
+	if cr.Spec.Driver.CSIDriverType == "powerflex" {
+		YamlString = ModifyPowerflexCR(YamlString, cr, "Node")
+	}
 
 	driverYAML, err := utils.GetDriverYaml(YamlString, "DaemonSet")
 	if err != nil {

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -33,6 +33,17 @@ const (
 
 	// PowerFlexConfigParamsVolumeMount -
 	PowerFlexConfigParamsVolumeMount = "vxflexos-config-params"
+
+	// CsiApproveSdcEnabled - Flag to enable/disable SDC approval
+	CsiApproveSdcEnabled = "<X_CSI_APPROVE_SDC_ENABLED>"
+
+	// CsiRenameSdcEnabled - Flag to enable/disable rename of SDC
+	CsiRenameSdcEnabled = "<X_CSI_RENAME_SDC_ENABLED>"
+
+	// CsiPrefixRenameSdc - String to rename SDC
+	CsiPrefixRenameSdc = "<X_CSI_RENAME_SDC_PREFIX>"
+
+
 )
 
 // PrecheckPowerFlex do input validation
@@ -202,4 +213,32 @@ var (
 // IsIpv4Regex - Matches Ipaddress with regex and returns error if the Ip Address doesn't match regex
 func IsIpv4Regex(ipAddress string) bool {
 	return ipRegex.MatchString(ipAddress)
+}
+
+// ModifyPowerflexCR - Set environment variables provided in CR
+func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileType string) string {
+
+	approvesdcvalue := ""
+	renamesdcenable := ""
+	prefixrenamesdc := ""
+
+
+	switch fileType {
+	case "Node":
+		for _, env := range cr.Spec.Driver.Node.Envs {
+			if env.Name == "X_CSI_APPROVE_SDC_ENABLED" {
+				approvesdcvalue = env.Value
+			}
+			if env.Name == "X_CSI_RENAME_SDC_ENABLED" {
+				renamesdcenable = env.Value
+			}
+			if env.Name == "X_CSI_RENAME_SDC_PREFIX" {
+				prefixrenamesdc = env.Value
+			}
+		}
+		yamlString = strings.ReplaceAll(yamlString, CsiApproveSdcEnabled, approvesdcvalue)
+		yamlString = strings.ReplaceAll(yamlString, CsiRenameSdcEnabled, renamesdcenable)
+		yamlString = strings.ReplaceAll(yamlString, CsiPrefixRenameSdc, prefixrenamesdc)
+	}
+	return yamlString
 }

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -42,8 +42,6 @@ const (
 
 	// CsiPrefixRenameSdc - String to rename SDC
 	CsiPrefixRenameSdc = "<X_CSI_RENAME_SDC_PREFIX>"
-
-
 )
 
 // PrecheckPowerFlex do input validation
@@ -221,7 +219,6 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 	approvesdcvalue := ""
 	renamesdcenable := ""
 	prefixrenamesdc := ""
-
 
 	switch fileType {
 	case "Node":

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -216,26 +216,26 @@ func IsIpv4Regex(ipAddress string) bool {
 // ModifyPowerflexCR - Set environment variables provided in CR
 func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileType string) string {
 
-	approvesdcvalue := ""
-	renamesdcenable := ""
-	prefixrenamesdc := ""
+	approveSdcEnabled := ""
+	renameSdcEnabled := ""
+	renameSdcPrefix := ""
 
 	switch fileType {
 	case "Node":
 		for _, env := range cr.Spec.Driver.Node.Envs {
 			if env.Name == "X_CSI_APPROVE_SDC_ENABLED" {
-				approvesdcvalue = env.Value
+				approveSdcEnabled = env.Value
 			}
 			if env.Name == "X_CSI_RENAME_SDC_ENABLED" {
-				renamesdcenable = env.Value
+				renameSdcEnabled = env.Value
 			}
 			if env.Name == "X_CSI_RENAME_SDC_PREFIX" {
-				prefixrenamesdc = env.Value
+				renameSdcPrefix = env.Value
 			}
 		}
-		yamlString = strings.ReplaceAll(yamlString, CsiApproveSdcEnabled, approvesdcvalue)
-		yamlString = strings.ReplaceAll(yamlString, CsiRenameSdcEnabled, renamesdcenable)
-		yamlString = strings.ReplaceAll(yamlString, CsiPrefixRenameSdc, prefixrenamesdc)
+		yamlString = strings.ReplaceAll(yamlString, CsiApproveSdcEnabled, approveSdcEnabled)
+		yamlString = strings.ReplaceAll(yamlString, CsiRenameSdcEnabled, renameSdcEnabled)
+		yamlString = strings.ReplaceAll(yamlString, CsiPrefixRenameSdc, renameSdcPrefix)
 	}
 	return yamlString
 }

--- a/samples/storage_csm_powerflex_v260.yaml
+++ b/samples/storage_csm_powerflex_v260.yaml
@@ -123,7 +123,7 @@ spec:
         # Default value: none
         # Examples: "rhel-sdc", "sdc-test"
         - name: X_CSI_RENAME_SDC_PREFIX
-          value: "sdc-test"
+          value: ""
           
 
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset

--- a/samples/storage_csm_powerflex_v260.yaml
+++ b/samples/storage_csm_powerflex_v260.yaml
@@ -101,6 +101,29 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+
+        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"  
+
+        # X_CSI_RENAME_SDC_ENABLED: Enable/Disable rename of SDC
+        # Allowed values:
+        #   true: enable renaming
+        #   false: disable renaming
+        # Default value: false
+        - name: X_CSI_RENAME_SDC_ENABLED
+          value: "false"
+
+        # X_CSI_RENAME_SDC_PREFIX: defines a string for prefix of the SDC name.
+        # "prefix" + "worker_node_hostname" should not exceed 31 chars.
+        # Default value: none
+        # Examples: "rhel-sdc", "sdc-test"
+        - name: X_CSI_RENAME_SDC_PREFIX
+          value: "sdc-test"
           
 
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset


### PR DESCRIPTION
# Description
This pr adds the Support for Powerflex 2.6 features( ApproveSdc,RenameSdc) to the csm-operator

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/402 |
| https://github.com/dell/csm/issues/583 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the Powerflex Driver with csm-operator by enabling the above features
- [x] Tested the features


![results](https://user-images.githubusercontent.com/103578883/220849721-1a9b3c6d-3ec7-4ecd-a7a3-024d96b5f729.PNG)
![results2](https://user-images.githubusercontent.com/103578883/220849748-d2fd9136-c114-4796-8d7c-89c641435704.PNG)

- [x] Sanity Test
![sanity-test](https://user-images.githubusercontent.com/103578883/220856273-6a8806f6-7d44-491f-9c20-98b68440c8c3.PNG)
