### PR TITLE
Csm object fails during down scale

### DIFF
--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -128,6 +128,8 @@ func getDeploymentStatus(ctx context.Context, instance *csmv1.ContainerStorageMo
 		err = errors.New(msg)
 	}
 
+	log.Infof("Deployment totalReplicas count %d totalReadyPods %d totalFailedCount %d", totalReplicas, totalReadyPods, totalFailedCount)
+
 	return totalReplicas, csmv1.PodStatus{
 		Available: fmt.Sprintf("%d", totalReadyPods),
 		Desired:   fmt.Sprintf("%d", totalReplicas),
@@ -221,33 +223,46 @@ func getDaemonSetStatus(ctx context.Context, instance *csmv1.ContainerStorageMod
 func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule, r ReconcileCSM, newStatus *csmv1.ContainerStorageModuleStatus) (bool, error) {
 	log := logger.GetLogger(ctx)
 	running := false
-	controllerReplicas, controllerStatus, controllerErr := getDeploymentStatus(ctx, instance, r)
+	// TODO: Currently commented this block of code as the API used to get the latest deployment status is not working as expected
+	// TODO: Can be uncommented once this issues gets sorted out
+	/* controllerReplicas, controllerStatus, controllerErr := getDeploymentStatus(ctx, instance, r)
+	expected, nodeStatus, daemonSetErr := getDaemonSetStatus(ctx, instance, r)
 	newStatus.ControllerStatus = controllerStatus
+	newStatus.NodeStatus = nodeStatus */
 	expected, nodeStatus, daemonSetErr := getDaemonSetStatus(ctx, instance, r)
 	newStatus.NodeStatus = nodeStatus
+	controllerReplicas := newStatus.ControllerStatus.Desired
+	controllerStatus := newStatus.ControllerStatus
 
 	newStatus.State = constants.Failed
-	log.Infof("deployment controllerReplicas [%d]", controllerReplicas)
+	log.Infof("deployment controllerReplicas [%s]", controllerReplicas)
 	log.Infof("deployment controllerStatus.Available [%s]", controllerStatus.Available)
 
 	log.Infof("daemonset expected [%d]", expected)
 	log.Infof("daemonset nodeStatus.Available [%s]", nodeStatus.Available)
 
-	if (fmt.Sprintf("%d", controllerReplicas) == controllerStatus.Available) && (fmt.Sprintf("%d", expected) == nodeStatus.Available) {
+	if (controllerReplicas == controllerStatus.Available) && (fmt.Sprintf("%d", expected) == nodeStatus.Available) {
 		running = true
 		newStatus.State = constants.Succeeded
 	}
 	log.Infof("calculate overall state [%s]", newStatus.State)
-	var err error
-	if controllerErr != nil {
-		err = controllerErr
-	}
+	var err error = nil
+	// TODO: Uncomment this when the controller runtime API gets fixed
+	/*
+		if controllerErr != nil {
+			err = controllerErr
+		}
+		if daemonSetErr != nil {
+			err = daemonSetErr
+		}
+		if daemonSetErr != nil && controllerErr != nil {
+			err = fmt.Errorf("ControllerError: %s, Daemonseterror: %s", controllerErr.Error(), daemonSetErr.Error())
+			log.Infof("calculate overall error msg [%s]", err.Error())
+		} */
+
 	if daemonSetErr != nil {
 		err = daemonSetErr
-	}
-	if daemonSetErr != nil && controllerErr != nil {
-		err = fmt.Errorf("ControllerError: %s, Daemonseterror: %s", controllerErr.Error(), daemonSetErr.Error())
-		log.Infof("calculate overall error msg [%s]", err.Error())
+		log.Infof("calculate Daemonseterror msg [%s]", daemonSetErr.Error())
 	}
 	SetStatus(ctx, r, instance, newStatus)
 	return running, err
@@ -284,6 +299,12 @@ func UpdateStatus(ctx context.Context, instance *csmv1.ContainerStorageModule, r
 	if err != nil {
 		return err
 	}
+
+	log.Infow("instance - new controller Status", "desired", instance.Status.ControllerStatus.Desired)
+	log.Infow("instance - new controller Status", "Available", instance.Status.ControllerStatus.Available)
+	log.Infow("instance - new controller Status", "numberUnavailable", instance.Status.ControllerStatus.Failed)
+	log.Infow("instance - new controller Status", "State", instance.Status.State)
+
 	csm.Status = instance.Status
 	err = r.GetClient().Status().Update(ctx, csm)
 	if err != nil {


### PR DESCRIPTION
# Description
Fix for CSM object getting into failed state when we scale down deployments in csm-operator

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/816 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Tested this specific scenario by scaling down and scaling up the deployment replicas. Also ran sanity jobs on k8s 1.27 and the results look good
Scaling down to 1
![image](https://github.com/dell/csm-operator/assets/82365588/f765175c-c47a-4022-ba2e-7d2956f1ad85)

Scaling up to 2
![image](https://github.com/dell/csm-operator/assets/82365588/8a1a5cac-1466-4a4c-be14-17014f33e6f2)
