### PR TITLE
Add testing files and unit test coverage for unity

### DIFF
--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -75,9 +75,10 @@ func csmWithTolerations(driver csmv1.DriverType, version string) csmv1.Container
 	res.Spec.Driver.Node.NodeSelector = map[string]string{"thisIs": "NodeSelector"}
 	res.Spec.Driver.Controller.NodeSelector = map[string]string{"thisIs": "NodeSelector"}
 
-	// Add log level to cover some code in GetConfigMap
-	envVarLogLevel := corev1.EnvVar{Name: "CSI_LOG_LEVEL"}
-	res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVarLogLevel}
+	// Add CSI_LOG_LEVEL environment variables
+	envVar := corev1.EnvVar{Name: "CSI_LOG_LEVEL"}
+        res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVar}
+
 	// Add sidecars to trigger code in controller
 	sideCarObjEnabledNil := csmv1.ContainerTemplate{
 		Name:    "driver",
@@ -192,20 +193,28 @@ func csmWithUnity(driver csmv1.DriverType, version string) csmv1.ContainerStorag
 	// Add image name
 	res.Spec.Driver.Common.Image = "thisIsAnImage"
 
-	// Add pstore driver version
+	// Add unity driver version
 	res.Spec.Driver.ConfigVersion = version
 
-	// Add pstore driver type
+	// Add unity driver type
 	res.Spec.Driver.CSIDriverType = driver
 
 	// Add NodeSelector to node and controller
 	res.Spec.Driver.Node.NodeSelector = map[string]string{"thisIs": "NodeSelector"}
 	res.Spec.Driver.Controller.NodeSelector = map[string]string{"thisIs": "NodeSelector"}
 
+	// Add environment variables
+        envVar1 := corev1.EnvVar{Name: "X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS", Value: "false"}
+        envVar2 := corev1.EnvVar{Name: "MAX_UNITY_VOLUMES_PER_NODE", Value: "0"}
+        envVar3 := corev1.EnvVar{Name: "X_CSI_UNITY_SYNC_NODEINFO_INTERVAL", Value: "15"}
+        envVar4 := corev1.EnvVar{Name: "TENANT_NAME", Value: ""}
+        envVar5 := corev1.EnvVar{Name: "CSI_LOG_LEVEL", Value: "debug"}
+        res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVar1, envVar2, envVar3, envVar4, envVar5}
+
 	// Add node name prefix to cover some code in GetNode
 	// nodeNamePrefix := corev1.EnvVar{Name: "X_CSI_UNITY_NODENAME_PREFIX"}
 
-	// Add node fields specific to powerstore
+	// Add node fields specific to unity
 	healthMonitor := corev1.EnvVar{Name: "X_CSI_HEALTH_MONITOR_ENABLED", Value: "true"}
 	res.Spec.Driver.Node.Envs = []corev1.EnvVar{healthMonitor}
 

--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -77,7 +77,7 @@ func csmWithTolerations(driver csmv1.DriverType, version string) csmv1.Container
 
 	// Add CSI_LOG_LEVEL environment variables
 	envVar := corev1.EnvVar{Name: "CSI_LOG_LEVEL"}
-        res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVar}
+	res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVar}
 
 	// Add sidecars to trigger code in controller
 	sideCarObjEnabledNil := csmv1.ContainerTemplate{
@@ -204,12 +204,12 @@ func csmWithUnity(driver csmv1.DriverType, version string) csmv1.ContainerStorag
 	res.Spec.Driver.Controller.NodeSelector = map[string]string{"thisIs": "NodeSelector"}
 
 	// Add environment variables
-        envVar1 := corev1.EnvVar{Name: "X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS", Value: "false"}
-        envVar2 := corev1.EnvVar{Name: "MAX_UNITY_VOLUMES_PER_NODE", Value: "0"}
-        envVar3 := corev1.EnvVar{Name: "X_CSI_UNITY_SYNC_NODEINFO_INTERVAL", Value: "15"}
-        envVar4 := corev1.EnvVar{Name: "TENANT_NAME", Value: ""}
-        envVar5 := corev1.EnvVar{Name: "CSI_LOG_LEVEL", Value: "debug"}
-        res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVar1, envVar2, envVar3, envVar4, envVar5}
+	envVar1 := corev1.EnvVar{Name: "X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS", Value: "false"}
+	envVar2 := corev1.EnvVar{Name: "MAX_UNITY_VOLUMES_PER_NODE", Value: "0"}
+	envVar3 := corev1.EnvVar{Name: "X_CSI_UNITY_SYNC_NODEINFO_INTERVAL", Value: "15"}
+	envVar4 := corev1.EnvVar{Name: "TENANT_NAME", Value: ""}
+	envVar5 := corev1.EnvVar{Name: "CSI_LOG_LEVEL", Value: "debug"}
+	res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVar1, envVar2, envVar3, envVar4, envVar5}
 
 	// Add node name prefix to cover some code in GetNode
 	// nodeNamePrefix := corev1.EnvVar{Name: "X_CSI_UNITY_NODENAME_PREFIX"}

