### PR TITLE
Added Storage Capacity Tracking Support for CSI-PowerScale in CSM-Operator

### DIFF
--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -92,7 +92,8 @@ metadata:
                 "tolerations": null
               },
               "csiDriverSpec": {
-                "fSGroupPolicy": "ReadWriteOnceWithFSType"
+                "fSGroupPolicy": "ReadWriteOnceWithFSType",
+                "storageCapacity": false
               },
               "csiDriverType": "isilon",
               "dnsPolicy": "ClusterFirstWithHostNet",

--- a/config/samples/storage_v1_csm_powerscale.yaml
+++ b/config/samples/storage_v1_csm_powerscale.yaml
@@ -11,6 +11,11 @@ spec:
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
       fSGroupPolicy: "ReadWriteOnceWithFSType"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: false
     # Config version for CSI PowerScale v2.7.0 driver
     configVersion: v2.7.0
     authSecret: test-isilon-creds

--- a/operatorconfig/driverconfig/powerscale/v2.7.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.7.0/controller.yaml
@@ -71,6 +71,16 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  # Permissions for CSIStorageCapacity
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -187,9 +197,20 @@ spec:
             - "--leader-election-renew-deadline=10s"
             - "--leader-election-lease-duration=15s"
             - "--leader-election-retry-period=5s"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval=5m"
           env:
             - name: ADDRESS
               value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/operatorconfig/driverconfig/powerscale/v2.7.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.7.0/csidriver.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
     attachRequired: true
     podInfoOnMount: true
+    storageCapacity: true
     fsGroupPolicy: ReadWriteOnceWithFSType
     volumeLifecycleModes:
     - Persistent

--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -191,6 +191,70 @@ func csmWithPowerstore(driver csmv1.DriverType, version string) csmv1.ContainerS
 	return res
 }
 
