### PR TITLE
Added validation for empty secrets for CSI Unity XT driver

### DIFF
--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -425,6 +425,10 @@ metadata:
                   {
                     "name": "TENANT_NAME",
                     "value": ""
+                  },
+                  {
+                    "name": "CERT_SECRET_COUNT"
+                    "value": "1"
                   }
                 ],
                 "image": "dellemc/csi-unity:v2.6.0",

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -427,8 +427,12 @@ metadata:
                     "value": ""
                   },
                   {
-                    "name": "CERT_SECRET_COUNT"
+                    "name": "CERT_SECRET_COUNT",
                     "value": "1"
+                  },
+                  {
+                    "name": "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION"
+                    "value": "true"
                   }
                 ],
                 "image": "dellemc/csi-unity:v2.6.0",

--- a/config/samples/storage_v1_csm_unity.yaml
+++ b/config/samples/storage_v1_csm_unity.yaml
@@ -43,6 +43,8 @@ spec:
           value: debug
         - name: TENANT_NAME
           value: ""
+        - name: CERT_SECRET_COUNT
+          value: "1"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it

--- a/config/samples/storage_v1_csm_unity.yaml
+++ b/config/samples/storage_v1_csm_unity.yaml
@@ -11,8 +11,8 @@ spec:
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
       fSGroupPolicy: "ReadWriteOnceWithFSType"
-    # Config version for CSI Unity v2.6.0 driver
-    configVersion: v2.6.0
+    # Config version for CSI Unity v2.7.0 driver
+    configVersion: v2.7.0
     # authSecret: This is the secret used to validate the default Unity secret used for installation
     # Allowed values: <metadataName specified in the Manifest>-creds
     # For example: If the metadataName is set to test-unity, authSecret value should be set to test-unity-creds
@@ -23,28 +23,59 @@ spec:
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      # Image for CSI Unity driver v2.6.0
-      image: "dellemc/csi-unity:v2.6.0"
+      # Image for CSI Unity driver v2.7.0
+      image: "dellemc/csi-unity:v2.7.0"
       imagePullPolicy: IfNotPresent
       envs:
         - name: X_CSI_UNITY_NODENAME_PREFIX
           value: "csi-node"
+          # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
+          # Allowed values: boolean
+          # Default value: "false"
+          # Examples : "true" , "false"
         - name: X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS
           value: "false"
         - name: X_CSI_EPHEMERAL_STAGING_PATH
           value: "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+        # X_CSI_ISCSI_CHROOT is the path to which the driver will chroot before
+        # running any iscsi commands. This value should only be set when instructed
+        # by technical support
         - name: X_CSI_ISCSI_CHROOT
           value: "/noderoot"
+        # X_CSI_UNITY_SYNC_NODEINFO_INTERVAL - Time interval to add node info to array. Default 15 minutes. Minimum value should be 1.
+        # Allowed values: integer
+        # Default value: 15
+        # Examples : 0 , 2
         - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL
           value: "15"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: None
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
+        # CSI_LOG_LEVEL is used to set the logging level of the driver.
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "info"
         - name: CSI_LOG_LEVEL
           value: debug
+        # TENANT_NAME - Tenant name that need to added while adding host entry to the array.
+        # Allowed values: string
+        # Default value: ""
+        # Examples : "tenant2" , "tenant3"
         - name: TENANT_NAME
           value: ""
+        # CERT_SECRET_COUNT: Represents number of certificate secrets, which user is going to create for
+        # ssl authentication. (unity-cert-0..unity-cert-n)
+        # Allowed values: n, where n > 0
+        # Default value: None          
         - name: CERT_SECRET_COUNT
           value: "1"
+        # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.
+        # If it is set to false, then a secret unity-certs has to be created with an X.509 certificate of CA which signed the Unisphere certificate
+        # Allowed values:
+        #   true: skip Unisphere API server's certificate verification
+        #   false: verify Unisphere API server's certificates 
+        # Default value: true	
         - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
           value: "true"
 

