### PR TITLE
CSI-PowerStore: Adding support for feature volume limits

### DIFF
--- a/operatorconfig/driverconfig/powerstore/v2.8.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.8.0/controller.yaml
@@ -1,0 +1,270 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["volumegroup.storage.dell.com"]
+    resources: ["dellcsivolumegroupsnapshots","dellcsivolumegroupsnapshots/status"]
+    verbs: ["create", "list", "watch", "delete", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots", "volumesnapshots/status"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  # below for resizer
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  # Permissions for CSIStorageCapacity
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-controller
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  selector:
+    matchLabels:
+      name: <DriverDefaultReleaseName>-controller
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: <DriverDefaultReleaseName>-controller
+    spec:
+      serviceAccountName: <DriverDefaultReleaseName>-controller
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: name
+                  operator: In
+                  values:
+                  - <DriverDefaultReleaseName>-controller
+            topologyKey: kubernetes.io/hostname 
+      containers:
+        - name: attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+            - "--worker-threads=130"
+            - "--resync=10s"
+            - "--timeout=130s"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--volume-name-prefix=csivol"
+            - "--volume-name-uuid-length=10"
+            - "--v=5"
+            - "--leader-election"
+            - "--default-fstype=ext4"
+            - "--extra-create-metadata"
+            - "--feature-gates=Topology=true"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval=5m"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: snapshotter
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+            - "--snapshot-name-prefix=csisnap"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: external-health-monitor
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--http-endpoint=:8080"
+            - "--enable-node-watcher=true"
+            - "--monitor-interval=60s"
+            - "--timeout=180s"
+            - "--leader-election-renew-deadline=10s"
+            - "--leader-election-lease-duration=15s"
+            - "--leader-election-retry-period=5s"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: driver
+          image: dellemc/csi-powerstore:v2.8.0
+          imagePullPolicy: IfNotPresent
+          command: [ "/csi-powerstore" ]
+          args:
+            - "--array-config=/powerstore-config/config"
+            - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
+          env:
+            - name: ENABLE_TRACING
+              value:
+            - name: CSI_ENDPOINT
+              value: /var/run/csi/csi.sock
+            - name: X_CSI_MODE
+              value: controller
+            - name: X_CSI_DRIVER_NAME
+              value: "csi-powerstore.dellemc.com"
+            - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
+              value: <X_CSI_POWERSTORE_EXTERNAL_ACCESS>
+            - name: X_CSI_NFS_ACLS
+              value: "<X_CSI_NFS_ACLS>"
+            - name: X_CSI_POWERSTORE_CONFIG_PATH
+              value: /powerstore-config/config
+            - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
+              value: /powerstore-config-params/driver-config-params.yaml
+            - name: GOPOWERSTORE_DEBUG
+              value: true
+            - name: CSI_AUTO_ROUND_OFF_FILESYSTEM_SIZE
+              value: false
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+            - name: powerstore-config
+              mountPath: /powerstore-config
+            - name: powerstore-config-params
+              mountPath: /powerstore-config-params
+      volumes:
+        - name: socket-dir
+          emptyDir:
+        - name: powerstore-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+        - name: powerstore-config
+          secret:
+            secretName: <DriverDefaultReleaseName>-config

--- a/operatorconfig/driverconfig/powerstore/v2.8.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.8.0/csidriver.yaml
@@ -1,0 +1,27 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi-powerstore.dellemc.com
+spec:
+  storageCapacity: false
+  podInfoOnMount: true
+  fsGroupPolicy: ReadWriteOnceWithFSType
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral

--- a/operatorconfig/driverconfig/powerstore/v2.8.0/driver-config-params.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.8.0/driver-config-params.yaml
@@ -1,0 +1,29 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: <DriverDefaultReleaseName>
+data:
+  driver-config-params.yaml: |
+    CSI_LOG_LEVEL: "debug"
+    CSI_LOG_FORMAT: "JSON"
+    PODMON_CONTROLLER_LOG_LEVEL: "debug"
+    PODMON_CONTROLLER_LOG_FORMAT: "JSON"
+    PODMON_NODE_LOG_LEVEL: "debug"
+    PODMON_NODE_LOG_FORMAT: "JSON"

--- a/operatorconfig/driverconfig/powerstore/v2.8.0/node.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.8.0/node.yaml
@@ -1,0 +1,244 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["create", "delete", "get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["privileged"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-node
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-node
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  selector:
+    matchLabels:
+      app: <DriverDefaultReleaseName>-node
+  template:
+    metadata:
+      labels:
+        app: <DriverDefaultReleaseName>-node
+        driver.dellemc.com: dell-storage
+    spec:
+      #nodeSelector:
+      #tolerations:
+      serviceAccount: <DriverDefaultReleaseName>-node
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      hostIPC: true
+      containers:
+        - name: driver
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: dellemc/csi-powerstore:v2.8.0
+          imagePullPolicy:  IfNotPresent
+          command: [ "/csi-powerstore" ]
+          args:
+            - "--array-config=/powerstore-config/config"
+            - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
+          env:
+            - name: ENABLE_TRACING
+              value:
+            - name: CSI_ENDPOINT
+              value: unix://<KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com/csi_sock
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+              value: <X_CSI_POWERSTORE_NODE_NAME_PREFIX>
+            - name: X_CSI_POWERSTORE_NODE_ID_PATH
+              value: /node-id
+            - name: X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE
+              value: <X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE>
+            - name: X_CSI_POWERSTORE_NODE_CHROOT_PATH
+              value: /noderoot
+            - name: X_CSI_POWERSTORE_TMP_DIR
+              value: <KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com/tmp
+            - name: X_CSI_DRIVER_NAME
+              value: "csi-powerstore.dellemc.com"
+            - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
+              value: <X_CSI_FC_PORTS_FILTER_FILE_PATH>
+            - name: X_CSI_POWERSTORE_ENABLE_CHAP
+              value: "<X_CSI_POWERSTORE_ENABLE_CHAP>"
+            - name: X_CSI_POWERSTORE_CONFIG_PATH
+              value: /powerstore-config/config
+            - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
+              value: /powerstore-config-params/driver-config-params.yaml
+            - name: GOPOWERSTORE_DEBUG
+              value: "true"
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+          volumeMounts:
+            - name: driver-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com
+            - name: csi-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
+              mountPropagation: "Bidirectional"
+            - name: pods-path
+              mountPath: <KUBELET_CONFIG_DIR>/pods
+              mountPropagation: "Bidirectional"
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+            - name: run
+              mountPath: /run
+            - name: node-id
+              mountPath: /node-id
+            - name: etciscsi
+              mountPath: /etc/iscsi
+            - name: mpath
+              mountPath: /etc/multipath.conf
+            - name: noderoot
+              mountPath: /noderoot
+            - name: powerstore-config
+              mountPath: /powerstore-config
+            - name: powerstore-config-params
+              mountPath: /powerstore-config-params
+        - name: registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - --kubelet-registration-path=<KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com/csi_sock
+          env:
+            - name: ADDRESS
+              value: /csi/csi_sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: registration-dir
+              mountPath: /registration
+            - name: driver-path
+              mountPath: /csi
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins_registry/
+            type: DirectoryOrCreate
+        - name: driver-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com
+            type: DirectoryOrCreate
+        - name: csi-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
+        - name: pods-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/pods
+            type: Directory
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: node-id
+          hostPath:
+            path: /etc/machine-id
+            type: File
+        - name: etciscsi
+          hostPath:
+            path: /etc/iscsi
+            type: DirectoryOrCreate
+        - name: mpath
+          hostPath:
+            path: /etc/multipath.conf
+            type: FileOrCreate
+        - name: noderoot
+          hostPath:
+            path: /
+            type: Directory
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: run
+          hostPath:
+            path: /run
+            type: Directory
+        - name: powerstore-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+        - name: powerstore-config
+          secret:
+            secretName: <DriverDefaultReleaseName>-config
+        - name: usr-bin
+          hostPath:
+            path: /usr/bin
+            type: Directory
+        - name: kubelet-pods
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: var-run
+          hostPath:
+            path: /var/run
+            type: Directory

--- a/operatorconfig/driverconfig/powerstore/v2.8.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.8.0/upgrade-path.yaml
@@ -1,0 +1,16 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+minUpgradePath: v2.7.0

--- a/operatorconfig/moduleconfig/common/version-values.yaml
+++ b/operatorconfig/moduleconfig/common/version-values.yaml
@@ -32,6 +32,8 @@ powerstore:
   # List of Driver versions and modules that supports the version
   v2.7.0:
       resiliency: "v1.6.0"
+  v2.8.0:
+      resiliency: "v1.7.0"
 powermax:
   # List of Driver versions and modules that supports the version
   v2.6.0:

--- a/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerflex-controller.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerflex-controller.yaml
@@ -1,0 +1,36 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+name: podmon
+image: dellemc/podmon:v1.7.0
+imagePullPolicy: IfNotPresent
+env:
+  - name: MY_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+volumeMounts:
+  - name: socket-dir
+    mountPath: /var/run/csi
+  - name: vxflexos-config-params
+    mountPath: /vxflexos-config-params

--- a/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerflex-node.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerflex-node.yaml
@@ -1,0 +1,58 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+name: podmon
+image: dellemc/podmon:v1.7.0
+imagePullPolicy: IfNotPresent
+securityContext:
+  privileged: true
+  capabilities:
+    add: ["SYS_ADMIN"]
+  allowPrivilegeEscalation: true
+env:
+  - name: KUBE_NODE_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: spec.nodeName
+  - name: X_CSI_PRIVATE_MOUNT_DIR
+    value: /var/lib/kubelet
+  - name: MY_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+volumeMounts:
+  - name: kubelet-pods
+    mountPath: <KUBELET_CONFIG_DIR>/pods
+    mountPropagation: "Bidirectional"
+  - name: driver-path
+    mountPath: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com
+    mountPropagation: "Bidirectional"
+  - name: dev
+    mountPath: /dev
+  - name: usr-bin
+    mountPath: /usr-bin
+  - name: var-run
+    mountPath: /var/run
+  - name: vxflexos-config-params
+    mountPath: /vxflexos-config-params 

--- a/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerscale-controller.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerscale-controller.yaml
@@ -1,0 +1,36 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+name: podmon
+image: dellemc/podmon:v1.7.0
+imagePullPolicy: IfNotPresent
+env:
+  - name: MY_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+volumeMounts:
+  - name: socket-dir
+    mountPath: /var/run/csi
+  - name: csi-isilon-config-params
+    mountPath: /csi-isilon-config-params

--- a/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerscale-node.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerscale-node.yaml
@@ -1,0 +1,61 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+name: podmon
+image: dellemc/podmon:v1.7.0
+imagePullPolicy: IfNotPresent
+securityContext:
+  privileged: true
+  capabilities:
+    add: ["SYS_ADMIN"]
+  allowPrivilegeEscalation: true
+env:
+  - name: KUBE_NODE_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: spec.nodeName
+  - name: X_CSI_PRIVATE_MOUNT_DIR
+    value: /var/lib/kubelet
+  - name: MY_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+volumeMounts:
+  - name: kubelet-pods
+    mountPath: <KUBELET_CONFIG_DIR>/pods
+    mountPropagation: "Bidirectional"
+  - name: driver-path
+    mountPath: <KUBELET_CONFIG_DIR>/plugins/csi-isilon
+    mountPropagation: "Bidirectional"
+  - name: csi-path
+    mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
+    mountPropagation: "Bidirectional"
+  - name: dev
+    mountPath: /dev
+  - name: usr-bin
+    mountPath: /usr-bin
+  - name: var-run
+    mountPath: /var/run
+  - name: csi-isilon-config-params
+    mountPath: /csi-isilon-config-params 

--- a/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerstore-controller.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerstore-controller.yaml
@@ -1,0 +1,36 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+name: podmon
+image: dellemc/podmon:v1.7.0
+imagePullPolicy: IfNotPresent
+env:
+  - name: MY_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+volumeMounts:
+  - name: socket-dir
+    mountPath: /var/run/csi
+  - name: powerstore-config-params
+    mountPath: /powerstore-config-params

--- a/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerstore-node.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.7.0/container-powerstore-node.yaml
@@ -1,0 +1,61 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+name: podmon
+securityContext:
+  privileged: true
+  capabilities:
+    add: ["SYS_ADMIN"]
+  allowPrivilegeEscalation: true
+image: dellemc/podmon:v1.7.0
+imagePullPolicy: IfNotPresent
+env:
+  - name: KUBE_NODE_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: spec.nodeName
+  - name: X_CSI_PRIVATE_MOUNT_DIR
+    value: /var/lib/kubelet
+  - name: MY_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+volumeMounts:
+  - name: kubelet-pods
+    mountPath: <KUBELET_CONFIG_DIR>/pods
+    mountPropagation: "Bidirectional"
+  - name: driver-path
+    mountPath: <KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com
+    mountPropagation: "Bidirectional"
+  - name: csi-path
+    mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
+    mountPropagation: "Bidirectional"
+  - name: dev
+    mountPath: /dev
+  - name: usr-bin
+    mountPath: /usr-bin
+  - name: var-run
+    mountPath: /var/run
+  - name: powerstore-config-params
+    mountPath: /powerstore-config-params 

--- a/operatorconfig/moduleconfig/resiliency/v1.7.0/controller-roles.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.7.0/controller-roles.yaml
@@ -1,0 +1,24 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "update", "delete"]

--- a/operatorconfig/moduleconfig/resiliency/v1.7.0/node-roles.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.7.0/node-roles.yaml
@@ -1,0 +1,21 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "update", "delete"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]

