### PR TITLE
Updated RBAC clusterrole fix

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -686,6 +686,7 @@ rules:
   - volumeattachments
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -120,7 +120,7 @@ var (
 // +kubebuilder:rbac:groups="",resources=deployments/finalizers,resourceNames=dell-csm-operator-controller-manager,verbs=update
 // +kubebuilder:rbac:groups="storage.k8s.io",resources=csidrivers,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="storage.k8s.io",resources=storageclasses,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups="storage.k8s.io",resources=volumeattachments,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="storage.k8s.io",resources=volumeattachments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="storage.k8s.io",resources=csinodes,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="csi.storage.k8s.io",resources=csinodeinfos,verbs=get;list;watch
 // +kubebuilder:rbac:groups="snapshot.storage.k8s.io",resources=volumesnapshotclasses;volumesnapshotcontents,verbs=get;list;watch;create;update;delete;patch
@@ -675,7 +675,7 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 				}
 				node.DaemonSetApplyConfig = *ds
 
-				clusterRoleForNode, err := modules.ResiliencyInjectClusterRole(controller.Rbac.ClusterRole, cr, operatorConfig, "node")
+				clusterRoleForNode, err := modules.ResiliencyInjectClusterRole(node.Rbac.ClusterRole, cr, operatorConfig, "node")
 				if err != nil {
 					return fmt.Errorf("injecting resiliency into node cluster role: %v", err)
 				}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -730,6 +730,7 @@ rules:
   - volumeattachments
   verbs:
   - create
+  - delete
   - get
   - list
   - patch


### PR DESCRIPTION
# Description
This PR is for fixing the RBAC clusterroles updating correctly for node & adding delete permission to volumeattachments required for resiliency module.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/739 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed driver and both the controller and node pods are up and running with resiliency enabled.
![image](https://user-images.githubusercontent.com/109594002/234780814-9921a470-102f-47e0-9327-0ed3917ea1c6.png)
