### PR TITLE
Add resiliency image label and extra args in sample yaml files

### DIFF
--- a/samples/storage_csm_powerflex_v270.yaml
+++ b/samples/storage_csm_powerflex_v270.yaml
@@ -322,16 +322,22 @@ spec:
       configVersion: v1.6.0
       components:
         - name: podmon-controller
+          image: dellemc/podmon:v1.6.0
+          imagePullPolicy: IfNotPresent
           args:
             - "--labelvalue=csi-vxflexos"
             - "--skipArrayConnectionValidation=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 3 args should not be modified.
             - "--csisock=unix:/var/run/csi/csi.sock"
             - "--mode=controller"
             - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
         - name: podmon-node
+          image: dellemc/podmon:v1.6.0
+          imagePullPolicy: IfNotPresent
           envs:
             # podmonAPIPort: Defines the port to be used within the kubernetes cluster
             # Allowed values: Any valid and free port (string)
@@ -343,6 +349,8 @@ spec:
             - "--leaderelection=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 3 args should not be modified.
             - "--csisock=unix:/var/lib/kubelet/plugins/vxflexos.emc.dell.com/csi_sock"
             - "--mode=node"

--- a/samples/storage_csm_powerscale_v270.yaml
+++ b/samples/storage_csm_powerscale_v270.yaml
@@ -443,18 +443,24 @@ spec:
       configVersion: v1.6.0
       components:
         - name: podmon-controller
+          image: dellemc/podmon:v1.6.0
+          imagePullPolicy: IfNotPresent
           args:
             - "--labelvalue=csi-isilon"
             - "--arrayConnectivityPollRate=60"
             - "--skipArrayConnectionValidation=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/run/csi/csi.sock"
             - "--mode=controller"
             - "--driverPath=csi-isilon.dellemc.com"
             - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
         - name: podmon-node
+          image: dellemc/podmon:v1.6.0
+          imagePullPolicy: IfNotPresent
           envs:
             # podmonAPIPort: Defines the port to be used within the kubernetes cluster
             # Allowed values: Any valid and free port (string)
@@ -467,6 +473,8 @@ spec:
             - "--leaderelection=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"
             - "--mode=node"

--- a/samples/storage_csm_powerstore_v270.yaml
+++ b/samples/storage_csm_powerstore_v270.yaml
@@ -163,18 +163,24 @@ spec:
       configVersion: v1.6.0
       components:
         - name: podmon-controller
+          image: dellemc/podmon:v1.6.0
+          imagePullPolicy: IfNotPresent
           args:
             - "--labelvalue=csi-powerstore"
             - "--arrayConnectivityPollRate=60"
             - "--skipArrayConnectionValidation=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/run/csi/csi.sock"
             - "--mode=controller"
             - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
             - "--driverPath=csi-powerstore.dellemc.com"
         - name: podmon-node
+          image: dellemc/podmon:v1.6.0
+          imagePullPolicy: IfNotPresent
           envs:
             # podmonAPIPort: Defines the port to be used within the kubernetes cluster
             # Allowed values: Any valid and free port (string)
@@ -187,6 +193,8 @@ spec:
             - "--leaderelection=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/csi_sock"
             - "--mode=node"

--- a/samples/storage_csm_powerstore_v280.yaml
+++ b/samples/storage_csm_powerstore_v280.yaml
@@ -168,18 +168,24 @@ spec:
       configVersion: v1.7.0
       components:
         - name: podmon-controller
+          image: dellemc/podmon:v1.7.0
+          imagePullPolicy: IfNotPresent
           args:
             - "--labelvalue=csi-powerstore"
             - "--arrayConnectivityPollRate=60"
             - "--skipArrayConnectionValidation=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/run/csi/csi.sock"
             - "--mode=controller"
             - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
             - "--driverPath=csi-powerstore.dellemc.com"
         - name: podmon-node
+          image: dellemc/podmon:v1.7.0
+          imagePullPolicy: IfNotPresent
           envs:
             # podmonAPIPort: Defines the port to be used within the kubernetes cluster
             # Allowed values: Any valid and free port (string)
@@ -192,6 +198,8 @@ spec:
             - "--leaderelection=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/csi_sock"
             - "--mode=node"


### PR DESCRIPTION
# Description
Add image label to sample configuration files for resiliency so that the users can customize the image to deploy resiliency with operator. Also added the extra args as per user's request.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/898|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Deployed the driver with resiliency enabled in e2e test on a local Kubernetes setup. Modified the resiliency image to use different versions/tags and repos to verify that users can specify a different resiliency image.