### PR TITLE
Step fails as Karavictl returns YAML instead of JSON

### DIFF
--- a/tests/e2e/steps/steps_def.go
+++ b/tests/e2e/steps/steps_def.go
@@ -14,7 +14,6 @@ package steps
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -1041,15 +1040,8 @@ func (step *Step) configureAuthorizationProxyServer(res Resource, driver string)
 
 	// Apply token to CSI driver host
 	fmt.Println("=== Applying token ===\n ")
-	var token struct {
-		Token string `json:"Token"`
-	}
-	err = json.Unmarshal(b, &token)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal token %s: %v", string(b), err)
-	}
 
-	err = os.WriteFile("/tmp/token.yaml", []byte(token.Token), 0644)
+	err = os.WriteFile("/tmp/token.yaml", b, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write tenant token: %v\nErrMessage:\n%s", err, string(b))
 	}


### PR DESCRIPTION
# Description
Scenario "Install PowerScale Driver(With Authorization)" consistently failed with err: failed to unmarshal token apiVersion: v1. Issue discovered with latest version of karavictl built from main. Karavictl is now returning YAML which breaks the JSON unmarshalling.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/853|

# Checklist:

- [X ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X ] Install PowerScale Driver(With Authorization) passes. Code is used in common step to setup token.

