### PR TITLE
remove the nfsAcls param from csi-powerflex.

### DIFF
--- a/config/samples/storage_v1_csm_powerflex.yaml
+++ b/config/samples/storage_v1_csm_powerflex.yaml
@@ -38,8 +38,6 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
-        - name: X_CSI_NFS_ACLS
-          value: "0777"
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/operatorconfig/driverconfig/powerflex/v2.8.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.8.0/controller.yaml
@@ -230,8 +230,6 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: false
-            - name: X_CSI_NFS_ACLS
-              value: <X_CSI_NFS_ACLS>
             - name: X_CSI_QUOTA_ENABLED
               value: <X_CSI_QUOTA_ENABLED>
           volumeMounts:

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -46,9 +46,6 @@ const (
 	// CsiVxflexosMaxVolumesPerNode - Max volumes that the controller could schedule on a node
 	CsiVxflexosMaxVolumesPerNode = "<X_CSI_MAX_VOLUMES_PER_NODE>"
 
-	// CsiVxflexosNfsAcls - Enables setting permissions on NFS mount directory
-	CsiVxflexosNfsAcls = "<X_CSI_NFS_ACLS>"
-
 	// CsiVxflexosQuotaEnabled - Flag to enable/disable setting of quota for NFS volumes
 	CsiVxflexosQuotaEnabled = "<X_CSI_QUOTA_ENABLED>"
 )
@@ -230,7 +227,6 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 	renameSdcPrefix := ""
 	maxVolumesPerNode := ""
 	storageCapacity := "false"
-	nfsAcls := ""
 	enableQuota := ""
 
 	switch fileType {
@@ -248,9 +244,6 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 			if env.Name == "X_CSI_MAX_VOLUMES_PER_NODE" {
 				maxVolumesPerNode = env.Value
 			}
-			if env.Name == "X_CSI_NFS_ACLS" {
-				nfsAcls = env.Value
-			}
 			if env.Name == "X_CSI_QUOTA_ENABLED" {
 				enableQuota = env.Value
 			}
@@ -264,7 +257,6 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 			storageCapacity = "true"
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiStorageCapacityEnabled, storageCapacity)
-		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosNfsAcls, nfsAcls)
 		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosQuotaEnabled, enableQuota)
 	}
 	return yamlString

--- a/samples/storage_csm_powerflex_v280.yaml
+++ b/samples/storage_csm_powerflex_v280.yaml
@@ -38,8 +38,6 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
-        - name: X_CSI_NFS_ACLS
-          value: "0777"
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/config/driverconfig/powerflex/v2.8.0/controller.yaml
+++ b/tests/config/driverconfig/powerflex/v2.8.0/controller.yaml
@@ -230,8 +230,6 @@ spec:
               value: /certs
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: false
-            - name: X_CSI_NFS_ACLS
-              value: "0777"
             - name: X_CSI_QUOTA_ENABLED
               value: false
           volumeMounts:

--- a/tests/e2e/testfiles/storage_csm_powerflex.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex.yaml
@@ -40,8 +40,6 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
-        - name: X_CSI_NFS_ACLS
-          value: "0777"
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_1.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_1.yaml
@@ -35,8 +35,6 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "1"
-        - name: X_CSI_NFS_ACLS
-          value: "0777"
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_2.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_2.yaml
@@ -35,8 +35,6 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
-        - name: X_CSI_NFS_ACLS
-          value: "0777"
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_3.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_3.yaml
@@ -35,8 +35,6 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
-        - name: X_CSI_NFS_ACLS
-          value: "0777"
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_4.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_4.yaml
@@ -35,8 +35,6 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
-        - name: X_CSI_NFS_ACLS
-          value: "0777"
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_5.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_5.yaml
@@ -35,8 +35,6 @@ spec:
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"
           value: "0"
-        - name: X_CSI_NFS_ACLS
-          value: "0777"
         - name: X_CSI_QUOTA_ENABLED
           value: "false"
 


### PR DESCRIPTION
# Description
This pr removed the redundent parameter nfAcls for csi-powerflex from csm-operator.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/763  |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit-test Refer github actions flow
- [x] Functional test, executed cert-csi and it passed with 100%
   ```driver:
    Container ID:  containerd://e5fc74538227f6587bc6f61a30b28b4720f1567bd46ee5618962d5acefd05c4b
    Image:         xxxx/csi-vxflexos:remove-nfsAcls
    Image ID:      xxxxx/csi-vxflexos@sha256:7facbaeabd345003cb167185e510dc8cf5aa1b8361c91f645a97e3a7a1736ba3
    Port:          <none>
    Host Port:     <none>
    Command:
      /csi-vxflexos.sh
    Args:
      --leader-election
      --array-config=/vxflexos-config/config
      --driver-config-params=/vxflexos-config-params/driver-config-params.yaml
    State:          Running
      Started:      Tue, 05 Sep 2023 03:36:17 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      CSI_ENDPOINT:                             /var/run/csi/csi.sock
      X_CSI_MODE:                               controller
      X_CSI_VXFLEXOS_ENABLESNAPSHOTCGDELETE:    false
      X_CSI_VXFLEXOS_ENABLELISTVOLUMESNAPSHOT:  false
      SSL_CERT_DIR:                             /certs
      X_CSI_HEALTH_MONITOR_ENABLED:             false
      X_CSI_QUOTA_ENABLED:                      false

```
```  [2023-09-05 03:39:54]  INFO Avg time of a run:   84.03s
  [2023-09-05 03:39:54]  INFO Avg time of a del:   12.02s
  [2023-09-05 03:39:54]  INFO Avg time of all:     106.03s
  [2023-09-05 03:39:54]  INFO During this run 100.0% of suites succeeded
```
