### PR TITLE
Remove test prefix from Unity namespace, name and authsecrets

### DIFF
--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -387,18 +387,14 @@ metadata:
           "apiVersion": "storage.dell.com/v1",
           "kind": "ContainerStorageModule",
           "metadata": {
-            "name": "test-unity",
-            "namespace": "test-unity"
+            "name": "unity",
+            "namespace": "unity"
           },
           "spec": {
             "driver": {
-              "authSecret": "test-unity-creds",
+              "authSecret": "unity-creds",
               "common": {
                 "envs": [
-                  {
-                    "name": "X_CSI_UNITY_NODENAME_PREFIX",
-                    "value": "csi-node"
-                  },
                   {
                     "name": "X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS",
                     "value": "false"

--- a/config/samples/storage_v1_csm_unity.yaml
+++ b/config/samples/storage_v1_csm_unity.yaml
@@ -1,8 +1,8 @@
 apiVersion: storage.dell.com/v1
 kind: ContainerStorageModule
 metadata:
-  name: test-unity
-  namespace: test-unity
+  name: unity
+  namespace: unity
 spec:
   driver:
     csiDriverType: "unity"
@@ -15,8 +15,8 @@ spec:
     configVersion: v2.7.0
     # authSecret: This is the secret used to validate the default Unity secret used for installation
     # Allowed values: <metadataName specified in the Manifest>-creds
-    # For example: If the metadataName is set to test-unity, authSecret value should be set to test-unity-creds
-    authSecret: test-unity-creds
+    # For example: If the metadataName is set to unity, authSecret value should be set to unity-creds
+    authSecret: unity-creds
     # Controller count
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
@@ -27,8 +27,6 @@ spec:
       image: "dellemc/csi-unity:v2.7.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_UNITY_NODENAME_PREFIX
-          value: "csi-node"
           # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
           # Allowed values: boolean
           # Default value: "false"

--- a/operatorconfig/driverconfig/unity/v2.5.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.5.0/node.yaml
@@ -101,8 +101,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: X_CSI_UNITY_NODENAME_PREFIX
-              value: <X_CSI_UNITY_NODENAME_PREFIX>
             - name: SSL_CERT_DIR
               value: /certs
             - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL

--- a/operatorconfig/driverconfig/unity/v2.6.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.6.0/node.yaml
@@ -101,8 +101,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: X_CSI_UNITY_NODENAME_PREFIX
-              value: <X_CSI_UNITY_NODENAME_PREFIX>
             - name: SSL_CERT_DIR
               value: /certs
             - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL

--- a/operatorconfig/driverconfig/unity/v2.7.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.7.0/node.yaml
@@ -101,8 +101,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: X_CSI_UNITY_NODENAME_PREFIX
-              value: <X_CSI_UNITY_NODENAME_PREFIX>
             - name: SSL_CERT_DIR
               value: /certs
             - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL

--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -290,9 +290,6 @@ func csmWithUnity(driver csmv1.DriverType, version string, certProvided bool) cs
 	}
 	res.Spec.Driver.Common.Envs = []corev1.EnvVar{envVar1, envVar2, envVar3, envVar4, envVar5, envVar6, envVar7}
 
-	// Add node name prefix to cover some code in GetNode
-	// nodeNamePrefix := corev1.EnvVar{Name: "X_CSI_UNITY_NODENAME_PREFIX"}
-
 	// Add node fields specific to unity
 	healthMonitor := corev1.EnvVar{Name: "X_CSI_HEALTH_MONITOR_ENABLED", Value: "true"}
 	res.Spec.Driver.Node.Envs = []corev1.EnvVar{healthMonitor}

--- a/pkg/drivers/unity.go
+++ b/pkg/drivers/unity.go
@@ -36,9 +36,6 @@ const (
 	// UnityConfigParamsVolumeMount - Volume mount
 	UnityConfigParamsVolumeMount = "csi-unity-config-params"
 
-	// CsiUnityNodeNamePrefix - Node Name Prefix
-	CsiUnityNodeNamePrefix = "<X_CSI_UNITY_NODENAME_PREFIX>"
-
 	// CsiLogLevel - Defines the log level
 	CsiLogLevel = "<CSI_LOG_LEVEL>"
 
@@ -116,24 +113,17 @@ func PrecheckUnity(ctx context.Context, cr *csmv1.ContainerStorageModule, operat
 // ModifyUnityCR - Configuring CR parameters
 func ModifyUnityCR(yamlString string, cr csmv1.ContainerStorageModule, fileType string) string {
 	// Parameters to initialise CR values
-	nodePrefix := ""
 	healthMonitorNode := ""
 	healthMonitorController := ""
 
 	switch fileType {
 	case "Node":
-		for _, env := range cr.Spec.Driver.Common.Envs {
-			if env.Name == "X_CSI_UNITY_NODENAME_PREFIX" {
-				nodePrefix = env.Value
-			}
-		}
 		for _, env := range cr.Spec.Driver.Node.Envs {
 
 			if env.Name == "X_CSI_HEALTH_MONITOR_ENABLED" {
 				healthMonitorNode = env.Value
 			}
 		}
-		yamlString = strings.ReplaceAll(yamlString, CsiUnityNodeNamePrefix, nodePrefix)
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorNode)
 	case "Controller":
 		for _, env := range cr.Spec.Driver.Controller.Envs {

--- a/samples/storage_csm_unity_v250.yaml
+++ b/samples/storage_csm_unity_v250.yaml
@@ -1,8 +1,8 @@
 apiVersion: storage.dell.com/v1
 kind: ContainerStorageModule
 metadata:
-  name: test-unity
-  namespace: test-unity
+  name: unity
+  namespace: unity
 spec:
   driver:
     csiDriverType: "unity"
@@ -15,8 +15,8 @@ spec:
     configVersion: v2.5.0
     # authSecret: This is the secret used to validate the default Unity secret used for installation
     # Allowed values: <metadataName specified in the Manifest>-creds
-    # For example: If the metadataName is set to test-unity, authSecret value should be set to test-unity-creds
-    authSecret: test-unity-creds
+    # For example: If the metadataName is set to unity, authSecret value should be set to unity-creds
+    authSecret: unity-creds
     # Controller count
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
@@ -27,8 +27,6 @@ spec:
       image: "dellemc/csi-unity:v2.5.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_UNITY_NODENAME_PREFIX
-          value: "csi-node"
           # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
           # Allowed values: boolean
           # Default value: "false"

--- a/samples/storage_csm_unity_v260.yaml
+++ b/samples/storage_csm_unity_v260.yaml
@@ -1,8 +1,8 @@
 apiVersion: storage.dell.com/v1
 kind: ContainerStorageModule
 metadata:
-  name: test-unity
-  namespace: test-unity
+  name: unity
+  namespace: unity
 spec:
   driver:
     csiDriverType: "unity"
@@ -15,8 +15,8 @@ spec:
     configVersion: v2.6.0
     # authSecret: This is the secret used to validate the default Unity secret used for installation
     # Allowed values: <metadataName specified in the Manifest>-creds
-    # For example: If the metadataName is set to test-unity, authSecret value should be set to test-unity-creds
-    authSecret: test-unity-creds
+    # For example: If the metadataName is set to unity, authSecret value should be set to unity-creds
+    authSecret: unity-creds
     # Controller count
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
@@ -27,8 +27,6 @@ spec:
       image: "dellemc/csi-unity:v2.6.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_UNITY_NODENAME_PREFIX
-          value: "csi-node"
           # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
           # Allowed values: boolean
           # Default value: "false"

--- a/samples/storage_csm_unity_v270.yaml
+++ b/samples/storage_csm_unity_v270.yaml
@@ -1,8 +1,8 @@
 apiVersion: storage.dell.com/v1
 kind: ContainerStorageModule
 metadata:
-  name: test-unity
-  namespace: test-unity
+  name: unity
+  namespace: unity
 spec:
   driver:
     csiDriverType: "unity"
@@ -15,8 +15,8 @@ spec:
     configVersion: v2.7.0
     # authSecret: This is the secret used to validate the default Unity secret used for installation
     # Allowed values: <metadataName specified in the Manifest>-creds
-    # For example: If the metadataName is set to test-unity, authSecret value should be set to test-unity-creds
-    authSecret: test-unity-creds
+    # For example: If the metadataName is set to unity, authSecret value should be set to unity-creds
+    authSecret: unity-creds
     # Controller count
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
@@ -27,8 +27,6 @@ spec:
       image: "dellemc/csi-unity:v2.7.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_UNITY_NODENAME_PREFIX
-          value: "csi-node"
           # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
           # Allowed values: boolean
           # Default value: "false"

--- a/tests/config/driverconfig/unity/v2.6.0/controller.yaml
+++ b/tests/config/driverconfig/unity/v2.6.0/controller.yaml
@@ -113,7 +113,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
         - name: attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.0.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -126,7 +126,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -147,7 +147,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -163,7 +163,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -176,7 +176,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: external-health-monitor
-          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.7.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.7.0
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/tests/config/driverconfig/unity/v2.6.0/node.yaml
+++ b/tests/config/driverconfig/unity/v2.6.0/node.yaml
@@ -101,8 +101,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: X_CSI_UNITY_NODENAME_PREFIX
-              value: <X_CSI_UNITY_NODENAME_PREFIX>
             - name: SSL_CERT_DIR
               value: /certs
             - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL
@@ -132,7 +130,7 @@ spec:
             - name: unity-secret
               mountPath: /unity-secret
         - name: registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/tests/e2e/testfiles/storage_csm_unity.yaml
+++ b/tests/e2e/testfiles/storage_csm_unity.yaml
@@ -1,8 +1,8 @@
 apiVersion: storage.dell.com/v1
 kind: ContainerStorageModule
 metadata:
-  name: test-unity
-  namespace: test-unity
+  name: unity
+  namespace: unity
 spec:
   driver:
     csiDriverType: "unity"
@@ -15,8 +15,8 @@ spec:
     configVersion: v2.6.0
     # authSecret: This is the secret used to validate the default Unity secret used for installation
     # Allowed values: <metadataName specified in the Manifest>-config
-    # For example: If the metadataName is set to test-unity, authSecret value should be set to test-unity-config
-    authSecret: test-unity-creds
+    # For example: If the metadataName is set to unity, authSecret value should be set to unity-config
+    authSecret: unity-creds
     # Controller count
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
@@ -27,8 +27,6 @@ spec:
       image: "dellemc/csi-unity:v2.6.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_UNITY_NODENAME_PREFIX
-          value: "csi-node"
         - name: X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS
           value: "false"
         - name: X_CSI_EPHEMERAL_STAGING_PATH


### PR DESCRIPTION
# Description
Remove test prefix from Unity namespace, name and authsecrets.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/743 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Sanity tests:

![image](https://github.com/dell/csm-operator/assets/92028646/832ed0bf-6ad9-4174-a3d5-f6b0248e6917)

