### PR TITLE
CSI-PowerStore: Enabling Storage Capacity Tracking 

### DIFF
--- a/samples/storage_csm_powerstore_v260.yaml
+++ b/samples/storage_csm_powerstore_v260.yaml
@@ -65,8 +65,8 @@ spec:
       # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
       # Configure only when the storageCapacity is set as "true"
       # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
-      - name: provisioner
-        args: ["--capacity-poll-interval=5m"]
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=5m"]
 
     controller:
       envs:

--- a/samples/storage_csm_powerstore_v260.yaml
+++ b/samples/storage_csm_powerstore_v260.yaml
@@ -30,7 +30,7 @@ spec:
       # Allowed values:
       #   true: enable storage capacity tracking
       #   false: disable storage capacity tracking
-      storageCapacity: false
+      storageCapacity: true
     # Config version for CSI PowerStore v2.6.0 driver
     configVersion: v2.6.0
     # authSecret: This is the secret used to validate the default PowerStore secret used for installation
@@ -65,8 +65,8 @@ spec:
       # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
       # Configure only when the storageCapacity is set as "true"
       # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
-      #- name: provisioner
-      #  args: ["--capacity-poll-interval=5m"]
+      - name: provisioner
+        args: ["--capacity-poll-interval=5m"]
 
     controller:
       envs:

--- a/samples/storage_csm_powerstore_v270.yaml
+++ b/samples/storage_csm_powerstore_v270.yaml
@@ -65,8 +65,8 @@ spec:
       # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
       # Configure only when the storageCapacity is set as "true"
       # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
-      - name: provisioner
-        args: ["--capacity-poll-interval=5m"]
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=5m"]
 
     controller:
       envs:

--- a/samples/storage_csm_powerstore_v270.yaml
+++ b/samples/storage_csm_powerstore_v270.yaml
@@ -30,7 +30,7 @@ spec:
       # Allowed values:
       #   true: enable storage capacity tracking
       #   false: disable storage capacity tracking
-      storageCapacity: false
+      storageCapacity: true
     # Config version for CSI PowerStore v2.7.0 driver
     configVersion: v2.7.0
     # authSecret: This is the secret used to validate the default PowerStore secret used for installation
@@ -65,8 +65,8 @@ spec:
       # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
       # Configure only when the storageCapacity is set as "true"
       # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
-      #- name: provisioner
-      #  args: ["--capacity-poll-interval=5m"]
+      - name: provisioner
+        args: ["--capacity-poll-interval=5m"]
 
     controller:
       envs:


### PR DESCRIPTION
# Description
Enabled storage capacity tracking in Powerstore 2.6 and 2.7 samples

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/743 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
- Executed storage capacity tracking suite using cert-csi
![image](https://github.com/dell/csm-operator/assets/120644626/36b2ffce-007f-4d2a-a97b-552bfe278e53)



