### PR TITLE
Fix for Replication Controller Pod not coming up

### DIFF
--- a/pkg/modules/replication.go
+++ b/pkg/modules/replication.go
@@ -372,7 +372,7 @@ func ReplicationManagerController(ctx context.Context, isDeleting bool, op utils
 		return err
 	}
 
-	ctrlObjects, err := utils.GetCTRLObject([]byte(YamlString))
+	ctrlObjects, err := utils.GetModuleComponentObj([]byte(YamlString))
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -512,6 +512,15 @@ func GetModuleComponentObj(CtrlBuf []byte) ([]crclient.Object, error) {
 
 			ctrlObjects = append(ctrlObjects, &cm)
 
+		case "Secret":
+
+			var s corev1.Secret
+			if err := yaml.Unmarshal(raw, &s); err != nil {
+				return ctrlObjects, err
+			}
+
+			ctrlObjects = append(ctrlObjects, &s)
+
 		case "Deployment":
 
 			var dp appsv1.Deployment


### PR DESCRIPTION
# Description
This fixes the issue related to replication where secret and service account were not getting created when installing replication controller via csm-operator

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/788 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