+func csmWithPowerScale(driver csmv1.DriverType, version string) csmv1.ContainerStorageModule {
+	res := shared.MakeCSM("csm", "driver-test", shared.ConfigVersion)
+
+	// Add FSGroupPolicy
+	res.Spec.Driver.CSIDriverSpec.FSGroupPolicy = "File"
+
+	// Add DNS Policy for GetNode test
+	res.Spec.Driver.DNSPolicy = "ThisIsADNSPolicy"
+
+	// Add image name
+	res.Spec.Driver.Common.Image = "thisIsAnImage"
+
+	// Add pscale driver version
+	res.Spec.Driver.ConfigVersion = version
+
+	// Add pscale driver type
+	res.Spec.Driver.CSIDriverType = driver
+
+	// Add NodeSelector to node and controller
+	res.Spec.Driver.Node.NodeSelector = map[string]string{"thisIs": "NodeSelector"}
+	res.Spec.Driver.Controller.NodeSelector = map[string]string{"thisIs": "NodeSelector"}
+
+	// Add node name prefix to cover some code in GetNode
+	nodeNamePrefix := corev1.EnvVar{Name: "X_CSI_POWERSTORE_NODE_NAME_PREFIX"}
+
+	// Add FC port filter
+	fcFilterPath := corev1.EnvVar{Name: "X_CSI_FC_PORTS_FILTER_FILE_PATH"}
+	res.Spec.Driver.Common.Envs = []corev1.EnvVar{nodeNamePrefix, fcFilterPath}
+
+	// Add environment variable
+	csiLogLevel := corev1.EnvVar{Name: "CSI_LOG_LEVEL", Value: "debug"}
+
+	res.Spec.Driver.Node.Envs = []corev1.EnvVar{csiLogLevel}
+
+	// Add node fields specific to powerstore
+	healthMonitor := corev1.EnvVar{Name: "X_CSI_HEALTH_MONITOR_ENABLED", Value: "true"}
+	res.Spec.Driver.Node.Envs = []corev1.EnvVar{healthMonitor}
+
+	// Add controller fields specific
+	res.Spec.Driver.Controller.Envs = []corev1.EnvVar{healthMonitor}
+
+	res.Spec.Driver.CSIDriverSpec.StorageCapacity = true
+
+	// Add sidecars to trigger code in controller
+	sideCarObjEnabledNil := csmv1.ContainerTemplate{
+		Name:    "driver",
+		Enabled: nil,
+		Args:    []string{"--v=5"},
+	}
+	sideCarObjEnabledFalse := csmv1.ContainerTemplate{
+		Name:    "resizer",
+		Enabled: &falseBool,
+		Args:    []string{"--v=5"},
+	}
+	sideCarObjEnabledTrue := csmv1.ContainerTemplate{
+		Name:    "provisioner",
+		Enabled: &trueBool,
+		Args:    []string{"--volume-name-prefix=k8s", "--enable-capacity=true", "--capacity-ownerref-level=2"},
+	}
+	sideCarList := []csmv1.ContainerTemplate{sideCarObjEnabledNil, sideCarObjEnabledFalse, sideCarObjEnabledTrue}
+	res.Spec.Driver.SideCars = sideCarList
+	return res
+}
+
 func csmWithUnity(driver csmv1.DriverType, version string, certProvided bool) csmv1.ContainerStorageModule {
 	res := shared.MakeCSM("csm", "driver-test", shared.ConfigVersion)
 

--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -378,8 +378,11 @@ func GetCSIDriver(ctx context.Context, cr csmv1.ContainerStorageModule, operator
 	}
 
 	YamlString := utils.ModifyCommonCR(string(buf), cr)
-	if cr.Spec.Driver.CSIDriverType == "powerstore" {
+	switch cr.Spec.Driver.CSIDriverType {
+	case "powerstore":
 		YamlString = ModifyPowerstoreCR(YamlString, cr, "CSIDriverSpec")
+	case "isilon":
+		YamlString = ModifyPowerScaleCR(YamlString, cr, "CSIDriverSpec")
 	}
 	err = yaml.Unmarshal([]byte(YamlString), &csidriver)
 	if err != nil {

--- a/pkg/drivers/commonconfig_test.go
+++ b/pkg/drivers/commonconfig_test.go
@@ -25,6 +25,7 @@ var (
 	csm                  = csmWithTolerations(csmv1.PowerScaleName, shared.ConfigVersion)
 	pFlexCSM             = csmForPowerFlex(pflexCSMName)
 	pStoreCSM            = csmWithPowerstore(csmv1.PowerStore, shared.PStoreConfigVersion)
+	pScaleCSM            = csmWithPowerScale(csmv1.PowerScale, shared.PScaleConfigVersion)
 	unityCSM             = csmWithUnity(csmv1.Unity, shared.UnityConfigVersion, false)
 	unityCSMCertProvided = csmWithUnity(csmv1.Unity, shared.UnityConfigVersion, true)
 
@@ -44,6 +45,7 @@ var (
 		expectedErr string
 	}{
 		{"pscale happy path", csm, csmv1.PowerScaleName, "node.yaml", ""},
+		{"powerscale happy path", pScaleCSM, csmv1.PowerScaleName, "node.yaml", ""},
 		{"pflex happy path", pFlexCSM, csmv1.PowerFlex, "node.yaml", ""},
 		{"pstore happy path", pStoreCSM, csmv1.PowerStore, "node.yaml", ""},
 		{"unity happy path", unityCSM, csmv1.Unity, "node.yaml", ""},

--- a/pkg/drivers/powerscale.go
+++ b/pkg/drivers/powerscale.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	csmv1 "github.com/dell/csm-operator/api/v1"
 	"github.com/dell/csm-operator/pkg/logger"
@@ -147,4 +148,19 @@ func getApplyCertVolume(cr csmv1.ContainerStorageModule) (*acorev1.VolumeApplyCo
 	}
 
 	return &volume, nil
+}
+
+// ModifyPowerScaleCR - It modifies the CR of powerscale/isilon (currently for Storage Capacity Tracking
+func ModifyPowerScaleCR(yamlString string, cr csmv1.ContainerStorageModule, fileType string) string {
+	// Parameters to initialise CR values
+	storageCapacity := "false"
+
+	switch fileType {
+	case "CSIDriverSpec":
+		if cr.Spec.Driver.CSIDriverSpec.StorageCapacity {
+			storageCapacity = "true"
+		}
+		yamlString = strings.ReplaceAll(yamlString, CsiStorageCapacityEnabled, storageCapacity)
+	}
+	return yamlString
 }

--- a/samples/storage_csm_powerscale_v270.yaml
+++ b/samples/storage_csm_powerscale_v270.yaml
@@ -5,12 +5,17 @@ metadata:
   namespace: test-isilon
 spec:
   driver:
-    csiDriverType: "isilon" 
+    csiDriverType: "isilon"
     csiDriverSpec:
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
       fSGroupPolicy: "ReadWriteOnceWithFSType"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: false
     # Config version for CSI PowerScale v2.7.0 driver
     configVersion: v2.7.0
     authSecret: test-isilon-creds
@@ -89,7 +94,7 @@ spec:
         # Default value: None
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
-        
+
         # certSecretCount: Represents number of certificate secrets, which user is going to create for
         # ssl authentication. (isilon-cert-0..isilon-cert-n)
         # Allowed values: n, where n > 0
@@ -241,6 +246,11 @@ spec:
       - name: external-health-monitor
         enabled: false
         args: ["--monitor-interval=60s"]
+      # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+      # Configure when the storageCapacity is set as "true"
+      # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=5m"]
 
   modules:
     # Authorization: enable csm-authorization for RBAC
@@ -255,7 +265,7 @@ spec:
           # proxyHost: hostname of the csm-authorization server
           - name: "PROXY_HOST"
             value: "csm-authorization.com"
-        
+
           # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server       
           - name: "SKIP_CERTIFICATE_VALIDATION"
             value: "true"
@@ -303,7 +313,7 @@ spec:
           # Default value: "debug"
           - name: "REPLICATION_CTRL_LOG_LEVEL"
             value: "debug"
-          
+
           # replicas: Defines number of controller replicas
           # Allowed values: int
           # Default value: 1
@@ -329,7 +339,7 @@ spec:
       # enabled: Enable/Disable observability
       enabled: false
       configVersion: v1.5.0
-      components: 
+      components:
         - name: topology
           # enabled: Enable/Disable topology
           enabled: false
@@ -341,7 +351,7 @@ spec:
             # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
             # Default value: "INFO"
             - name: "TOPOLOGY_LOG_LEVEL"
-              value: "INFO"           
+              value: "INFO"
 
         - name: otel-collector
           # enabled: Enable/Disable OpenTelemetry Collector

--- a/tests/config/driverconfig/powerscale/v2.7.0/controller.yaml
+++ b/tests/config/driverconfig/powerscale/v2.7.0/controller.yaml
@@ -71,6 +71,16 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  # Permissions for CSIStorageCapacity
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/config/driverconfig/powerscale/v2.7.0/controller.yaml
+++ b/tests/config/driverconfig/powerscale/v2.7.0/controller.yaml
@@ -197,9 +197,20 @@ spec:
             - "--leader-election-renew-deadline=10s"
             - "--leader-election-lease-duration=15s"
             - "--leader-election-retry-period=5s"
+            - "--enable-capacity=false"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval=5m"
           env:
             - name: ADDRESS
               value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/tests/config/driverconfig/powerscale/v2.7.0/csidriver.yaml
+++ b/tests/config/driverconfig/powerscale/v2.7.0/csidriver.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
     attachRequired: true
     podInfoOnMount: true
+    storageCapacity: false
     fsGroupPolicy: ReadWriteOnceWithFSType
     volumeLifecycleModes:
     - Persistent

--- a/tests/e2e/testfiles/storage_csm_powerscale.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale.yaml
@@ -11,6 +11,7 @@ spec:
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
       fSGroupPolicy: "ReadWriteOnceWithFSType"
+      storageCapacity: false
     # Config version for CSI PowerScale v2.6.0 driver
     configVersion: v2.6.0
     authSecret: test-isilon-creds

--- a/tests/shared/common.go
+++ b/tests/shared/common.go
@@ -35,6 +35,7 @@ const (
 	BadConfigVersion         string = "v0"
 	PStoreConfigVersion      string = "v2.7.0"
 	UnityConfigVersion       string = "v2.6.0"
+	PScaleConfigVersion      string = "v2.7.0"
 )
 
 // StorageKey is used to store a runtime object. It's used for both clientgo client and controller runtime client


### PR DESCRIPTION
# Description

Added Storage Capacity Tracking Support for CSI-PowerScale in CSM-Operator.

# GitHub Issues

List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/743 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Installed driver using CSM-operator
![csm-operator pod](https://github.com/dell/csm-operator/assets/36687396/72647944-9c9d-445e-9a48-8dcd14690db9)
![csi-driver pods](https://github.com/dell/csm-operator/assets/36687396/300824fb-b2d4-4f63-89d6-b6f947552e3d)

- Ran Cert-CSI
![SCT csm-operator](https://github.com/dell/csm-operator/assets/36687396/1681620f-73ed-4b75-8612-fc87835bef1b)