--- a/config/samples/storage_v1_csm_unity.yaml
+++ b/config/samples/storage_v1_csm_unity.yaml
@@ -45,6 +45,8 @@ spec:
           value: ""
         - name: CERT_SECRET_COUNT
           value: "1"
+        - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+          value: "true"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -841,9 +841,6 @@ func getDriverConfig(ctx context.Context,
 		// use powerscale instead of isilon as the folder name is powerscale
 		driverType = csmv1.PowerScaleName
 	}
-	if driverType == csmv1.Unity {
-		driverType = csmv1.Unity
-	}
 	configMap, err = drivers.GetConfigMap(ctx, cr, operatorConfig, driverType)
 	if err != nil {
 		return nil, fmt.Errorf("getting %s configMap: %v", driverType, err)

--- a/operatorconfig/driverconfig/unity/v2.5.0/controller.yaml
+++ b/operatorconfig/driverconfig/unity/v2.5.0/controller.yaml
@@ -211,6 +211,8 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/operatorconfig/driverconfig/unity/v2.5.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.5.0/node.yaml
@@ -109,6 +109,8 @@ spec:
               value: "15"
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
           volumeMounts:
             - name: driver-path
               mountPath: /var/lib/kubelet/plugins/unity.emc.dell.com

--- a/operatorconfig/driverconfig/unity/v2.6.0/controller.yaml
+++ b/operatorconfig/driverconfig/unity/v2.6.0/controller.yaml
@@ -211,6 +211,8 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/operatorconfig/driverconfig/unity/v2.6.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.6.0/node.yaml
@@ -109,6 +109,8 @@ spec:
               value: "15"
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
           volumeMounts:
             - name: driver-path
               mountPath: /var/lib/kubelet/plugins/unity.emc.dell.com

--- a/operatorconfig/driverconfig/unity/v2.7.0/controller.yaml
+++ b/operatorconfig/driverconfig/unity/v2.7.0/controller.yaml
@@ -211,6 +211,8 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/operatorconfig/driverconfig/unity/v2.7.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.7.0/node.yaml
@@ -109,6 +109,8 @@ spec:
               value: "15"
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
           volumeMounts:
             - name: driver-path
               mountPath: /var/lib/kubelet/plugins/unity.emc.dell.com

--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -191,7 +191,7 @@ func csmWithPowerstore(driver csmv1.DriverType, version string) csmv1.ContainerS
 	return res
 }
 
-func csmWithUnity(driver csmv1.DriverType, version string) csmv1.ContainerStorageModule {
+func csmWithUnity(driver csmv1.DriverType, version string, certProvided bool) csmv1.ContainerStorageModule {
 	res := shared.MakeCSM("csm", "driver-test", shared.ConfigVersion)
 
 	// Add FSGroupPolicy
@@ -219,7 +219,12 @@ func csmWithUnity(driver csmv1.DriverType, version string) csmv1.ContainerStorag
 	envVar3 := corev1.EnvVar{Name: "X_CSI_UNITY_SYNC_NODEINFO_INTERVAL", Value: "15"}
 	envVar4 := corev1.EnvVar{Name: "TENANT_NAME", Value: ""}
 	envVar5 := corev1.EnvVar{Name: "CSI_LOG_LEVEL", Value: "debug"}
-	res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVar1, envVar2, envVar3, envVar4, envVar5}
+	envVar6 := corev1.EnvVar{Name: "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION", Value: "true"}
+	envVar7 := corev1.EnvVar{Name: "CERT_SECRET_COUNT", Value: "1"}
+	if certProvided {
+		envVar6 = corev1.EnvVar{Name: "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION", Value: "false"}
+	}
+	res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVar1, envVar2, envVar3, envVar4, envVar5, envVar6, envVar7}
 
 	// Add node name prefix to cover some code in GetNode
 	// nodeNamePrefix := corev1.EnvVar{Name: "X_CSI_UNITY_NODENAME_PREFIX"}

