### PR TITLE
Remove configmap creation from PowerFlex sample files

### DIFF
--- a/samples/storage_csm_powerflex_v240.yaml
+++ b/samples/storage_csm_powerflex_v240.yaml
@@ -26,8 +26,6 @@ spec:
           value: "false"
         - name: X_CSI_DEBUG
           value: "true"
-        - name: X_CSI_ALLOW_RWO_MULTI_POD_ACCESS
-          value: "false"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: None
@@ -94,13 +92,6 @@ spec:
 
     node:
       envs:
-        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin - volume usage
-        # Allowed values:
-        #   true: enable checking of health condition of CSI volumes
-        #   false: disable checking of health condition of CSI volumes
-        # Default value: false
-        - name: X_CSI_HEALTH_MONITOR_ENABLED
-          value: "false"
 
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes

--- a/samples/storage_csm_powerflex_v240.yaml
+++ b/samples/storage_csm_powerflex_v240.yaml
@@ -239,14 +239,3 @@ spec:
             # Default value: "otel-collector:55680"
             - name: "COLLECTOR_ADDRESS"
               value: "otel-collector:55680"
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: test-vxflexos-config-params
-  namespace: test-vxflexos
-data:
-  driver-config-params.yaml: |
-    CSI_LOG_LEVEL: "debug"
-    CSI_LOG_FORMAT: "TEXT"

--- a/samples/storage_csm_powerflex_v250.yaml
+++ b/samples/storage_csm_powerflex_v250.yaml
@@ -26,8 +26,6 @@ spec:
           value: "false"
         - name: X_CSI_DEBUG
           value: "true"
-        - name: X_CSI_ALLOW_RWO_MULTI_POD_ACCESS
-          value: "false"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: None
@@ -94,13 +92,6 @@ spec:
 
     node:
       envs:
-        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin - volume usage
-        # Allowed values:
-        #   true: enable checking of health condition of CSI volumes
-        #   false: disable checking of health condition of CSI volumes
-        # Default value: false
-        - name: X_CSI_HEALTH_MONITOR_ENABLED
-          value: "false"
 
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes

--- a/samples/storage_csm_powerflex_v250.yaml
+++ b/samples/storage_csm_powerflex_v250.yaml
@@ -239,14 +239,3 @@ spec:
             # Default value: "otel-collector:55680"
             - name: "COLLECTOR_ADDRESS"
               value: "otel-collector:55680"
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: test-vxflexos-config-params
-  namespace: test-vxflexos
-data:
-  driver-config-params.yaml: |
-    CSI_LOG_LEVEL: "debug"
-    CSI_LOG_FORMAT: "TEXT"

--- a/samples/storage_csm_powerflex_v260.yaml
+++ b/samples/storage_csm_powerflex_v260.yaml
@@ -26,8 +26,6 @@ spec:
           value: "false"
         - name: X_CSI_DEBUG
           value: "true"
-        - name: X_CSI_ALLOW_RWO_MULTI_POD_ACCESS
-          value: "false"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: None
@@ -94,13 +92,6 @@ spec:
 
     node:
       envs:
-        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin - volume usage
-        # Allowed values:
-        #   true: enable checking of health condition of CSI volumes
-        #   false: disable checking of health condition of CSI volumes
-        # Default value: false
-        - name: X_CSI_HEALTH_MONITOR_ENABLED
-          value: "false"
 
         # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
         # Allowed values:

--- a/samples/storage_csm_powerflex_v260.yaml
+++ b/samples/storage_csm_powerflex_v260.yaml
@@ -263,14 +263,3 @@ spec:
             # Default value: "otel-collector:55680"
             - name: "COLLECTOR_ADDRESS"
               value: "otel-collector:55680"
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: test-vxflexos-config-params
-  namespace: test-vxflexos
-data:
-  driver-config-params.yaml: |
-    CSI_LOG_LEVEL: "debug"
-    CSI_LOG_FORMAT: "TEXT"


### PR DESCRIPTION
# Description
1. Remove configmap creation from PowerFlex sample files to address defect.
2. Removed environment variables that were not configurable in sample files

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/713 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
1. For removal of configmap creation: Deleted driver installation, namespace (to ensure all configmaps were gone) and csm- 
    operator. Reinstalled everything successfully with the configmap-less sample file. Confirmed that configmaps did not exist 
    before doing a `kubectl create -f` on the sample file and that it did exist afterward. Repeated for all supported versions.
2. Removing environment variables : Deleted older driver installation (to ensure older csm-operator pods and driver pods are deleted). reinstalled the driver by removing the environment variables that were not configurable and deployed the driver with new sample files. I was able to get the driver pods up and running without those environment variables.
