### PR TITLE
fix toleration bug by making tolerationseconds optional

### DIFF
--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -40,16 +40,26 @@ func csmWithTolerations(driver csmv1.DriverType, version string) csmv1.Container
 	// Add tolerations to controller and node
 	res.Spec.Driver.Node.Tolerations = []corev1.Toleration{
 		{
-			Key:               "123",
+			Key:               "notNil",
 			Value:             "123",
 			TolerationSeconds: new(int64),
+		},
+		{
+			Key:               "nil",
+			Value:             "123",
+			TolerationSeconds: nil,
 		},
 	}
 	res.Spec.Driver.Controller.Tolerations = []corev1.Toleration{
 		{
-			Key:               "123",
+			Key:               "notNil",
 			Value:             "123",
 			TolerationSeconds: new(int64),
+		},
+		{
+			Key:               "nil",
+			Value:             "123",
+			TolerationSeconds: nil,
 		},
 	}
 

--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -66,11 +66,13 @@ func GetController(ctx context.Context, cr csmv1.ContainerStorageModule, operato
 		tols := make([]acorev1.TolerationApplyConfiguration, 0)
 		for _, t := range cr.Spec.Driver.Controller.Tolerations {
 			toleration := acorev1.Toleration()
-			toleration.WithEffect(t.Effect)
 			toleration.WithKey(t.Key)
-			toleration.WithValue(t.Value)
 			toleration.WithOperator(t.Operator)
-			toleration.WithTolerationSeconds(*t.TolerationSeconds)
+			toleration.WithValue(t.Value)
+			toleration.WithEffect(t.Effect)
+			if t.TolerationSeconds != nil {
+				toleration.WithTolerationSeconds(*t.TolerationSeconds)
+			}
 			tols = append(tols, *toleration)
 		}
 
@@ -191,12 +193,15 @@ func GetNode(ctx context.Context, cr csmv1.ContainerStorageModule, operatorConfi
 	if len(cr.Spec.Driver.Node.Tolerations) != 0 {
 		tols := make([]acorev1.TolerationApplyConfiguration, 0)
 		for _, t := range cr.Spec.Driver.Node.Tolerations {
+			fmt.Printf("[BRUH] toleration t: %+v\n", t)
 			toleration := acorev1.Toleration()
-			toleration.WithEffect(t.Effect)
 			toleration.WithKey(t.Key)
-			toleration.WithValue(t.Value)
 			toleration.WithOperator(t.Operator)
-			toleration.WithTolerationSeconds(*t.TolerationSeconds)
+			toleration.WithValue(t.Value)
+			toleration.WithEffect(t.Effect)
+			if t.TolerationSeconds != nil {
+				toleration.WithTolerationSeconds(*t.TolerationSeconds)
+			}
 			tols = append(tols, *toleration)
 		}
 


### PR DESCRIPTION
# Description
Fix a bug where the operator crashes if we try to set tolerations in node or controller. The issue is that we were treating the tolerationSeconds parameter as mandatory when it is in fact optional. By trying to pass it in by default, we ended up dereferencing <nil> if it hadn't been specified. Now, there is a check to see if the parameter is nil before dereferencing it.

# GitHub Issues
| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/743 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
- Ran driver unit tests and controller unit tests, confirmed passing and the additional code is covered.
- Successfully installed csi-powerscale with tolerations
