### PR TITLE
fix test compile error

### DIFF
--- a/tests/e2e/steps/step_common.go
+++ b/tests/e2e/steps/step_common.go
@@ -13,7 +13,6 @@
 package steps
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os/exec"


### PR DESCRIPTION
# Description
e2e tests can't compile on latest changes made 
this removes the syntax issue 

```
Failed to compile e2e:

# github.com/dell/csm-operator/tests/e2e/steps
steps/step_common.go:16:2: "bytes" imported and not used

Ginkgo ran 1 suite in 24.260316404s
```

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
