### PR TITLE
PowerStore: Storage Capacity Tracking related changes

### DIFF
--- a/operatorconfig/driverconfig/powerstore/v2.5.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.5.0/controller.yaml
@@ -172,7 +172,7 @@ spec:
             - "--default-fstype=ext4"
             - "--extra-create-metadata"
             - "--feature-gates=Topology=true"
-            - "--enable-capacity=false"
+            - "--enable-capacity=true"
             - "--capacity-ownerref-level=2"
             - "--capacity-poll-interval=5m"
           env:

--- a/operatorconfig/driverconfig/powerstore/v2.6.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.6.0/controller.yaml
@@ -171,7 +171,7 @@ spec:
             - "--default-fstype=ext4"
             - "--extra-create-metadata"
             - "--feature-gates=Topology=true"
-            - "--enable-capacity=false"
+            - "--enable-capacity=true"
             - "--capacity-ownerref-level=2"
             - "--capacity-poll-interval=5m"
           env:

--- a/operatorconfig/driverconfig/powerstore/v2.7.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.7.0/controller.yaml
@@ -171,7 +171,7 @@ spec:
             - "--default-fstype=ext4"
             - "--extra-create-metadata"
             - "--feature-gates=Topology=true"
-            - "--enable-capacity=false"
+            - "--enable-capacity=true"
             - "--capacity-ownerref-level=2"
             - "--capacity-poll-interval=5m"
           env:

--- a/samples/storage_csm_powerstore_v250.yaml
+++ b/samples/storage_csm_powerstore_v250.yaml
@@ -62,6 +62,13 @@ spec:
       - name: external-health-monitor
         enabled: false
         args: ["--monitor-interval=60s"]
+
+      # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+      # Configure only when the storageCapacity is set as "true"
+      # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=5m"]
+
     controller:
       envs:
         # X_CSI_NFS_ACLS: enables setting permissions on NFS mount directory

--- a/samples/storage_csm_powerstore_v260.yaml
+++ b/samples/storage_csm_powerstore_v260.yaml
@@ -61,6 +61,13 @@ spec:
       - name: external-health-monitor
         enabled: false
         args: ["--monitor-interval=60s"]
+
+      # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+      # Configure only when the storageCapacity is set as "true"
+      # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=5m"]
+
     controller:
       envs:
         # X_CSI_NFS_ACLS: enables setting permissions on NFS mount directory

--- a/samples/storage_csm_powerstore_v270.yaml
+++ b/samples/storage_csm_powerstore_v270.yaml
@@ -61,6 +61,13 @@ spec:
       - name: external-health-monitor
         enabled: false
         args: ["--monitor-interval=60s"]
+
+      # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+      # Configure only when the storageCapacity is set as "true"
+      # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=5m"]
+
     controller:
       envs:
         # X_CSI_NFS_ACLS: enables setting permissions on NFS mount directory


### PR DESCRIPTION
# Description

- Updated `enable-capacity` arg to true for provisioner sidecar.
- Added option to configure `capacity-poll-interval` in sample yamls.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/823 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Enabled storage capacity and installed the driver. Storage Capacity spec is being set to true.
  ![image](https://github.com/dell/csm-operator/assets/109594002/bc9b53af-d676-4e89-8d53-836554857185)

- [x] CSIStorageCapacity objects are getting created for each of the storageclass.
  ![image](https://github.com/dell/csm-operator/assets/109594002/20a8021f-7726-4072-88d5-65f280b8e26f)
