### PR TITLE
Resiliency module support for PowerFlex driver

### DIFF
--- a/operatorconfig/moduleconfig/resiliency/v1.6.0/container-powerflex-controller.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.6.0/container-powerflex-controller.yaml
@@ -1,14 +1,6 @@
 name: podmon
 image: dellemc/podmon:v1.5.0
 imagePullPolicy: IfNotPresent
-args:
-  - "--csisock=unix:/var/run/csi/csi.sock"
-  - "--labelvalue=csi-vxflexos"
-  - "--mode=controller"
-  - "--skipArrayConnectionValidation=false"
-  - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
-  - "--driverPodLabelValue=dell-storage"
-  - "--ignoreVolumelessPods=false"
 env:
   - name: MY_NODE_NAME
     valueFrom:
@@ -22,12 +14,6 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: metadata.namespace
-  - name: X_CSI_PODMON_ENABLED
-    value: "true"
-  - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_POLL_RATE
-    value: <PodmonArrayConnectivityPollRate>
-  - name: X_CSI_PODMON_API_PORT
-    value: <PodmonAPIPort>
 volumeMounts:
   - name: socket-dir
     mountPath: /var/run/csi

--- a/operatorconfig/moduleconfig/resiliency/v1.6.0/container-powerflex-node.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.6.0/container-powerflex-node.yaml
@@ -1,16 +1,11 @@
 name: podmon
 image: dellemc/podmon:v1.5.0
 imagePullPolicy: IfNotPresent
-args:
-  - "--csisock=unix:/var/lib/kubelet/plugins/csi-vxflexos.dellemc.com/csi_sock"
-  - "--labelvalue=csi-vxflexos"
-  - "--arrayConnectivityPollRate=60"
-  - "--driverPath=csi-vxflexos.dellemc.com"
-  - "--mode=node"
-  - "--leaderelection=false"
-  - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
-  - "--driverPodLabelValue=dell-storage"
-  - "--ignoreVolumelessPods=false"
+securityContext:
+  privileged: true
+  capabilities:
+    add: ["SYS_ADMIN"]
+  allowPrivilegeEscalation: true
 env:
   - name: KUBE_NODE_NAME
     valueFrom:
@@ -31,21 +26,12 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: metadata.namespace
-  - name: X_CSI_PODMON_ENABLED
-    value: "true"
-  - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_POLL_RATE
-    value: <PodmonArrayConnectivityPollRate>
-  - name: X_CSI_PODMON_API_PORT
-    value: <PodmonAPIPort>
 volumeMounts:
   - name: kubelet-pods
-    mountPath: /var/lib/kubelet/pods
+    mountPath: <KUBELET_CONFIG_DIR>/pods
     mountPropagation: "Bidirectional"
   - name: driver-path
-    mountPath: /var/lib/kubelet/plugins/csi-vxflexos.dellemc.com
-    mountPropagation: "Bidirectional"
-  - name: csi-path
-    mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+    mountPath: /var/lib/kubelet/plugins/vxflexos.emc.dell.com
     mountPropagation: "Bidirectional"
   - name: dev
     mountPath: /dev


### PR DESCRIPTION
# Description
Resiliency module support for PowerFlex(v2.7.0) driver in csm-operator.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/739 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Installed the driver and verified all args and env var, driver is coming up properly with podmon sidecar.
