### PR TITLE
powerflex: support added for NFS

### DIFF
--- a/config/samples/storage_v1_csm_powerflex.yaml
+++ b/config/samples/storage_v1_csm_powerflex.yaml
@@ -33,6 +33,12 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value: ""
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
 
     sideCars:
     # sdc-monitor is disabled by default, due to high CPU usage 

--- a/operatorconfig/driverconfig/powerflex/v2.8.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.8.0/controller.yaml
@@ -212,6 +212,12 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: false
+            - name: X_CSI_NFS_ACLS
+              value: <X_CSI_NFS_ACLS>
+            - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+              value: <X_CSI_POWERFLEX_EXTERNAL_ACCESS>
+            - name: X_CSI_QUOTA_ENABLED
+              value: <X_CSI_QUOTA_ENABLED>
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -45,6 +45,15 @@ const (
 
 	// CsiVxflexosMaxVolumesPerNode - Max volumes that the controller could schedule on a node
 	CsiVxflexosMaxVolumesPerNode = "<X_CSI_MAX_VOLUMES_PER_NODE>"
+
+	// CsiVxflexosNfsAcls - Enables setting permissions on NFS mount directory
+	CsiVxflexosNfsAcls = "<X_CSI_NFS_ACLS>"
+
+	// CsiVxflexosExternaAccess - Specify additional entries for host to access NFS volumes
+	CsiVxflexosExternaAccess = "<X_CSI_POWERFLEX_EXTERNAL_ACCESS>"
+
+	// CsiVxflexosQuotaEnabled - Flag to enable/disable setting of quota for NFS volumes
+	CsiVxflexosQuotaEnabled = "<X_CSI_QUOTA_ENABLED>"
 )
 
 // PrecheckPowerFlex do input validation
@@ -223,6 +232,9 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 	renameSdcEnabled := ""
 	renameSdcPrefix := ""
 	maxVolumesPerNode := ""
+	nfsAcls := ""
+	externalAscess := ""
+	enableQuota := ""
 
 	switch fileType {
 	case "Node":
@@ -239,11 +251,23 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 			if env.Name == "X_CSI_MAX_VOLUMES_PER_NODE" {
 				maxVolumesPerNode = env.Value
 			}
+			if env.Name == "X_CSI_NFS_ACLS" {
+				nfsAcls = env.Value
+			}
+			if env.Name == "X_CSI_POWERFLEX_EXTERNAL_ACCESS" {
+				externalAscess = env.Value
+			}
+			if env.Name == "X_CSI_QUOTA_ENABLED" {
+				enableQuota = env.Value
+			}
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiApproveSdcEnabled, approveSdcEnabled)
 		yamlString = strings.ReplaceAll(yamlString, CsiRenameSdcEnabled, renameSdcEnabled)
 		yamlString = strings.ReplaceAll(yamlString, CsiPrefixRenameSdc, renameSdcPrefix)
 		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosMaxVolumesPerNode, maxVolumesPerNode)
+		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosNfsAcls, nfsAcls)
+		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosExternaAccess, externalAscess)
+		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosQuotaEnabled, enableQuota)
 
 	}
 	return yamlString

--- a/samples/storage_csm_powerflex_v280.yaml
+++ b/samples/storage_csm_powerflex_v280.yaml
@@ -33,6 +33,12 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value: ""
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
 
     sideCars:
     # sdc-monitor is disabled by default, due to high CPU usage 

--- a/tests/config/driverconfig/powerflex/v2.8.0/controller.yaml
+++ b/tests/config/driverconfig/powerflex/v2.8.0/controller.yaml
@@ -212,6 +212,12 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: false
+            - name: X_CSI_NFS_ACLS
+              value: "0777"
+            - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+              value: ""
+            - name: X_CSI_QUOTA_ENABLED
+              value: false
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/tests/e2e/testfiles/storage_csm_powerflex.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex.yaml
@@ -35,6 +35,12 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value: ""
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
 
 
     sideCars:

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_1.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_1.yaml
@@ -35,6 +35,12 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "1"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value: ""
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
 
 
     sideCars:

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_2.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_2.yaml
@@ -35,6 +35,12 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value: ""
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
 
 
     sideCars:

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_3.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_3.yaml
@@ -35,6 +35,12 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value: ""
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
 
 
     sideCars:

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_4.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_4.yaml
@@ -35,6 +35,12 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value: ""
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
 
 
     sideCars:

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_5.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_5.yaml
@@ -35,6 +35,12 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value: ""
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
 
 
     sideCars:


### PR DESCRIPTION
# Description
Changes added for NFS support in PowerFlex.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/763 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit test (refer GitHub actions workflow)
- [x] Functional test, executed 1vol-nfs helm test
- [x] e2e tests

controller pod with env vars set for driver:
```
driver:
    Container ID:  containerd://b2939bxxxxxxxxxxxx
    Image:         <local-artifactory>:5036/csi-vxflexos:vmain-latest
    Image ID:      <local-artifactory>:5036/csi-vxflexos@sha256:c23420xxxxxxxxxxxx
    Port:          <none>
    Host Port:     <none>
    Command:
      /csi-vxflexos.sh
    Args:
      --leader-election
      --array-config=/vxflexos-config/config
      --driver-config-params=/vxflexos-config-params/driver-config-params.yaml
    State:          Running
      Started:      Mon, 07 Aug 2023 08:40:10 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      CSI_ENDPOINT:                             /var/run/csi/csi.sock
      X_CSI_MODE:                               controller
      X_CSI_VXFLEXOS_ENABLESNAPSHOTCGDELETE:    false
      X_CSI_VXFLEXOS_ENABLELISTVOLUMESNAPSHOT:  false
      SSL_CERT_DIR:                             /certs
      X_CSI_HEALTH_MONITOR_ENABLED:             false
      X_CSI_NFS_ACLS:                           0777
      X_CSI_POWERFLEX_EXTERNAL_ACCESS:
      X_CSI_QUOTA_ENABLED:                      true
```
1vol-nfs test events:
```
Events:
  Type    Reason                  Age   From                     Message
  ----    ------                  ----  ----                     -------
  Normal  Scheduled               22s   default-scheduler        Successfully assigned helmtest-vxflexos/vxflextest-0 to worker-1-k8vqcgtjmfu8k.domain
  Normal  SuccessfulAttachVolume  20s   attachdetach-controller  AttachVolume.Attach succeeded for volume "k8s-46a5c22bc9"
  Normal  Pulling                 14s   kubelet                  Pulling image "docker.io/centos:latest"
  Normal  Pulled                  14s   kubelet                  Successfully pulled image "docker.io/centos:latest" in 533.962187ms (533.981681ms including waiting)
  Normal  Created                 14s   kubelet                  Created container test
  Normal  Started                 14s   kubelet                  Started container test
10.x.x.x:/k8s-46a5c22bc9   8388608  1582336   6806272  19% /data0
10.x.x.x:/k8s-46a5c22bc9 on /data0 type nfs4 (rw,relatime,vers=4.2,rsize=262144,wsize=262144,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=10.x.x.x,local_lock=none,addr=10.x.x.x)
```