### PR TITLE
Fix for secrets getting regenerated on apply of driver manifest

### DIFF
--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -102,9 +102,6 @@ var (
 	getSAError    bool
 	getSAErrorStr = "unable to get ServiceAccount"
 
-	updateSAError    bool
-	updateSAErrorStr = "unable to update ServiceAccount"
-
 	updateDSError    bool
 	updateDSErrorStr = "unable to update Daemonset"
 
@@ -980,12 +977,6 @@ func (suite *CSMControllerTestSuite) reconcileWithErrorInjection(reqName, expect
 	assert.Error(suite.T(), err)
 	assert.Containsf(suite.T(), err.Error(), getSAErrorStr, "expected error containing %q, got %s", expectedErr, err)
 	getSAError = false
-
-	updateSAError = true
-	_, err = reconciler.Reconcile(ctx, req)
-	assert.Error(suite.T(), err)
-	assert.Containsf(suite.T(), err.Error(), updateSAErrorStr, "expected error containing %q, got %s", expectedErr, err)
-	updateSAError = false
 
 	updateDSError = true
 	_, err = reconciler.Reconcile(ctx, req)

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -1535,9 +1535,6 @@ func (suite *CSMControllerTestSuite) ShouldFail(method string, obj runtime.Objec
 		if method == "Create" && createSAError {
 			fmt.Printf("[ShouldFail] force Create ServiceAccount error for ServiceAccount named %+v\n", sa.Name)
 			return errors.New(createSAErrorStr)
-		} else if method == "Update" && updateSAError {
-			fmt.Printf("[ShouldFail] force Update ServiceAccount error for ServiceAccount named %+v\n", sa.Name)
-			return errors.New(updateSAErrorStr)
 		} else if method == "Get" && getSAError {
 			fmt.Printf("[ShouldFail] force Get ServiceAccount error for ServiceAccount named %+v\n", sa.Name)
 			return errors.New(getSAErrorStr)

--- a/pkg/resources/serviceaccount/serviceaccount.go
+++ b/pkg/resources/serviceaccount/serviceaccount.go
@@ -40,11 +40,9 @@ func SyncServiceAccount(ctx context.Context, sa corev1.ServiceAccount, client cl
 		log.Errorw("Unknown error.", "Error", err.Error())
 		return err
 	} else {
-		log.Infow("Updating ServiceAccount", "Name:", sa.Name)
-		err = client.Update(ctx, &sa)
-		if err != nil {
-			return err
-		}
+		// Updating the service account keeps regenerating the secrets.
+		// We dont have to update the service account if it exists.
+		log.Infow("ServiceAccount already exists", "Name:", sa.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description
This PR has fix for secrets getting regenerated on `kubectl apply` of any driver manifest. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/743 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
1. Installed the operator followed by install of Unity driver. 
2. Make change to any of the field in driver manifest and apply the changes
3. Check the secrets. It should not get generated. 
Repeat step 2 couple of times and ensure that secrets are not getting regenerated. 
