### PR TITLE
remove the externalAccess param from csi-powerflex.

### DIFF
--- a/config/samples/storage_v1_csm_powerflex.yaml
+++ b/config/samples/storage_v1_csm_powerflex.yaml
@@ -40,8 +40,6 @@ spec:
           value: "0"
         - name: X_CSI_NFS_ACLS
           value: "0777"
-        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-          value: ""
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/config/samples/storage_v1_csm_powerflex.yaml
+++ b/config/samples/storage_v1_csm_powerflex.yaml
@@ -52,7 +52,7 @@ spec:
         - name: HOST_PID
           value: "1"
         - name: MDM
-          value: "10.xx.xx.xx,10.xx.xx.xx" #provide MDM value
+          value: "10.xx.xx.xx,10.xx.xx.xx" #do not add mdm value here if it is present in secret
 
     # health monitor is disabled by default, refer to driver documentation before enabling it
     # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED  to "true".

--- a/operatorconfig/driverconfig/powerflex/v2.8.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.8.0/controller.yaml
@@ -232,8 +232,6 @@ spec:
               value: false
             - name: X_CSI_NFS_ACLS
               value: <X_CSI_NFS_ACLS>
-            - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-              value: <X_CSI_POWERFLEX_EXTERNAL_ACCESS>
             - name: X_CSI_QUOTA_ENABLED
               value: <X_CSI_QUOTA_ENABLED>
           volumeMounts:

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -49,9 +49,6 @@ const (
 	// CsiVxflexosNfsAcls - Enables setting permissions on NFS mount directory
 	CsiVxflexosNfsAcls = "<X_CSI_NFS_ACLS>"
 
-	// CsiVxflexosExternaAccess - Specify additional entries for host to access NFS volumes
-	CsiVxflexosExternaAccess = "<X_CSI_POWERFLEX_EXTERNAL_ACCESS>"
-
 	// CsiVxflexosQuotaEnabled - Flag to enable/disable setting of quota for NFS volumes
 	CsiVxflexosQuotaEnabled = "<X_CSI_QUOTA_ENABLED>"
 )
@@ -234,7 +231,6 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 	maxVolumesPerNode := ""
 	storageCapacity := "false"
 	nfsAcls := ""
-	externalAscess := ""
 	enableQuota := ""
 
 	switch fileType {
@@ -255,9 +251,6 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 			if env.Name == "X_CSI_NFS_ACLS" {
 				nfsAcls = env.Value
 			}
-			if env.Name == "X_CSI_POWERFLEX_EXTERNAL_ACCESS" {
-				externalAscess = env.Value
-			}
 			if env.Name == "X_CSI_QUOTA_ENABLED" {
 				enableQuota = env.Value
 			}
@@ -272,7 +265,6 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiStorageCapacityEnabled, storageCapacity)
 		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosNfsAcls, nfsAcls)
-		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosExternaAccess, externalAscess)
 		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosQuotaEnabled, enableQuota)
 	}
 	return yamlString

--- a/samples/storage_csm_powerflex_v280.yaml
+++ b/samples/storage_csm_powerflex_v280.yaml
@@ -40,8 +40,6 @@ spec:
           value: "0"
         - name: X_CSI_NFS_ACLS
           value: "0777"
-        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-          value: ""
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/samples/storage_csm_powerflex_v280.yaml
+++ b/samples/storage_csm_powerflex_v280.yaml
@@ -52,7 +52,7 @@ spec:
         - name: HOST_PID
           value: "1"
         - name: MDM
-          value: "10.xx.xx.xx,10.xx.xx.xx" #provide MDM value
+          value: "10.xx.xx.xx,10.xx.xx.xx" #do not add mdm value here if it is present in secret
 
     # health monitor is disabled by default, refer to driver documentation before enabling it
     # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED  to "true".

--- a/tests/config/driverconfig/powerflex/v2.8.0/controller.yaml
+++ b/tests/config/driverconfig/powerflex/v2.8.0/controller.yaml
@@ -232,8 +232,6 @@ spec:
               value: false
             - name: X_CSI_NFS_ACLS
               value: "0777"
-            - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-              value: ""
             - name: X_CSI_QUOTA_ENABLED
               value: false
           volumeMounts:

--- a/tests/e2e/testfiles/storage_csm_powerflex.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex.yaml
@@ -42,8 +42,6 @@ spec:
           value: "0"
         - name: X_CSI_NFS_ACLS
           value: "0777"
-        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-          value: ""
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_1.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_1.yaml
@@ -37,8 +37,6 @@ spec:
           value: "1"
         - name: X_CSI_NFS_ACLS
           value: "0777"
-        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-          value: ""
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_2.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_2.yaml
@@ -37,8 +37,6 @@ spec:
           value: "0"
         - name: X_CSI_NFS_ACLS
           value: "0777"
-        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-          value: ""
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_3.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_3.yaml
@@ -37,8 +37,6 @@ spec:
           value: "0"
         - name: X_CSI_NFS_ACLS
           value: "0777"
-        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-          value: ""
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_4.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_4.yaml
@@ -37,8 +37,6 @@ spec:
           value: "0"
         - name: X_CSI_NFS_ACLS
           value: "0777"
-        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-          value: ""
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_5.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_5.yaml
@@ -37,8 +37,6 @@ spec:
           value: "0"
         - name: X_CSI_NFS_ACLS
           value: "0777"
-        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-          value: ""
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 


### PR DESCRIPTION
# Description
This pr removed the redundent parameter ExternalAccess for csi-powerflex from csm-operator.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/763 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit-test Refer github actions flow
- [x] Functional test, executed cert-csi and it passed with  100%
```
driver:
    Container ID:  containerd://16ced8c7a52d9883e9a146a316d56f9de612df36df897a3b46efceebc526dde8
    Image:         amaas-eos-mw1.cec.lab.emc.com:5036/csi-vxflexos:vmain-latest
    Image ID:      amaas-eos-mw1.cec.lab.emc.com:5036/csi-vxflexos@sha256:b69860968dcb74fe3bb05068a44c19adabbf4d766f19c07d6f17481f2fb1af56
    Port:          <none>
    Host Port:     <none>
    Command:
      /csi-vxflexos.sh
    Args:
      --leader-election
      --array-config=/vxflexos-config/config
      --driver-config-params=/vxflexos-config-params/driver-config-params.yaml
    State:          Running
      Started:      Fri, 01 Sep 2023 00:23:48 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      CSI_ENDPOINT:                             /var/run/csi/csi.sock
      X_CSI_MODE:                               controller
      X_CSI_VXFLEXOS_ENABLESNAPSHOTCGDELETE:    false
      X_CSI_VXFLEXOS_ENABLELISTVOLUMESNAPSHOT:  false
      SSL_CERT_DIR:                             /certs
      X_CSI_HEALTH_MONITOR_ENABLED:             false
      X_CSI_NFS_ACLS:                           0777
      X_CSI_QUOTA_ENABLED:                      false
```

```
[2023-09-01 03:48:28]  INFO Avg time of a run:   61.02s
[2023-09-01 03:48:28]  INFO Avg time of a del:   12.01s
[2023-09-01 03:48:28]  INFO Avg time of all:     77.57s
[2023-09-01 03:48:28]  INFO During this run 100.0% of suites succeeded
```