--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -122,8 +122,14 @@ func GetController(ctx context.Context, cr csmv1.ContainerStorageModule, operato
 	controllerYAML.Deployment.Spec.Template.Spec.Containers = newcontainers
 	// Update volumes
 	for i, v := range controllerYAML.Deployment.Spec.Template.Spec.Volumes {
+		newV := new(acorev1.VolumeApplyConfiguration)
 		if *v.Name == "certs" {
-			newV, err := getApplyCertVolume(cr)
+			if cr.Spec.Driver.CSIDriverType == "isilon" {
+				newV, err = getApplyCertVolume(cr)
+			}
+			if cr.Spec.Driver.CSIDriverType == "unity" {
+				newV, err = getApplyCertVolumeUnity(cr)
+			}
 			if err != nil {
 				log.Errorw("GetController spec template volumes", "Error", err.Error())
 				return nil, err
@@ -258,8 +264,14 @@ func GetNode(ctx context.Context, cr csmv1.ContainerStorageModule, operatorConfi
 
 	// Update volumes
 	for i, v := range nodeYaml.DaemonSetApplyConfig.Spec.Template.Spec.Volumes {
+		newV := new(acorev1.VolumeApplyConfiguration)
 		if *v.Name == "certs" {
-			newV, err := getApplyCertVolume(cr)
+			if cr.Spec.Driver.CSIDriverType == "isilon" {
+				newV, err = getApplyCertVolume(cr)
+			}
+			if cr.Spec.Driver.CSIDriverType == "unity" {
+				newV, err = getApplyCertVolumeUnity(cr)
+			}
 			if err != nil {
 				log.Errorw("GetNode apply cert Volume failed", "Error", err.Error())
 				return nil, err

--- a/pkg/drivers/commonconfig_test.go
+++ b/pkg/drivers/commonconfig_test.go
@@ -22,10 +22,11 @@ import (
 )
 
 var (
-	csm       = csmWithTolerations(csmv1.PowerScaleName, shared.ConfigVersion)
-	pFlexCSM  = csmForPowerFlex(pflexCSMName)
-	pStoreCSM = csmWithPowerstore(csmv1.PowerStore, shared.PStoreConfigVersion)
-	unityCSM  = csmWithUnity(csmv1.Unity, shared.UnityConfigVersion)
+	csm                  = csmWithTolerations(csmv1.PowerScaleName, shared.ConfigVersion)
+	pFlexCSM             = csmForPowerFlex(pflexCSMName)
+	pStoreCSM            = csmWithPowerstore(csmv1.PowerStore, shared.PStoreConfigVersion)
+	unityCSM             = csmWithUnity(csmv1.Unity, shared.UnityConfigVersion, false)
+	unityCSMCertProvided = csmWithUnity(csmv1.Unity, shared.UnityConfigVersion, true)
 
 	fakeDriver csmv1.DriverType = "fakeDriver"
 	badDriver  csmv1.DriverType = "badDriver"
@@ -46,6 +47,7 @@ var (
 		{"pflex happy path", pFlexCSM, csmv1.PowerFlex, "node.yaml", ""},
 		{"pstore happy path", pStoreCSM, csmv1.PowerStore, "node.yaml", ""},
 		{"unity happy path", unityCSM, csmv1.Unity, "node.yaml", ""},
+		{"unity happy path when secrets with certificates provided", unityCSMCertProvided, csmv1.Unity, "node.yaml", ""},
 		{"file does not exist", csm, fakeDriver, "NonExist.yaml", "no such file or directory"},
 		{"config file is invalid", csm, badDriver, "bad.yaml", "unmarshal"},
 	}

--- a/pkg/drivers/unity.go
+++ b/pkg/drivers/unity.go
@@ -68,7 +68,7 @@ func PrecheckUnity(ctx context.Context, cr *csmv1.ContainerStorageModule, operat
 	// Check if driver version is supported by doing a stat on a config file
 	configFilePath := fmt.Sprintf("%s/driverconfig/unity/%s/upgrade-path.yaml", operatorConfig.ConfigDirectory, cr.Spec.Driver.ConfigVersion)
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
-		log.Errorw("PreCheckUnity failed in version check", "Error", err.Error())
+		log.Errorw("PreCheckUnity failed in version check", "Error", err.Error(), "Namespace", cr.Namespace)
 		return fmt.Errorf("%s %s not supported", csmv1.Unity, cr.Spec.Driver.ConfigVersion)
 	}
 
@@ -92,7 +92,7 @@ func PrecheckUnity(ctx context.Context, cr *csmv1.ContainerStorageModule, operat
 	}
 
 	secrets := []string{config}
-	log.Debugw("preCheck", "secrets", len(secrets), "certCount", certCount)
+	log.Debugw("preCheck", "secrets", len(secrets), "certCount", certCount, "Namespace", cr.Namespace)
 	if !skipCertValid {
 		for i := 0; i < certCount; i++ {
 			secrets = append(secrets, fmt.Sprintf("%s-certs-%d", cr.Name, i))
@@ -103,7 +103,7 @@ func PrecheckUnity(ctx context.Context, cr *csmv1.ContainerStorageModule, operat
 		found := &corev1.Secret{}
 		err := ct.Get(ctx, types.NamespacedName{Name: name, Namespace: cr.GetNamespace()}, found)
 		if err != nil {
-			log.Error(err, "Failed query for secret ", name)
+			log.Error(err, " Failed query for secret ", name, "Namespace", cr.Namespace)
 			if errors.IsNotFound(err) {
 				return fmt.Errorf("failed to find secret %s", name)
 			}

--- a/pkg/drivers/unity.go
+++ b/pkg/drivers/unity.go
@@ -72,7 +72,7 @@ func PrecheckUnity(ctx context.Context, cr *csmv1.ContainerStorageModule, operat
 		return fmt.Errorf("%s %s not supported", csmv1.Unity, cr.Spec.Driver.ConfigVersion)
 	}
 
-	skipCertValid := false
+	skipCertValid := true
 	certCount := 1
 	for _, env := range cr.Spec.Driver.Common.Envs {
 		if env.Name == "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION" {
@@ -180,7 +180,7 @@ func ModifyUnityConfigMap(ctx context.Context, cr csmv1.ContainerStorageModule) 
 }
 
 func getApplyCertVolumeUnity(cr csmv1.ContainerStorageModule) (*acorev1.VolumeApplyConfiguration, error) {
-	skipCertValid := false
+	skipCertValid := true
 	certCount := 1
 	for _, env := range cr.Spec.Driver.Common.Envs {
 		if env.Name == "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION" {

--- a/pkg/drivers/unity.go
+++ b/pkg/drivers/unity.go
@@ -78,7 +78,7 @@ func PrecheckUnity(ctx context.Context, cr *csmv1.ContainerStorageModule, operat
 		if env.Name == "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION" {
 			b, err := strconv.ParseBool(env.Value)
 			if err != nil {
-				return fmt.Errorf("%s is an invalid value for X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION: %v", env.Value, err)
+				return fmt.Errorf("%s is an invalid value for X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: %v", env.Value, err)
 			}
 			skipCertValid = b
 		}
@@ -186,7 +186,7 @@ func getApplyCertVolumeUnity(cr csmv1.ContainerStorageModule) (*acorev1.VolumeAp
 		if env.Name == "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION" {
 			b, err := strconv.ParseBool(env.Value)
 			if err != nil {
-				return nil, fmt.Errorf("%s is an invalid value for X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION: %v", env.Value, err)
+				return nil, fmt.Errorf("%s is an invalid value for X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: %v", env.Value, err)
 			}
 			skipCertValid = b
 		}

--- a/samples/storage_csm_unity_v250.yaml
+++ b/samples/storage_csm_unity_v250.yaml
@@ -45,6 +45,12 @@ spec:
           value: ""
         - name: CERT_SECRET_COUNT
           value: "1"
+        # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.
+        # If it is set to false, then a secret unity-certs has to be created with an X.509 certificate of CA which signed the Unisphere certificate
+        # Allowed values:
+        #   true: skip Unisphere API server's certificate verification
+        #   false: verify Unisphere API server's certificates 
+        # Default value: true	
         - name: "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION"
           value: "true"
 

--- a/samples/storage_csm_unity_v250.yaml
+++ b/samples/storage_csm_unity_v250.yaml
@@ -29,20 +29,45 @@ spec:
       envs:
         - name: X_CSI_UNITY_NODENAME_PREFIX
           value: "csi-node"
+          # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
+          # Allowed values: boolean
+          # Default value: "false"
+          # Examples : "true" , "false"
         - name: X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS
           value: "false"
         - name: X_CSI_EPHEMERAL_STAGING_PATH
           value: "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+        # X_CSI_ISCSI_CHROOT is the path to which the driver will chroot before
+        # running any iscsi commands. This value should only be set when instructed
+        # by technical support
         - name: X_CSI_ISCSI_CHROOT
           value: "/noderoot"
+        # X_CSI_UNITY_SYNC_NODEINFO_INTERVAL - Time interval to add node info to array. Default 15 minutes. Minimum value should be 1.
+        # Allowed values: integer
+        # Default value: 15
+        # Examples : 0 , 2
         - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL
           value: "15"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: None
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
+        # CSI_LOG_LEVEL is used to set the logging level of the driver.
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "info"
         - name: CSI_LOG_LEVEL
           value: debug
+        # TENANT_NAME - Tenant name that need to added while adding host entry to the array.
+        # Allowed values: string
+        # Default value: ""
+        # Examples : "tenant2" , "tenant3"
         - name: TENANT_NAME
           value: ""
+        # CERT_SECRET_COUNT: Represents number of certificate secrets, which user is going to create for
+        # ssl authentication. (unity-cert-0..unity-cert-n)
+        # Allowed values: n, where n > 0
+        # Default value: None          
         - name: CERT_SECRET_COUNT
           value: "1"
         # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.
@@ -51,7 +76,7 @@ spec:
         #   true: skip Unisphere API server's certificate verification
         #   false: verify Unisphere API server's certificates 
         # Default value: true	
-        - name: "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION"
+        - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
           value: "true"
 
     sideCars:

--- a/samples/storage_csm_unity_v250.yaml
+++ b/samples/storage_csm_unity_v250.yaml
@@ -43,6 +43,8 @@ spec:
           value: debug
         - name: TENANT_NAME
           value: ""
+        - name: CERT_SECRET_COUNT
+          value: "1"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it

--- a/samples/storage_csm_unity_v250.yaml
+++ b/samples/storage_csm_unity_v250.yaml
@@ -45,6 +45,8 @@ spec:
           value: ""
         - name: CERT_SECRET_COUNT
           value: "1"
+        - name: "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION"
+          value: "true"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it

--- a/samples/storage_csm_unity_v260.yaml
+++ b/samples/storage_csm_unity_v260.yaml
@@ -29,20 +29,45 @@ spec:
       envs:
         - name: X_CSI_UNITY_NODENAME_PREFIX
           value: "csi-node"
+          # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
+          # Allowed values: boolean
+          # Default value: "false"
+          # Examples : "true" , "false"
         - name: X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS
           value: "false"
         - name: X_CSI_EPHEMERAL_STAGING_PATH
           value: "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+        # X_CSI_ISCSI_CHROOT is the path to which the driver will chroot before
+        # running any iscsi commands. This value should only be set when instructed
+        # by technical support
         - name: X_CSI_ISCSI_CHROOT
           value: "/noderoot"
+        # X_CSI_UNITY_SYNC_NODEINFO_INTERVAL - Time interval to add node info to array. Default 15 minutes. Minimum value should be 1.
+        # Allowed values: integer
+        # Default value: 15
+        # Examples : 0 , 2
         - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL
           value: "15"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: None
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
+        # CSI_LOG_LEVEL is used to set the logging level of the driver.
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "info"
         - name: CSI_LOG_LEVEL
           value: debug
+        # TENANT_NAME - Tenant name that need to added while adding host entry to the array.
+        # Allowed values: string
+        # Default value: ""
+        # Examples : "tenant2" , "tenant3"
         - name: TENANT_NAME
           value: ""
+        # CERT_SECRET_COUNT: Represents number of certificate secrets, which user is going to create for
+        # ssl authentication. (unity-cert-0..unity-cert-n)
+        # Allowed values: n, where n > 0
+        # Default value: None          
         - name: CERT_SECRET_COUNT
           value: "1"
         # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.

--- a/samples/storage_csm_unity_v260.yaml
+++ b/samples/storage_csm_unity_v260.yaml
@@ -43,6 +43,8 @@ spec:
           value: debug
         - name: TENANT_NAME
           value: ""
+        - name: CERT_SECRET_COUNT
+          value: "1"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it

--- a/samples/storage_csm_unity_v260.yaml
+++ b/samples/storage_csm_unity_v260.yaml
@@ -45,6 +45,12 @@ spec:
           value: ""
         - name: CERT_SECRET_COUNT
           value: "1"
+        # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.
+        # If it is set to false, then a secret unity-certs has to be created with an X.509 certificate of CA which signed the Unisphere certificate
+        # Allowed values:
+        #   true: skip Unisphere API server's certificate verification
+        #   false: verify Unisphere API server's certificates 
+        # Default value: true	
         - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
           value: "true"
 

--- a/samples/storage_csm_unity_v260.yaml
+++ b/samples/storage_csm_unity_v260.yaml
@@ -45,6 +45,8 @@ spec:
           value: ""
         - name: CERT_SECRET_COUNT
           value: "1"
+        - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+          value: "true"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it

--- a/samples/storage_csm_unity_v270.yaml
+++ b/samples/storage_csm_unity_v270.yaml
@@ -45,6 +45,12 @@ spec:
           value: ""
         - name: CERT_SECRET_COUNT
           value: "1"
+        # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.
+        # If it is set to false, then a secret unity-certs has to be created with an X.509 certificate of CA which signed the Unisphere certificate
+        # Allowed values:
+        #   true: skip Unisphere API server's certificate verification
+        #   false: verify Unisphere API server's certificates 
+        # Default value: true	
         - name: "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION"
           value: "true"
 

--- a/samples/storage_csm_unity_v270.yaml
+++ b/samples/storage_csm_unity_v270.yaml
@@ -29,20 +29,45 @@ spec:
       envs:
         - name: X_CSI_UNITY_NODENAME_PREFIX
           value: "csi-node"
+          # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
+          # Allowed values: boolean
+          # Default value: "false"
+          # Examples : "true" , "false"
         - name: X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS
           value: "false"
         - name: X_CSI_EPHEMERAL_STAGING_PATH
           value: "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+        # X_CSI_ISCSI_CHROOT is the path to which the driver will chroot before
+        # running any iscsi commands. This value should only be set when instructed
+        # by technical support
         - name: X_CSI_ISCSI_CHROOT
           value: "/noderoot"
+        # X_CSI_UNITY_SYNC_NODEINFO_INTERVAL - Time interval to add node info to array. Default 15 minutes. Minimum value should be 1.
+        # Allowed values: integer
+        # Default value: 15
+        # Examples : 0 , 2
         - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL
           value: "15"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: None
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
+        # CSI_LOG_LEVEL is used to set the logging level of the driver.
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "info"
         - name: CSI_LOG_LEVEL
           value: debug
+        # TENANT_NAME - Tenant name that need to added while adding host entry to the array.
+        # Allowed values: string
+        # Default value: ""
+        # Examples : "tenant2" , "tenant3"
         - name: TENANT_NAME
           value: ""
+        # CERT_SECRET_COUNT: Represents number of certificate secrets, which user is going to create for
+        # ssl authentication. (unity-cert-0..unity-cert-n)
+        # Allowed values: n, where n > 0
+        # Default value: None          
         - name: CERT_SECRET_COUNT
           value: "1"
         # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.
@@ -51,7 +76,7 @@ spec:
         #   true: skip Unisphere API server's certificate verification
         #   false: verify Unisphere API server's certificates 
         # Default value: true	
-        - name: "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION"
+        - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
           value: "true"
 
     sideCars:

--- a/samples/storage_csm_unity_v270.yaml
+++ b/samples/storage_csm_unity_v270.yaml
@@ -43,6 +43,8 @@ spec:
           value: debug
         - name: TENANT_NAME
           value: ""
+        - name: CERT_SECRET_COUNT
+          value: "1"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it

--- a/samples/storage_csm_unity_v270.yaml
+++ b/samples/storage_csm_unity_v270.yaml
@@ -45,6 +45,8 @@ spec:
           value: ""
         - name: CERT_SECRET_COUNT
           value: "1"
+        - name: "X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION"
+          value: "true"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it

--- a/scripts/common.bash
+++ b/scripts/common.bash
@@ -117,8 +117,8 @@ function check_or_create_namespace() {
 }
 
 # Get the kubernetes major and minor version numbers.
-kMajorVersion=$(kubectl version | grep 'Server Version' | sed -e 's/^.*Major:"//' -e 's/[^0-9].*//g')
-kMinorVersion=$(kubectl version | grep 'Server Version' | sed -e 's/^.*Minor:"//' -e 's/[^0-9].*//g')
+kMajorVersion=$(kubectl version -o="yaml" | grep -A8 'serverVersion:' | grep 'major'| egrep -o '[0-9]+')
+kMinorVersion=$(kubectl version -o="yaml" | grep -A8 'serverVersion:' | grep 'minor'| egrep -o '[0-9]+')
 kubectl get crd | grep securitycontextconstraints.security.openshift.io --quiet
 if [ $? -ne 0 ]; then
   isOpenShift=false

--- a/tests/config/driverconfig/unity/v2.6.0/controller.yaml
+++ b/tests/config/driverconfig/unity/v2.6.0/controller.yaml
@@ -211,6 +211,8 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/tests/config/driverconfig/unity/v2.6.0/node.yaml
+++ b/tests/config/driverconfig/unity/v2.6.0/node.yaml
@@ -109,6 +109,8 @@ spec:
               value: "15"
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
           volumeMounts:
             - name: driver-path
               mountPath: /var/lib/kubelet/plugins/unity.emc.dell.com

--- a/tests/e2e/testfiles/storage_csm_unity.yaml
+++ b/tests/e2e/testfiles/storage_csm_unity.yaml
@@ -43,8 +43,6 @@ spec:
           value: debug
         - name: TENANT_NAME
           value: ""
-        - name: CERT_SECRET_COUNT
-          value: "1"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it

--- a/tests/e2e/testfiles/storage_csm_unity.yaml
+++ b/tests/e2e/testfiles/storage_csm_unity.yaml
@@ -43,6 +43,8 @@ spec:
           value: debug
         - name: TENANT_NAME
           value: ""
+        - name: CERT_SECRET_COUNT
+          value: "1"
 
     sideCars:
       # health monitor is disabled by default, refer to driver documentation before enabling it


### PR DESCRIPTION
# Description
The PR adds validation to create certs only if we are providing  X509 certificates in our certs 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/756 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Sanity test:
CSI Unity Driver Installation when X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION is true
![unity csm op without empty secret](https://github.com/dell/csm-operator/assets/92028646/b00ff983-96d8-41a7-a196-d34143898aa6)
CSI Unity Driver Installation when X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION is false
![when skipcert is true](https://github.com/dell/csm-operator/assets/92028646/b23be08e-d81b-4315-89e6-bd5bc2162f7e)