--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -179,7 +179,8 @@ func csmWithPowerstore(driver csmv1.DriverType, version string) csmv1.ContainerS
 	// Add node fields specific to powerstore
 	enableChap := corev1.EnvVar{Name: "X_CSI_POWERSTORE_ENABLE_CHAP", Value: "true"}
 	healthMonitor := corev1.EnvVar{Name: "X_CSI_HEALTH_MONITOR_ENABLED", Value: "true"}
-	res.Spec.Driver.Node.Envs = []corev1.EnvVar{enableChap, healthMonitor}
+	maxVolumesPerNode := corev1.EnvVar{Name: "X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE", Value: "0"}
+	res.Spec.Driver.Node.Envs = []corev1.EnvVar{enableChap, healthMonitor, maxVolumesPerNode}
 
 	// Add controller fields specific
 	nfsAclsParam := corev1.EnvVar{Name: "X_CSI_NFS_ACLS"}

--- a/pkg/drivers/powerstore.go
+++ b/pkg/drivers/powerstore.go
@@ -37,6 +37,9 @@ const (
 	// CsiPowerstoreNodeNamePrefix - Node Name Prefix
 	CsiPowerstoreNodeNamePrefix = "<X_CSI_POWERSTORE_NODE_NAME_PREFIX>"
 
+	// CsiPowerstoreMaxVolumesPerNode - Maximum Volumes Per Node
+	CsiPowerstoreMaxVolumesPerNode = "<X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE>"
+
 	// CsiFcPortFilterFilePath - Fc Port Filter File Path
 	CsiFcPortFilterFilePath = "<X_CSI_FC_PORTS_FILTER_FILE_PATH>"
 
@@ -99,6 +102,7 @@ func ModifyPowerstoreCR(yamlString string, cr csmv1.ContainerStorageModule, file
 	healthMonitorNode := ""
 	powerstoreExternalAccess := ""
 	storageCapacity := "false"
+	maxVolumesPerNode := ""
 
 	switch fileType {
 	case "Node":
@@ -117,11 +121,15 @@ func ModifyPowerstoreCR(yamlString string, cr csmv1.ContainerStorageModule, file
 			if env.Name == "X_CSI_HEALTH_MONITOR_ENABLED" {
 				healthMonitorNode = env.Value
 			}
+			if env.Name == "X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE" {
+				maxVolumesPerNode = env.Value
+			}
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiPowerstoreNodeNamePrefix, nodePrefix)
 		yamlString = strings.ReplaceAll(yamlString, CsiFcPortFilterFilePath, fcPortFilter)
 		yamlString = strings.ReplaceAll(yamlString, CsiPowerstoreEnableChap, chap)
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorNode)
+		yamlString = strings.ReplaceAll(yamlString, CsiPowerstoreMaxVolumesPerNode, maxVolumesPerNode)
 	case "Controller":
 		for _, env := range cr.Spec.Driver.Controller.Envs {
 			if env.Name == "X_CSI_NFS_ACLS" {

--- a/samples/storage_csm_powerstore_v280.yaml
+++ b/samples/storage_csm_powerstore_v280.yaml
@@ -31,8 +31,8 @@ spec:
       #   true: enable storage capacity tracking
       #   false: disable storage capacity tracking
       storageCapacity: true
-    # Config version for CSI PowerStore v2.7.0 driver
-    configVersion: v2.7.0
+    # Config version for CSI PowerStore v2.8.0 driver
+    configVersion: v2.8.0
     # authSecret: This is the secret used to validate the default PowerStore secret used for installation
     # Allowed values: <metadataName specified in the Manifest>-config
     # For example: If the metadataName is set to powerstore, authSecret value should be set to powerstore-config
@@ -43,8 +43,8 @@ spec:
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerStore driver v2.7.0
-      image: "dellemc/csi-powerstore:v2.7.0"
+      # Image for CSI PowerStore driver v2.8.0
+      image: "dellemc/csi-powerstore:v2.8.0"
       imagePullPolicy: IfNotPresent
       envs:
         - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
@@ -165,7 +165,7 @@ spec:
       #   false: disable Resiliency feature(do not deploy podmon sidecar)
       # Default value: false
       enabled: false
-      configVersion: v1.6.0
+      configVersion: v1.7.0
       components:
         - name: podmon-controller
           args:

--- a/tests/config/driverconfig/badDriver/v2.8.0/bad.yaml
+++ b/tests/config/driverconfig/badDriver/v2.8.0/bad.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.8.0/controller.yaml
+++ b/tests/config/driverconfig/badDriver/v2.8.0/controller.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.8.0/csidriver.yaml
+++ b/tests/config/driverconfig/badDriver/v2.8.0/csidriver.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/badDriver/v2.8.0/driver-config-params.yaml
+++ b/tests/config/driverconfig/badDriver/v2.8.0/driver-config-params.yaml
@@ -1,0 +1,5 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml
+ 

--- a/tests/config/driverconfig/badDriver/v2.8.0/upgrade-path.yaml
+++ b/tests/config/driverconfig/badDriver/v2.8.0/upgrade-path.yaml
@@ -1,0 +1,4 @@
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/powerstore/v2.8.0/bad.yaml
+++ b/tests/config/driverconfig/powerstore/v2.8.0/bad.yaml
@@ -1,0 +1,19 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+this snfoiasga
+ is
+
+ 843*&(*(% invalid YAml

--- a/tests/config/driverconfig/powerstore/v2.8.0/config.json
+++ b/tests/config/driverconfig/powerstore/v2.8.0/config.json
@@ -1,0 +1,12 @@
+[
+    {
+        "username": "admin",
+        "password": "password",
+        "globalID": "unique" ,
+        "blockProtocol": "auto",
+        "endpoint": "https://10.0.0.1/api/rest",
+        "skipCertificateValidation": true,
+        "nasName": "nas-server" ,
+        "nfsAcls": "0777"
+    }
+]

--- a/tests/config/driverconfig/powerstore/v2.8.0/controller.yaml
+++ b/tests/config/driverconfig/powerstore/v2.8.0/controller.yaml
@@ -1,0 +1,270 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["volumegroup.storage.dell.com"]
+    resources: ["dellcsivolumegroupsnapshots","dellcsivolumegroupsnapshots/status"]
+    verbs: ["create", "list", "watch", "delete", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots", "volumesnapshots/status"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  # below for resizer
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  # Permissions for CSIStorageCapacity
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-controller
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  selector:
+    matchLabels:
+      name: <DriverDefaultReleaseName>-controller
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: <DriverDefaultReleaseName>-controller
+    spec:
+      serviceAccountName: <DriverDefaultReleaseName>-controller
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: name
+                  operator: In
+                  values:
+                  - <DriverDefaultReleaseName>-controller
+            topologyKey: kubernetes.io/hostname 
+      containers:
+        - name: attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+            - "--worker-threads=130"
+            - "--resync=10s"
+            - "--timeout=130s"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--volume-name-prefix=csivol"
+            - "--volume-name-uuid-length=10"
+            - "--v=5"
+            - "--leader-election"
+            - "--default-fstype=ext4"
+            - "--extra-create-metadata"
+            - "--feature-gates=Topology=true"
+            - "--enable-capacity=false"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval=5m"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: snapshotter
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+            - "--snapshot-name-prefix=csisnap"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: external-health-monitor
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--http-endpoint=:8080"
+            - "--enable-node-watcher=true"
+            - "--monitor-interval=60s"
+            - "--timeout=180s"
+            - "--leader-election-renew-deadline=10s"
+            - "--leader-election-lease-duration=15s"
+            - "--leader-election-retry-period=5s"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: driver
+          image: dellemc/csi-powerstore:v2.8.0
+          imagePullPolicy: IfNotPresent
+          command: [ "/csi-powerstore" ]
+          args:
+            - "--array-config=/powerstore-config/config"
+            - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
+          env:
+            - name: ENABLE_TRACING
+              value:
+            - name: CSI_ENDPOINT
+              value: /var/run/csi/csi.sock
+            - name: X_CSI_MODE
+              value: controller
+            - name: X_CSI_DRIVER_NAME
+              value: "csi-powerstore.dellemc.com"
+            - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
+              value: <X_CSI_POWERSTORE_EXTERNAL_ACCESS>
+            - name: X_CSI_NFS_ACLS
+              value: "<X_CSI_NFS_ACLS>"
+            - name: X_CSI_POWERSTORE_CONFIG_PATH
+              value: /powerstore-config/config
+            - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
+              value: /powerstore-config-params/driver-config-params.yaml
+            - name: GOPOWERSTORE_DEBUG
+              value: true
+            - name: CSI_AUTO_ROUND_OFF_FILESYSTEM_SIZE
+              value: false
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+            - name: powerstore-config
+              mountPath: /powerstore-config
+            - name: powerstore-config-params
+              mountPath: /powerstore-config-params
+      volumes:
+        - name: socket-dir
+          emptyDir:
+        - name: powerstore-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+        - name: powerstore-config
+          secret:
+            secretName: <DriverDefaultReleaseName>-config

--- a/tests/config/driverconfig/powerstore/v2.8.0/csidriver.yaml
+++ b/tests/config/driverconfig/powerstore/v2.8.0/csidriver.yaml
@@ -1,0 +1,27 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi-powerstore.dellemc.com
+spec:
+  storageCapacity: false
+  podInfoOnMount: true
+  fsGroupPolicy: ReadWriteOnceWithFSType
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral

--- a/tests/config/driverconfig/powerstore/v2.8.0/driver-config-params.yaml
+++ b/tests/config/driverconfig/powerstore/v2.8.0/driver-config-params.yaml
@@ -1,0 +1,25 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: <DriverDefaultReleaseNamespace>
+data:
+  driver-config-params.yaml: |
+    CSI_LOG_LEVEL: "debug"
+    CSI_LOG_FORMAT: "JSON"

--- a/tests/config/driverconfig/powerstore/v2.8.0/node.yaml
+++ b/tests/config/driverconfig/powerstore/v2.8.0/node.yaml
@@ -1,0 +1,244 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["create", "delete", "get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["privileged"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-node
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-node
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  selector:
+    matchLabels:
+      app: <DriverDefaultReleaseName>-node
+  template:
+    metadata:
+      labels:
+        app: <DriverDefaultReleaseName>-node
+        driver.dellemc.com: dell-storage
+    spec:
+      #nodeSelector:
+      #tolerations:
+      serviceAccount: <DriverDefaultReleaseName>-node
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      hostIPC: true
+      containers:
+        - name: driver
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: dellemc/csi-powerstore:v2.6.0
+          imagePullPolicy:  IfNotPresent
+          command: [ "/csi-powerstore" ]
+          args:
+            - "--array-config=/powerstore-config/config"
+            - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
+          env:
+            - name: ENABLE_TRACING
+              value:
+            - name: CSI_ENDPOINT
+              value: unix://<KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com/csi_sock
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+              value: <X_CSI_POWERSTORE_NODE_NAME_PREFIX>
+            - name: X_CSI_POWERSTORE_NODE_ID_PATH
+              value: /node-id
+            - name: X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE
+              value: <X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE>
+            - name: X_CSI_POWERSTORE_NODE_CHROOT_PATH
+              value: /noderoot
+            - name: X_CSI_POWERSTORE_TMP_DIR
+              value: <KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com/tmp
+            - name: X_CSI_DRIVER_NAME
+              value: "csi-powerstore.dellemc.com"
+            - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
+              value: <X_CSI_FC_PORTS_FILTER_FILE_PATH>
+            - name: X_CSI_POWERSTORE_ENABLE_CHAP
+              value: "<X_CSI_POWERSTORE_ENABLE_CHAP>"
+            - name: X_CSI_POWERSTORE_CONFIG_PATH
+              value: /powerstore-config/config
+            - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
+              value: /powerstore-config-params/driver-config-params.yaml
+            - name: GOPOWERSTORE_DEBUG
+              value: "true"
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+          volumeMounts:
+            - name: driver-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com
+            - name: csi-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
+              mountPropagation: "Bidirectional"
+            - name: pods-path
+              mountPath: <KUBELET_CONFIG_DIR>/pods
+              mountPropagation: "Bidirectional"
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+            - name: run
+              mountPath: /run
+            - name: node-id
+              mountPath: /node-id
+            - name: etciscsi
+              mountPath: /etc/iscsi
+            - name: mpath
+              mountPath: /etc/multipath.conf
+            - name: noderoot
+              mountPath: /noderoot
+            - name: powerstore-config
+              mountPath: /powerstore-config
+            - name: powerstore-config-params
+              mountPath: /powerstore-config-params
+        - name: registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - --kubelet-registration-path=<KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com/csi_sock
+          env:
+            - name: ADDRESS
+              value: /csi/csi_sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: registration-dir
+              mountPath: /registration
+            - name: driver-path
+              mountPath: /csi
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins_registry/
+            type: DirectoryOrCreate
+        - name: driver-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/csi-powerstore.dellemc.com
+            type: DirectoryOrCreate
+        - name: csi-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
+        - name: pods-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/pods
+            type: Directory
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: node-id
+          hostPath:
+            path: /etc/machine-id
+            type: File
+        - name: etciscsi
+          hostPath:
+            path: /etc/iscsi
+            type: DirectoryOrCreate
+        - name: mpath
+          hostPath:
+            path: /etc/multipath.conf
+            type: FileOrCreate
+        - name: noderoot
+          hostPath:
+            path: /
+            type: Directory
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: run
+          hostPath:
+            path: /run
+            type: Directory
+        - name: powerstore-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+        - name: powerstore-config
+          secret:
+            secretName: <DriverDefaultReleaseName>-config
+        - name: usr-bin
+          hostPath:
+            path: /usr/bin
+            type: Directory
+        - name: kubelet-pods
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: var-run
+          hostPath:
+            path: /var/run
+            type: Directory

--- a/tests/config/driverconfig/powerstore/v2.8.0/node.yaml
+++ b/tests/config/driverconfig/powerstore/v2.8.0/node.yaml
@@ -91,7 +91,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: dellemc/csi-powerstore:v2.6.0
+          image: dellemc/csi-powerstore:v2.8.0
           imagePullPolicy:  IfNotPresent
           command: [ "/csi-powerstore" ]
           args:

--- a/tests/config/driverconfig/powerstore/v2.8.0/upgrade-path.yaml
+++ b/tests/config/driverconfig/powerstore/v2.8.0/upgrade-path.yaml
@@ -1,0 +1,16 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+minUpgradePath: v2.7.0


### PR DESCRIPTION
# Description

- Changes for adding support of volume limits feature.
- Added PowerStore v2.8.0 config.
- Added Resiliency v1.7.0 config.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/878 |
| https://github.com/dell/csm/issues/885 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran make unit-test
- [x] Verified the feature after installing the driver via csm-operator.  Further volume creation is not happening as per the value set to the parameter X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE as expected by the feature.