### PR TITLE
Update base image from ubi-minimal to ubi9 micro image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,8 @@ COPY tests/ tests/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Tag corresponding to digest sha256:82d08fba0a8322ff0c39934efe6972ccbf152dfb4639fb7a5765192f674e3eaa is 8.8-860
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:82d08fba0a8322ff0c39934efe6972ccbf152dfb4639fb7a5765192f674e3eaa
-
-RUN microdnf install yum \
-    && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \
-    && yum clean all \
-    && rpm -e yum \
-    && microdnf clean all
+# Tag corresponding to digest sha256:18a01cb5c53560ca2295e8a218454fe33b330ad6fac0d0ea43a513cd93787b7f for ubi9 micro is 9.2-9
+FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:18a01cb5c53560ca2295e8a218454fe33b330ad6fac0d0ea43a513cd93787b7f
 
 ENV USER_UID=1001 \
     USER_NAME=dell-csm-operator

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:18a01cb5c53560ca2295e8a218454fe33b330ad6fac0d0ea43a513cd93787b7f
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
# Description
Update UBI image to ubi-micro with ubi9

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/922 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

1. Build the image and ensured that are no build errors
2. Did one round of sanity by installing the operator followed by Unity driver install. This scenario was tried in both OLM and non-OLM environments
