### PR TITLE
Validation of authSecret field for Powerstore driver in csm-operator

### DIFF
--- a/pkg/drivers/powerstore.go
+++ b/pkg/drivers/powerstore.go
@@ -61,6 +61,10 @@ func PrecheckPowerStore(ctx context.Context, cr *csmv1.ContainerStorageModule, o
 	// Check for secret only
 	config := cr.Name + "-config"
 
+	if cr.Spec.Driver.AuthSecret != "" {
+		config = cr.Spec.Driver.AuthSecret
+	}
+
 	// Check if driver version is supported by doing a stat on a config file
 	configFilePath := fmt.Sprintf("%s/driverconfig/powerstore/%s/upgrade-path.yaml", operatorConfig.ConfigDirectory, cr.Spec.Driver.ConfigVersion)
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {


### PR DESCRIPTION
# Description
Validation of authSecret field for Powerstore driver in csm-operator

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|  https://github.com/dell/csm/issues/784 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
<img width="387" alt="auth_secret_parameter_set" src="https://user-images.githubusercontent.com/92289639/234771171-6d972096-c536-498f-9159-7cb6cbcb05d5.PNG">

<img width="746" alt="error_message" src="https://user-images.githubusercontent.com/92289639/234771194-8ed5fdfc-9f80-4586-a5d7-1f6f241a5bf5.PNG">

<img width="576" alt="secret_created" src="https://user-images.githubusercontent.com/92289639/234771226-15701a0c-30f4-4195-bf5d-2bb68bbb5054.png">
