### PR TITLE
Test variables added

### DIFF
--- a/tests/config/driverconfig/powerflex/v2.6.0/node.yaml
+++ b/tests/config/driverconfig/powerflex/v2.6.0/node.yaml
@@ -101,6 +101,12 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: false
+            - name: X_CSI_APPROVE_SDC_ENABLED
+              value: true
+            - name: X_CSI_RENAME_SDC_ENABLED
+              value: true
+            - name: X_CSI_RENAME_SDC_PREFIX
+              value: "test"
           volumeMounts:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com

--- a/tests/e2e/testfiles/storage_csm_powerflex.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex.yaml
@@ -104,6 +104,28 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"  
+
+        # X_CSI_RENAME_SDC_ENABLED: Enable/Disable rename of SDC
+        # Allowed values:
+        #   true: enable renaming
+        #   false: disable renaming
+        # Default value: false
+        - name: X_CSI_RENAME_SDC_ENABLED
+          value: "false"
+
+        # X_CSI_RENAME_SDC_PREFIX: defines a string for prefix of the SDC name.
+        # "prefix" + "worker_node_hostname" should not exceed 31 chars.
+        # Default value: none
+        # Examples: "rhel-sdc", "sdc-test"
+        - name: X_CSI_RENAME_SDC_PREFIX
+          value: ""
 
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes


### PR DESCRIPTION
# Description
Minor changes to unit-test for powerflex -2.6

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/402 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Unit-test :

--- PASS: TestCustom (22.46s)
    --- PASS: TestCustom/TestAuthorizationServerReconcile (20.48s)
    --- PASS: TestCustom/TestContentWatch (0.02s)
    --- PASS: TestCustom/TestCsmFinalizerError (0.00s)
    --- PASS: TestCustom/TestCsmPreCheckModuleError (0.00s)
    --- PASS: TestCustom/TestCsmPreCheckModuleUnsupportedVersion (0.00s)
    --- PASS: TestCustom/TestCsmPreCheckTypeError (0.00s)
    --- PASS: TestCustom/TestCsmPreCheckVersionError (0.00s)
    --- PASS: TestCustom/TestCsmUpgrade (0.17s)
    --- PASS: TestCustom/TestCsmUpgradePathInvalid (0.02s)
    --- PASS: TestCustom/TestCsmUpgradeSkipVersion (0.00s)
    --- PASS: TestCustom/TestCsmUpgradeVersionTooOld (0.00s)
    --- PASS: TestCustom/TestDeleteErrorReconcile (0.29s)
    --- PASS: TestCustom/TestErrorInjection (0.42s)
    --- PASS: TestCustom/TestIgnoreUpdatePredicate (0.00s)
    --- PASS: TestCustom/TestOldStandAloneModuleCleanup (0.12s)
        --- PASS: TestCustom/TestOldStandAloneModuleCleanup/Success_-_Disable_Components (0.02s)
        --- PASS: TestCustom/TestOldStandAloneModuleCleanup/Success_-_Enable_all_modules (0.02s)
        --- PASS: TestCustom/TestOldStandAloneModuleCleanup/Success_-_Disable_all_modules (0.08s)
    --- PASS: TestCustom/TestPowerFlexAnnotation (0.00s)
    --- PASS: TestCustom/TestPowerScaleAnnotation (0.00s)
    --- PASS: TestCustom/TestPowerStoreAnnotation (0.00s)
    --- PASS: TestCustom/TestReconcile (0.24s)
    --- PASS: TestCustom/TestReconcileAuthorization (0.00s)
    --- PASS: TestCustom/TestReconcileObservabilityError (0.00s)
    --- PASS: TestCustom/TestRemoveDriver (0.58s)
        --- PASS: TestCustom/TestRemoveDriver/getDriverConfig_error (0.00s)
        --- PASS: TestCustom/TestRemoveDriver/delete_obj_not_found (0.02s)
        --- PASS: TestCustom/TestRemoveDriver/get_SA_error (0.07s)
        --- PASS: TestCustom/TestRemoveDriver/get_CR_error (0.06s)
        --- PASS: TestCustom/TestRemoveDriver/get_CRB_error (0.07s)
        --- PASS: TestCustom/TestRemoveDriver/get_CM_error (0.08s)
        --- PASS: TestCustom/TestRemoveDriver/get_Driver_error (0.07s)
        --- PASS: TestCustom/TestRemoveDriver/delete_SA_error (0.07s)
        --- PASS: TestCustom/TestRemoveDriver/delete_Daemonset_error (0.08s)
        --- PASS: TestCustom/TestRemoveDriver/delete_Deployment_error (0.07s)
    --- PASS: TestCustom/TestRemoveModule (0.11s)
        --- PASS: TestCustom/TestRemoveModule/csm (0.11s)
PASS
coverage: 88.6% of statements
ok      command-line-arguments  22.508s coverage: 88.6% of statements
