### PR TITLE
Remove resiliency duplicated extra args in sample yaml files

### DIFF
--- a/samples/storage_csm_powerscale_v270.yaml
+++ b/samples/storage_csm_powerscale_v270.yaml
@@ -451,7 +451,6 @@ spec:
             - "--skipArrayConnectionValidation=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityPollRate=5"
             - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/run/csi/csi.sock"
@@ -473,7 +472,6 @@ spec:
             - "--leaderelection=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityPollRate=5"
             - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"

--- a/samples/storage_csm_powerscale_v280.yaml
+++ b/samples/storage_csm_powerscale_v280.yaml
@@ -451,7 +451,6 @@ spec:
             - "--skipArrayConnectionValidation=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityPollRate=5"
             - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/run/csi/csi.sock"
@@ -473,7 +472,6 @@ spec:
             - "--leaderelection=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityPollRate=5"
             - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"

--- a/samples/storage_csm_powerstore_v270.yaml
+++ b/samples/storage_csm_powerstore_v270.yaml
@@ -171,7 +171,6 @@ spec:
             - "--skipArrayConnectionValidation=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityPollRate=5"
             - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/run/csi/csi.sock"
@@ -193,7 +192,6 @@ spec:
             - "--leaderelection=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityPollRate=5"
             - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/csi_sock"

--- a/samples/storage_csm_powerstore_v280.yaml
+++ b/samples/storage_csm_powerstore_v280.yaml
@@ -176,7 +176,6 @@ spec:
             - "--skipArrayConnectionValidation=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityPollRate=5"
             - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/run/csi/csi.sock"
@@ -198,7 +197,6 @@ spec:
             - "--leaderelection=false"
             - "--driverPodLabelValue=dell-storage"
             - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityPollRate=5"
             - "--arrayConnectivityConnectionLossThreshold=3"
             # Below 4 args should not be modified.
             - "--csisock=unix:/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/csi_sock"


### PR DESCRIPTION
# Description
Remove the duplicated `arrayConnectivityPollRate` args in CR yaml files.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/898 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Deployed the driver with resiliency enabled in e2e test on a local Kubernetes setup. Modified the resiliency image to use different versions/tags and repos to verify that users can specify a different resiliency image.
