### PR TITLE
Adds v2.5.0 config for csireverseproxy

### DIFF
--- a/operatorconfig/driverconfig/powermax/v2.6.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.6.0/controller.yaml
@@ -127,7 +127,7 @@ spec:
 
       containers:
         - name: resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -141,7 +141,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -156,7 +156,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: external-health-monitor
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.7.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -173,7 +173,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -193,7 +193,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"

--- a/operatorconfig/driverconfig/powermax/v2.6.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.6.0/node.yaml
@@ -189,7 +189,7 @@ spec:
             - name: node-topology-config
               mountPath: /node-topology-config
         - name: registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/operatorconfig/driverconfig/powermax/v2.7.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.7.0/node.yaml
@@ -189,7 +189,7 @@ spec:
             - name: node-topology-config
               mountPath: /node-topology-config
         - name: registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.5.0/controller.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.5.0/controller.yaml
@@ -1,0 +1,105 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["list", "watch", "get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+subjects:
+  - kind: ServiceAccount
+    name: csipowermax-reverseproxy
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: Role
+  name: csipowermax-reverseproxy
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  ports:
+    - port: <X_CSI_REVPROXY_PORT>
+      protocol: TCP
+      targetPort: 2222
+  selector:
+    name: csipowermax-reverseproxy
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: csipowermax-reverseproxy
+  template:
+    metadata:
+      labels:
+        name: csipowermax-reverseproxy
+    spec:
+      serviceAccountName: csipowermax-reverseproxy
+      containers:
+        - name: csipowermax-reverseproxy
+          # Replace this with the built image name
+          image: <REVERSEPROXY_PROXY_SERVER_IMAGE>
+          imagePullPolicy: Always
+          env:
+            - name: X_CSI_REVPROXY_CONFIG_DIR
+              value: /etc/config/configmap
+            - name: X_CSI_REVPROXY_CONFIG_FILE_NAME
+              value: config.yaml
+            - name: X_CSI_REVRPOXY_IN_CLUSTER
+              value: "true"
+            - name: X_CSI_REVPROXY_TLS_CERT_DIR
+              value: /app/tls
+            - name: X_CSI_REVPROXY_WATCH_NAMESPACE
+              value: <DriverDefaultReleaseNamespace> #Change this to the namespace where proxy will be installed
+          volumeMounts:
+            - name: configmap-volume
+              mountPath: /etc/config/configmap
+            - name: tls-secret
+              mountPath: /app/tls
+            - name: cert-dir
+              mountPath: /app/certs
+      volumes:
+        - name: configmap-volume
+          configMap:
+            name: <X_CSI_CONFIG_MAP_NAME>
+            optional: true
+        - name: tls-secret
+          secret:
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>
+        - name: cert-dir
+          emptyDir:

--- a/samples/csireverseproxy/config.yaml
+++ b/samples/csireverseproxy/config.yaml
@@ -35,10 +35,10 @@ standAloneConfig:
         - proxy-secret-22
   managementServers:
     - url: https://primary-1.unisphe.re:8443 # primary unisphere endpoint
-      arrayCredentialSecret: primary-1-secret # credential secret
+      arrayCredentialSecret: primary-1-secret # credential secret, e.g., powermax-creds
       skipCertificateValidation: true
-    - url: https://backup-1.unisphe.re:8443
-      arrayCredentialSecret: backup-1-secret # backup unisphere endpoint
+    - url: https://backup-1.unisphe.re:8443 # backup unisphere endpoint
+      arrayCredentialSecret: backup-1-secret # credential secret, e.g., powermax-creds
       skipCertificateValidation: false # value false, to verify unisphere certificate and provide certSecret
       certSecret: primary-certs # unisphere verification certificate
     - url: https://primary-2.unisphe.re:8443

--- a/samples/storage_csm_powermax_v260.yaml
+++ b/samples/storage_csm_powermax_v260.yaml
@@ -107,25 +107,25 @@ spec:
         #   "true" - vSphere volumes are enabled
         #   "false" - vSphere volumes are disabled
         # Default value: "false"
-        - name: "X_CSI_VSPHERE_ENABLED"
+        - name: X_CSI_VSPHERE_ENABLED
           value: "false"
         # X_CSI_VSPHERE_PORTGROUP: An existing portGroup that driver will use for vSphere
         # recommended format: csi-x-VC-PG, x can be anything of user choice
         # Allowed value: valid existing port group on the array
         # Default value: "" <empty>
-        - name: "X_CSI_VSPHERE_PORTGROUP"
+        - name: X_CSI_VSPHERE_PORTGROUP
           value: ""
         # X_CSI_VSPHERE_HOSTNAME: An existing host(initiator group)/ host group(cascaded initiator group) that driver will use for vSphere
         # this host should contain initiators from all the ESXs/ESXi host where the cluster is deployed
         # recommended format: csi-x-VC-HN, x can be anything of user choice
         # Allowed value: valid existing host/host group on the array
         # Default value: "" <empty>
-        - name: "X_CSI_VSPHERE_HOSTNAME"
+        - name: X_CSI_VSPHERE_HOSTNAME
           value: ""
         # X_CSI_VCENTER_HOST: URL/endpoint of the vCenter where all the ESX are present
         # Allowed value: valid vCenter host endpoint
         # Default value: "" <empty>
-        - name: "X_CSI_VCENTER_HOST"
+        - name: X_CSI_VCENTER_HOST
           value: ""
     controller:
       envs:
@@ -148,7 +148,7 @@ spec:
         # Default value: "false"
         - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
           value: "false"
-        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin-volume usage, volume condition
         # Allowed values:
         #   true: enable checking of health condition of CSI volumes
         #   false: disable checking of health condition of CSI volumes
@@ -174,14 +174,14 @@ spec:
     - name: csireverseproxy
       # enabled: Always set to true
       enabled: true
-      configVersion: v2.6.0
+      configVersion: v2.5.0
       forceRemoveModule: true
       components:
       - name: csipowermax-reverseproxy
       # image: Define the container images used for the reverse proxy
       # Default value: None
-      # Example: "csipowermax-reverseproxy:v2.6.0"
-        image: dellemc/csipowermax-reverseproxy:v2.6.0
+      # Example: "csipowermax-reverseproxy:v2.5.0"
+        image: dellemc/csipowermax-reverseproxy:v2.5.0
         envs:
           # "tlsSecret" defines the TLS secret that is created with certificate
           # and its associated key


### PR DESCRIPTION
# Description
- Add missing v2.5.0 config for csireverseproxy

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/838|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Cluster Test
- [x] Unit Test
