### PR TITLE
Storage Capacity Tracking for CSI-Powerflex

### DIFF
--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -798,10 +798,10 @@ metadata:
                     "value": "0"
                   }
                 ],
-                "image": "dellemc/csi-vxflexos:v2.7.0",
+                "image": "dellemc/csi-vxflexos:v2.8.0",
                 "imagePullPolicy": "IfNotPresent"
               },
-              "configVersion": "v2.7.0",
+              "configVersion": "v2.8.0",
               "controller": {
                 "envs": [
                   {
@@ -813,7 +813,8 @@ metadata:
                 "tolerations": null
               },
               "csiDriverSpec": {
-                "fSGroupPolicy": "File"
+                "fSGroupPolicy": "File",
+                "storageCapacity": true
               },
               "csiDriverType": "powerflex",
               "dnsPolicy": "ClusterFirstWithHostNet",

--- a/config/samples/storage_v1_csm_powerflex.yaml
+++ b/config/samples/storage_v1_csm_powerflex.yaml
@@ -11,6 +11,11 @@ spec:
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
       fSGroupPolicy: "File"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
     configVersion: v2.8.0
     replicas: 1
     dnsPolicy: ClusterFirstWithHostNet
@@ -56,6 +61,11 @@ spec:
       - name: csi-external-health-monitor-controller
         enabled: false
         args: ["--monitor-interval=60s"]
+      # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+      # Configure when the storageCapacity is set as "true"
+      # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=5m"]
 
     controller:
       envs:

--- a/operatorconfig/driverconfig/powerflex/v2.8.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.8.0/controller.yaml
@@ -68,6 +68,13 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "update"]
+  # Permissions for CSIStorageCapacity
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -141,9 +148,20 @@ spec:
             - "--v=5"
             - "--default-fstype=ext4"
             - "--extra-create-metadata"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval=5m"
           env:
             - name: ADDRESS
               value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/operatorconfig/driverconfig/powerflex/v2.8.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.8.0/csidriver.yaml
@@ -6,6 +6,7 @@ spec:
     fsGroupPolicy: ReadWriteOnceWithFSType
     attachRequired: true
     podInfoOnMount: true
+    storageCapacity: false
     volumeLifecycleModes: 
     - Persistent
     - Ephemeral

--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -398,6 +398,8 @@ func GetCSIDriver(ctx context.Context, cr csmv1.ContainerStorageModule, operator
 		YamlString = ModifyPowerScaleCR(YamlString, cr, "CSIDriverSpec")
 	case "powermax":
 		YamlString = ModifyPowermaxCR(YamlString, cr, "CSIDriverSpec")
+	case "powerflex":
+		YamlString = ModifyPowerflexCR(YamlString, cr, "CSIDriverSpec")
 	case "unity":
 		YamlString = ModifyUnityCR(YamlString, cr, "CSIDriverSpec")
 	}

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -232,6 +232,7 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 	renameSdcEnabled := ""
 	renameSdcPrefix := ""
 	maxVolumesPerNode := ""
+	storageCapacity := "false"
 	nfsAcls := ""
 	externalAscess := ""
 	enableQuota := ""
@@ -265,10 +266,14 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 		yamlString = strings.ReplaceAll(yamlString, CsiRenameSdcEnabled, renameSdcEnabled)
 		yamlString = strings.ReplaceAll(yamlString, CsiPrefixRenameSdc, renameSdcPrefix)
 		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosMaxVolumesPerNode, maxVolumesPerNode)
+	case "CSIDriverSpec":
+		if cr.Spec.Driver.CSIDriverSpec.StorageCapacity {
+			storageCapacity = "true"
+		}
+		yamlString = strings.ReplaceAll(yamlString, CsiStorageCapacityEnabled, storageCapacity)
 		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosNfsAcls, nfsAcls)
 		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosExternaAccess, externalAscess)
 		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosQuotaEnabled, enableQuota)
-
 	}
 	return yamlString
 }

--- a/samples/storage_csm_powerflex_v280.yaml
+++ b/samples/storage_csm_powerflex_v280.yaml
@@ -11,6 +11,11 @@ spec:
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
       fSGroupPolicy: "File"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
     configVersion: v2.8.0
     replicas: 1
     dnsPolicy: ClusterFirstWithHostNet
@@ -56,6 +61,11 @@ spec:
       - name: csi-external-health-monitor-controller
         enabled: false
         args: ["--monitor-interval=60s"]
+    # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+    # Configure when the storageCapacity is set as "true"
+    # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+    #- name: provisioner
+    #  args: ["--capacity-poll-interval=5m"]
 
     controller:
       envs:

--- a/tests/config/driverconfig/powerflex/v2.8.0/controller.yaml
+++ b/tests/config/driverconfig/powerflex/v2.8.0/controller.yaml
@@ -68,6 +68,13 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "update"]
+  # Permissions for CSIStorageCapacity
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -141,9 +148,20 @@ spec:
             - "--v=5"
             - "--default-fstype=ext4"
             - "--extra-create-metadata"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval=5m"
           env:
             - name: ADDRESS
               value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/tests/config/driverconfig/powerflex/v2.8.0/csidriver.yaml
+++ b/tests/config/driverconfig/powerflex/v2.8.0/csidriver.yaml
@@ -6,6 +6,7 @@ spec:
     fsGroupPolicy: ReadWriteOnceWithFSType
     attachRequired: true
     podInfoOnMount: true
+    storageCapacity: true
     volumeLifecycleModes: 
     - Persistent
     - Ephemeral

--- a/tests/e2e/testfiles/storage_csm_powerflex.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex.yaml
@@ -11,6 +11,11 @@ spec:
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
       fSGroupPolicy: "File"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
     configVersion: v2.8.0
     replicas: 1
     dnsPolicy: ClusterFirstWithHostNet
@@ -59,6 +64,11 @@ spec:
       - name: csi-external-health-monitor-controller
         enabled: false
         args: ["--monitor-interval=60s"]
+      # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+      # Configure when the storageCapacity is set as "true"
+      # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=5m"]
 
     controller:
       envs:


### PR DESCRIPTION
# Description
This PR adds addresses changes in csm-operator to support Storage Capacity Tracking feature for PowerFlex driver

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| (https://github.com/dell/csm/issues/876) |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Deployed driver using csm-operator with sct flag set to true and described csi-driver. StorageCapacity is enabled and csistoraagecapacitiesobjects are created. Successfully executed Cert-CSI test suites and StorageCapacity Functional test suites. Test Suites passed 100%
- [x] Deployed driver using csm-operator with sct flag set to false and described csi-driver. StorageCapacity is not enabled
<img width="379" alt="sctoperatorenabled" src="https://github.com/dell/csm-operator/assets/110008193/87d386d5-bde2-46d4-9031-b2dd318e2d2d">
<img width="496" alt="Screenshot 2023-08-17 231102" src="https://github.com/dell/csm-operator/assets/110008193/2bd62670-948c-4e96-a621-f31436abd003">

```
INFO 1. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 8Gi}
INFO 2. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 8Gi}
INFO 3. VolumeIoSuite {volumes: 2, volumeSize: 8Gi chains: 2-2}
INFO 4. SnapSuite {snapshots: 3, volumeSize; 8Gi}
INFO 5. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 8Gi}
Does it look OK? (Y)es/(n)o
-> y
INFO Avg time of a run:   60.37s
INFO Avg time of a del:   13.81s
INFO Avg time of all:     79.24s
INFO During this run 100.0% of suites succeeded
------------------------------------------------------------
./cert-csi functional-test capacity-tracking --sc vxflexos-xfs --drns vxflexos --pi 5m
INFO Starting cert-csi; ver. 0.8.1
INFO Using EVENT observer type
INFO Using default config
INFO Successfully loaded config. Host: https://
INFO Created new KubeClient
INFO Found 1 topology segment(s) in csinode
INFO Creating capacity-tracking-4367b929 storage class
INFO Waiting for CSIStorageCapacity to be CREATED for capacity-tracking-4367b929 storage class in vxflexos namespace
INFO All CSIStorageCapacity are created in 2.005263936s
INFO Deleting capacity-tracking-4367b929 storage class,
INFO Waiting for CSIStorageCapacity to be DELETED for capacity-tracking-4367b929 storage class in vxflexos namespace
INFO All CSIStorageCapacity are deleted in 2.005498431s
INFO Updating CSIStorageCapacity for vxflexos-xfs storage class, setting capacity to 0
INFO Creating capacity-tracking-pod-d0a8eb93 pod using vxflexos-xfs storage class
INFO capacity-tracking-pod-d0a8eb93 pod is PENDING
INFO Waiting for provisioner to POLL GetCapacity for vxflexos-xfs storage class in 5m0s
INFO Provisioner POLLED GetCapacity for vxflexos-xfs storage class
INFO Waiting for pod capacity-tracking-pod-d0a8eb93 to be READY
INFO capacity-tracking-pod-d0a8eb93 pod is RUNNING
INFO SUCCESS: CapacityTrackingSuite in 1m10.092508801s
INFO Trying to connect to cluster...
INFO Created new KubeClient
INFO During this run 100.0% of suites succeeded
```
