### PR TITLE
add the changes to support mke 3.5.x for latest vxflexos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For any CSM Operator and driver issues, questions or feedback, join the [Dell Te
 ## Supported Platforms
 Dell Container Storage Modules Operator has been tested and qualified with 
 
-    * Upstream Kubernetes cluster v1.21, v1.24, v1.25, v1.26
+    * Upstream Kubernetes cluster v1.24, v1.25, v1.26
     * OpenShift Clusters 4.10, 4.11 with RHEL 8.x & RHCOS worker nodes
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For any CSM Operator and driver issues, questions or feedback, join the [Dell Te
 ## Supported Platforms
 Dell Container Storage Modules Operator has been tested and qualified with 
 
-    * Upstream Kubernetes cluster v1.24, v1.25, v1.26
+    * Upstream Kubernetes cluster v1.21, v1.24, v1.25, v1.26
     * OpenShift Clusters 4.10, 4.11 with RHEL 8.x & RHCOS worker nodes
 
 ## Installation

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ const (
 	// Operatorconfig sub folder for deployment files
 	Operatorconfig = "operatorconfig"
 	// K8sMinimumSupportedVersion is the minimum supported version for k8s
-	K8sMinimumSupportedVersion = "1.24"
+	K8sMinimumSupportedVersion = "1.21"
 	// K8sMaximumSupportedVersion is the maximum supported version for k8s
 	K8sMaximumSupportedVersion = "1.26"
 )


### PR DESCRIPTION
# Description
This pr adds the changes to support mke 3.5.x for latest vxflexos driver.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/699  |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Successfully Installed the csi-powerflex driver using csm-operator on mke 3..5.4 cluster 
- [x] Ran Cert-csi  and it passed with 100%
 
![cert-csi-operator](https://user-images.githubusercontent.com/103578883/222738683-ff812dd5-5775-4f5d-ab24-4c3c6815e179.PNG)