--- a/pkg/drivers/unity_test.go
+++ b/pkg/drivers/unity_test.go
@@ -28,6 +28,7 @@ import (
 var (
 	csmUnity                = csmForUnity("csm")
 	unityCSMBadVersion      = csmForUnityBadVersion()
+	unityCSMBadConfig       = csmForUnityBadConfig()
 	unityClient             = crclient.NewFakeClientNoInjector(objects)
 	configJSONFileGoodUnity = fmt.Sprintf("%s/driverconfig/%s/config.json", config.ConfigDirectory, csmv1.Unity)
 	unitySecret             = shared.MakeSecretWithJSON("csm-creds", "driver-test", configJSONFileGoodUnity)
@@ -48,6 +49,7 @@ var (
 
 		{"happy path", csmUnity, unityClient, unitySecret, ""},
 		{"bad version", unityCSMBadVersion, unityClient, unitySecret, "not supported"},
+		{"bad config", unityCSMBadConfig, unityClient, unitySecret, "failed to find secret"},
 	}
 
 	unityPrecheckTests = []struct {
@@ -96,9 +98,23 @@ func TestPrecheckUnity(t *testing.T) {
 func csmForUnityBadVersion() csmv1.ContainerStorageModule {
 	res := shared.MakeCSM("csm", "driver-test", shared.UnityConfigVersion)
 
-	// Add pstore driver version
+	// Add unity driver version
 	res.Spec.Driver.ConfigVersion = shared.BadConfigVersion
 	res.Spec.Driver.CSIDriverType = csmv1.Unity
+
+	return res
+}
+
+// makes a csm object with a bad auth secret
+func csmForUnityBadConfig() csmv1.ContainerStorageModule {
+	res := shared.MakeCSM("csm", "driver-test", shared.UnityConfigVersion)
+
+	// Add unity driver version
+	res.Spec.Driver.ConfigVersion = shared.UnityConfigVersion
+	res.Spec.Driver.CSIDriverType = csmv1.Unity
+
+	// Add bad auth secret name
+	res.Spec.Driver.AuthSecret = "notARealSecret"
 
 	return res
 }
@@ -108,7 +124,7 @@ func csmForUnity(customCSMName string) csmv1.ContainerStorageModule {
 	res := shared.MakeCSM(customCSMName, "driver-test", shared.UnityConfigVersion)
 	res.Spec.Driver.AuthSecret = "csm-creds"
 
-	// Add pstore driver version
+	// Add unity driver version
 	res.Spec.Driver.ConfigVersion = shared.UnityConfigVersion
 	res.Spec.Driver.CSIDriverType = csmv1.Unity
 

--- a/tests/config/driverconfig/badDriver/v2.4.0/bad.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/bad.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.4.0/controller.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/controller.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.4.0/csidriver.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/csidriver.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.4.0/driver-config-params.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/driver-config-params.yaml
@@ -1,0 +1,5 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml
+ 

--- a/tests/config/driverconfig/badDriver/v2.4.0/upgrade-path.yaml
+++ b/tests/config/driverconfig/badDriver/v2.4.0/upgrade-path.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.5.0/bad.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/bad.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.5.0/controller.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/controller.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.5.0/csidriver.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/csidriver.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.5.0/driver-config-params.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/driver-config-params.yaml
@@ -1,0 +1,5 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml
+ 

--- a/tests/config/driverconfig/badDriver/v2.5.0/upgrade-path.yaml
+++ b/tests/config/driverconfig/badDriver/v2.5.0/upgrade-path.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/shared/common.go
+++ b/tests/shared/common.go
@@ -28,8 +28,8 @@ import (
 // ConfigVersions used for all unit tests
 const (
 	PFlexConfigVersion       string = "v2.6.0"
-	ConfigVersion            string = "v2.6.0"
-	UpgradeConfigVersion     string = "v2.6.0"
+	ConfigVersion            string = "v2.4.0"
+	UpgradeConfigVersion     string = "v2.5.0"
 	JumpUpgradeConfigVersion string = "v2.6.0"
 	OldConfigVersion         string = "v2.2.0"
 	BadConfigVersion         string = "v0"


### PR DESCRIPTION
# Description
Some of the badDriver yaml files required for unit testing were removed in a recent PR. This PR adds them back in, and also adds a unit tests for unity to bring up the drivers package coverage to 95%.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/756 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Ran driver and controller unit tests to confirm tests pass and coverage is improved.
