### PR TITLE
Add back testing files

### DIFF
--- a/pkg/drivers/unity_test.go
+++ b/pkg/drivers/unity_test.go
@@ -28,6 +28,7 @@ import (
 var (
 	csmUnity                = csmForUnity("csm")
 	unityCSMBadVersion      = csmForUnityBadVersion()
+	unityCSMBadConfig       = csmForUnityBadConfig()
 	unityClient             = crclient.NewFakeClientNoInjector(objects)
 	configJSONFileGoodUnity = fmt.Sprintf("%s/driverconfig/%s/config.json", config.ConfigDirectory, csmv1.Unity)
 	unitySecret             = shared.MakeSecretWithJSON("csm-creds", "driver-test", configJSONFileGoodUnity)
@@ -48,6 +49,7 @@ var (
 
 		{"happy path", csmUnity, unityClient, unitySecret, ""},
 		{"bad version", unityCSMBadVersion, unityClient, unitySecret, "not supported"},
+		{"bad version", unityCSMBadConfig, unityClient, unitySecret, "failed to find secret"},
 	}
 
 	unityPrecheckTests = []struct {
@@ -99,6 +101,19 @@ func csmForUnityBadVersion() csmv1.ContainerStorageModule {
 	// Add pstore driver version
 	res.Spec.Driver.ConfigVersion = shared.BadConfigVersion
 	res.Spec.Driver.CSIDriverType = csmv1.Unity
+
+	return res
+}
+
+// makes a csm object with a bad version
+func csmForUnityBadConfig() csmv1.ContainerStorageModule {
+	res := shared.MakeCSM("csm", "driver-test", shared.UnityConfigVersion)
+
+	// Add pstore driver version
+	res.Spec.Driver.ConfigVersion = shared.UnityConfigVersion
+	res.Spec.Driver.CSIDriverType = csmv1.Unity
+
+	res.Spec.Driver.AuthSecret = "notARealSecret"
 
 	return res
 }

--- a/tests/config/driverconfig/badDriver/v2.4.0/bad.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/bad.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.4.0/controller.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/controller.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.4.0/csidriver.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/csidriver.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.4.0/driver-config-params.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/driver-config-params.yaml
@@ -1,0 +1,5 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml
+ 

--- a/tests/config/driverconfig/badDriver/v2.4.0/upgrade-path.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/upgrade-path.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.5.0/bad.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/bad.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.5.0/controller.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/controller.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.5.0/csidriver.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/csidriver.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.5.0/driver-config-params.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/driver-config-params.yaml
@@ -1,0 +1,5 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml
+ 

--- a/tests/config/driverconfig/badDriver/v2.5.0/upgrade-path.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/upgrade-path.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/shared/common.go
+++ b/tests/shared/common.go
@@ -28,8 +28,8 @@ import (
 // ConfigVersions used for all unit tests
 const (
 	PFlexConfigVersion       string = "v2.6.0"
-	ConfigVersion            string = "v2.6.0"
-	UpgradeConfigVersion     string = "v2.6.0"
+	ConfigVersion            string = "v2.4.0"
+	UpgradeConfigVersion     string = "v2.5.0"
 	JumpUpgradeConfigVersion string = "v2.6.0"
 	OldConfigVersion         string = "v2.2.0"
 	BadConfigVersion         string = "v0"


### PR DESCRIPTION
# Description
Some of the badDriver yaml files required for unit testing were removed in a recent PR. This PR adds them back in, and also adds a unit tests for unity to bring up the drivers package coverage to 95%.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/756 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Ran driver and controller unit tests to confirm tests pass and coverage is improved.
