### PR TITLE
AM deployment fixes and updates 

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -893,6 +893,18 @@ rules:
 - apiGroups:
   - velero.io
   resources:
+  - backuprepositories
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
   - backups
   verbs:
   - create
@@ -969,18 +981,6 @@ rules:
   - velero.io
   resources:
   - podvolumerestores
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - velero.io
-  resources:
-  - backuprepositories
   verbs:
   - create
   - delete

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -660,7 +660,6 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 		if err := r.reconcileAppMobility(ctx, false, operatorConfig, cr, ctrlClient); err != nil {
 			return fmt.Errorf("failed to deploy application mobility: %v", err)
 		}
-		return nil
 	}
 
 	//Create/Update Reverseproxy Server

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -676,6 +676,12 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 	if err != nil {
 		return err
 	}
+
+	// driverConfig = nil means no driver specified in manifest
+	if driverConfig == nil {
+		return nil
+	}
+
 	err = r.oldStandAloneModuleCleanup(ctx, &cr, operatorConfig, driverConfig)
 	if err != nil {
 		return err
@@ -982,6 +988,12 @@ func getDriverConfig(ctx context.Context,
 		log        = logger.GetLogger(ctx)
 	)
 
+	//if no driver is specified, return nil
+	if cr.Spec.Driver.CSIDriverType == "" {
+		log.Infof("No driver specified in manifest")
+		return nil, nil
+	}
+
 	// Get Driver resources
 	log.Infof("Getting %s CSI Driver for Dell Technologies", cr.Spec.Driver.CSIDriverType)
 	driverType := cr.Spec.Driver.CSIDriverType
@@ -1117,6 +1129,10 @@ func (r *ContainerStorageModuleReconciler) removeDriver(ctx context.Context, ins
 	if err != nil {
 		log.Error("error in getDriverConfig")
 		return err
+	}
+	// driverConfig = nil means no driver specified in manifest
+	if driverConfig == nil {
+		return nil
 	}
 
 	replicationEnabled, clusterClients, err := utils.GetDefaultClusters(ctx, instance, r)

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -485,6 +485,8 @@ func (suite *CSMControllerTestSuite) TestCsmFinalizerError() {
 // Test all edge cases in RemoveDriver
 func (suite *CSMControllerTestSuite) TestRemoveDriver() {
 	r := suite.createReconciler()
+	csmBadType := shared.MakeCSM(csmName, suite.namespace, configVersion)
+	csmBadType.Spec.Driver.CSIDriverType = "wrongdriver"
 	csmWoType := shared.MakeCSM(csmName, suite.namespace, configVersion)
 	csm := shared.MakeCSM(csmName, suite.namespace, configVersion)
 	csm.Spec.Driver.CSIDriverType = "powerscale"
@@ -495,7 +497,9 @@ func (suite *CSMControllerTestSuite) TestRemoveDriver() {
 		errorInjector *bool
 		expectedErr   string
 	}{
-		{"getDriverConfig error", csmWoType, nil, "no such file or directory"},
+		{"getDriverConfig error", csmBadType, nil, "no such file or directory"},
+		// don't return error if there's no driver- could be a valid case like Auth server or App Mobility
+		{"getDriverConfig no driver", csmWoType, nil, ""},
 		// can't find objects since they are not created. In this case error is nil
 		{"delete obj not found", csm, nil, ""},
 		{"get SA error", csm, &getSAError, getSAErrorStr},
@@ -539,6 +543,8 @@ func (suite *CSMControllerTestSuite) TestRemoveDriver() {
 func (suite *CSMControllerTestSuite) TestSyncCSM() {
 	r := suite.createReconciler()
 	csm := shared.MakeCSM(csmName, suite.namespace, configVersion)
+	csmBadType := shared.MakeCSM(csmName, suite.namespace, configVersion)
+	csmBadType.Spec.Driver.CSIDriverType = "wrongdriver"
 	authProxyServerCSM := shared.MakeCSM(csmName, suite.namespace, configVersion)
 	authProxyServerCSM.Spec.Modules = getAuthProxyServer()
 	appMobCSM := shared.MakeCSM(csmName, suite.namespace, configVersion)
@@ -556,7 +562,8 @@ func (suite *CSMControllerTestSuite) TestSyncCSM() {
 		{"app mobility happy path", appMobCSM, operatorConfig, ""},
 		{"app mobility bad op conf", appMobCSM, badOperatorConfig, "failed to deploy application mobility"},
 		{"reverse proxy server bad op conf", reverseProxyServerCSM, badOperatorConfig, "failed to deploy reverseproxy proxy server"},
-		{"getDriverConfig bad op config", csm, badOperatorConfig, "no such file or directory"},
+		{"getDriverConfig bad op config", csm, badOperatorConfig, ""},
+		{"getDriverConfig error", csmBadType, badOperatorConfig, "no such file or directory"},
 	}
 
 	for _, tt := range syncCSMTests {

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -1325,10 +1325,6 @@ func getAppMob() []csmv1.Module {
 							Value: "default",
 						},
 						{
-							Name:  "VELERO_NAMESPACE",
-							Value: "application-mobility",
-						},
-						{
 							Name:  "CONFIG_PROVIDER",
 							Value: "aws",
 						},

--- a/operatorconfig/moduleconfig/application-mobility/v0.3.0/app-mobility-controller-manager-metrics-service.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v0.3.0/app-mobility-controller-manager-metrics-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-  name: <NAMESPACE>-controller-manager-metrics-service
+  name: application-mobility-controller-manager-metrics-service
   namespace: <NAMESPACE>
 spec:
   ports:

--- a/operatorconfig/moduleconfig/application-mobility/v0.3.0/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v0.3.0/app-mobility-controller-manager.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-  name: <NAMESPACE>-controller-manager
+  name: application-mobility-controller-manager
   namespace: <NAMESPACE>
 spec:
   replicas: <APPLICATION_MOBILITY_REPLICA_COUNT>

--- a/operatorconfig/moduleconfig/application-mobility/v0.3.0/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v0.3.0/app-mobility-controller-manager.yaml
@@ -475,7 +475,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: <NAMESPACE>-leader-election-role
-  namespace: application-mobility
+  namespace: <NAMESPACE>
 rules:
 - apiGroups:
   - ""

--- a/operatorconfig/moduleconfig/application-mobility/v0.3.0/cleanupcrds.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v0.3.0/cleanupcrds.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: velero-cleanup-crds
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   labels:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: application-mobility

--- a/operatorconfig/moduleconfig/application-mobility/v0.3.0/node-agent.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v0.3.0/node-agent.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: application-mobility-node-agent
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   labels:
     app.kubernetes.io/name: application-mobility-velero
     app.kubernetes.io/instance: application-mobility

--- a/operatorconfig/moduleconfig/application-mobility/v0.3.0/velero-deployment.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v0.3.0/velero-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: velero.io/v1
 kind: BackupStorageLocation
 metadata:
   name: <BACKUPSTORAGELOCATION_NAME>
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   labels:
     app.kubernetes.io/name: application-mobility-velero
     app.kubernetes.io/instance: application-mobility
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/instance: application-mobility
 subjects:
   - kind: ServiceAccount
-    namespace: <VELERO_NAMESPACE>
+    namespace: <NAMESPACE>
     name: application-mobility-velero-server-service-account
 roleRef:
   kind: ClusterRole
@@ -38,7 +38,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: application-mobility-velero-server
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: application-mobility-velero
@@ -55,14 +55,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: application-mobility-velero-server
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: application-mobility-velero
     app.kubernetes.io/instance: application-mobility
 subjects:
   - kind: ServiceAccount
-    namespace: <VELERO_NAMESPACE>
+    namespace: <NAMESPACE>
     name: application-mobility-velero-server-service-account
 roleRef:
   kind: Role
@@ -73,7 +73,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: application-mobility-velero-server-service-account
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   annotations:
   labels:
     app.kubernetes.io/name: application-mobility-velero
@@ -83,7 +83,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: application-mobility-velero-server
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   annotations:
   labels:
     app.kubernetes.io/name: application-mobility-velero
@@ -103,7 +103,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: application-mobility-velero
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   annotations:
   labels:
     app.kubernetes.io/name: application-mobility-velero

--- a/operatorconfig/moduleconfig/application-mobility/v0.3.0/velero-secret.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v0.3.0/velero-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: <VELERO_ACCESS>
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   labels:
     app.kubernetes.io/name: application-mobility-velero
     app.kubernetes.io/instance: application-mobility

--- a/operatorconfig/moduleconfig/application-mobility/v0.3.0/velero-volumesnapshotlocation.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v0.3.0/velero-volumesnapshotlocation.yaml
@@ -2,7 +2,7 @@ apiVersion: velero.io/v1
 kind: VolumeSnapshotLocation
 metadata:
   name: <VOL_SNAPSHOT_LOCATION_NAME>
-  namespace: <VELERO_NAMESPACE>
+  namespace: <NAMESPACE>
   annotations:
   labels:
     app.kubernetes.io/name: velero

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -57,7 +57,7 @@ const (
 	// CertManagerIssuerCertManifest - filename of the issuer and cert for app-mobility
 	CertManagerIssuerCertManifest = "certificate.yaml"
 	//NodeAgentCrdManifest - filename of node-agent manifest for app-mobility
-	NodeAgentCrdManifest = "node-agent.yaml" 
+	NodeAgentCrdManifest = "node-agent.yaml"
 	//ControllerImg - image for app-mobility-controller
 	ControllerImg = "<CONTROLLER_IMAGE>"
 	// AppMobNamespace - namespace Application Mobility is installed in
@@ -468,15 +468,15 @@ func getCreateVeleroAccess(op utils.OperatorConfig, cr csmv1.ContainerStorageMod
 	access := ""
 
 	for _, component := range appMob.Components {
-			for _, cred := range component.ComponentCred {
-				if cred.Enabled {
-					credName = string(cred.Name)
-					accessID = string(cred.SecretContents.AccessKeyID)
-					access = string(cred.SecretContents.AccessKey)
+		for _, cred := range component.ComponentCred {
+			if cred.Enabled {
+				credName = string(cred.Name)
+				accessID = string(cred.SecretContents.AccessKeyID)
+				access = string(cred.SecretContents.AccessKey)
 
-				}
 			}
-		
+		}
+
 	}
 
 	yamlString = strings.ReplaceAll(yamlString, AppMobNamespace, cr.Namespace)

--- a/pkg/modules/testdata/cr_application_mobility.yaml
+++ b/pkg/modules/testdata/cr_application_mobility.yaml
@@ -58,11 +58,6 @@ spec:
           - name: "BUCKET_NAME"
             value: "my-bucket"
 
-          # Namespace for Velero installation
-          # Default value: application-mobility
-          - name: "VELERO_NAMESPACE"
-            value: "application-mobility"
-
           # Based on the objectstore being used, the velero plugin and its configuration may need to change!
           # default value: aws
           - name: "CONFIGURATION_PROVIDER"

--- a/samples/application-mobility/csm_application_mobility_v030.yaml
+++ b/samples/application-mobility/csm_application_mobility_v030.yaml
@@ -58,11 +58,6 @@ spec:
           - name: "BUCKET_NAME"
             value: "my-bucket"
 
-          # Namespace for Velero installation
-          # Default value: application-mobility
-          - name: "VELERO_NAMESPACE"
-            value: "application-mobility"
-
           # Based on the objectstore being used, the velero plugin and its configuration may need to change!
           # default value: aws
           - name: "CONFIGURATION_PROVIDER"

--- a/samples/application-mobility/csm_application_mobility_with_driver.yaml
+++ b/samples/application-mobility/csm_application_mobility_with_driver.yaml
@@ -1,0 +1,486 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: vxflexos-app-mobility
+  namespace: vxflexos
+spec:
+  driver:
+    csiDriverType: "powerflex"
+    csiDriverSpec:
+      # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+      # Allowed values: ReadWriteOnceWithFSType, File , None
+      # Default value: ReadWriteOnceWithFSType
+      fSGroupPolicy: "File"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
+    configVersion: v2.8.0
+    replicas: 1
+    dnsPolicy: ClusterFirstWithHostNet
+    forceUpdate: false
+    forceRemoveDriver: true
+    common:
+      image: "dellemc/csi-vxflexos:nightly"
+      imagePullPolicy: IfNotPresent
+      envs:
+        - name: X_CSI_VXFLEXOS_ENABLELISTVOLUMESNAPSHOT
+          value: "false"
+        - name: X_CSI_VXFLEXOS_ENABLESNAPSHOTCGDELETE
+          value: "false"
+        - name: X_CSI_DEBUG
+          value: "true"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: None
+        - name: KUBELET_CONFIG_DIR
+          value: "/var/lib/kubelet"
+        - name: "CERT_SECRET_COUNT"
+          value: "0"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value: ""
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
+
+    sideCars:
+    # sdc-monitor is disabled by default, due to high CPU usage 
+      - name: sdc-monitor
+        enabled: false
+        image: dellemc/sdc:3.6.2
+        envs:
+        - name: HOST_PID
+          value: "1"
+        - name: MDM
+          value: "10.xx.xx.xx,10.xx.xx.xx" #provide MDM value
+
+    # health monitor is disabled by default, refer to driver documentation before enabling it
+    # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED  to "true".
+      - name: csi-external-health-monitor-controller
+        enabled: false
+        args: ["--monitor-interval=60s"]
+    # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+    # Configure when the storageCapacity is set as "true"
+    # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+    #- name: provisioner
+    #  args: ["--capacity-poll-interval=5m"]
+
+    controller:
+      envs:
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin - volume condition.
+        # Install the 'external-health-monitor' sidecar accordingly.
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+
+      #"controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
+      # Leave as blank to use all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # "controller.tolerations" defines tolerations that would be applied to controller deployment
+      # Leave as blank to install controller on worker nodes
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint 
+      # - key: "node-role.kubernetes.io/master"   
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint 
+      # - key: "node-role.kubernetes.io/control-plane"   
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+
+    node:
+      envs:
+
+        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"  
+
+        # X_CSI_RENAME_SDC_ENABLED: Enable/Disable rename of SDC
+        # Allowed values:
+        #   true: enable renaming
+        #   false: disable renaming
+        # Default value: false
+        - name: X_CSI_RENAME_SDC_ENABLED
+          value: "false"
+
+        # X_CSI_RENAME_SDC_PREFIX: defines a string for prefix of the SDC name.
+        # "prefix" + "worker_node_hostname" should not exceed 31 chars.
+        # Default value: none
+        # Examples: "rhel-sdc", "sdc-test"
+        - name: X_CSI_RENAME_SDC_PREFIX
+          value: ""
+
+        # X_CSI_MAX_VOLUMES_PER_NODE: Defines the maximum PowerFlex volumes that can be created per node
+        # Allowed values: Any value greater than or equal to 0
+        # Default value: "0"
+        - name: X_CSI_MAX_VOLUMES_PER_NODE
+          value: "1"
+          
+          
+
+      # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
+      # Leave as blank to use all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # "node.tolerations" defines tolerations that would be applied to node daemonset
+      # Leave as blank to install node driver only on worker nodes
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # - key: "node-role.kubernetes.io/master"   
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint 
+      # - key: "node-role.kubernetes.io/control-plane"   
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+
+    initContainers:
+      - image: dellemc/sdc:3.6.1
+        imagePullPolicy: IfNotPresent
+        name: sdc
+        envs:
+          - name: MDM
+            value: "10.xx.xx.xx,10.xx.xx.xx"  #provide MDM value
+
+  modules:
+    # Authorization: enable csm-authorization for RBAC
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: false
+      configVersion: v1.7.0
+      components:
+      - name: karavi-authorization-proxy
+        image: dellemc/csm-authorization-sidecar:v1.7.0
+        envs:
+          # proxyHost: hostname of the csm-authorization server
+          - name: "PROXY_HOST"
+            value: "csm-authorization.com"
+        
+          # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server       
+          - name: "SKIP_CERTIFICATE_VALIDATION"
+            value: "true"
+
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: false
+      configVersion: v1.5.0
+      components:
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: false
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: dellemc/csm-topology:v1.5.0
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"
+
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: false
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: otel/opentelemetry-collector:0.42.0
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.20"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.20"
+
+        # enabled: Enable/Disable cert-manager
+        # Allowed values:
+        #   true: enable deployment of cert-manager
+        #   false: disable deployment of cert-manager only if it's already deployed
+        # Default value: false
+        - name: cert-manager
+          enabled: false
+
+        - name: metrics-powerflex
+          # enabled: Enable/Disable PowerFlex metrics
+          enabled: false
+          # image: Defines PowerFlex metrics image. This shouldn't be changed
+          image: dellemc/csm-metrics-powerflex:v1.5.0
+          envs:
+            # POWERFLEX_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerFlex
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERFLEX_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERFLEX_SDC_METRICS_ENABLED: enable/disable collection of sdc metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERFLEX_SDC_METRICS_ENABLED"
+              value: "true"
+            # POWERFLEX_VOLUME_METRICS_ENABLED: enable/disable collection of volume metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERFLEX_VOLUME_METRICS_ENABLED"
+              value: "true"
+            # POWERFLEX_STORAGE_POOL_METRICS_ENABLED: enable/disable collection of storage pool metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERFLEX_STORAGE_POOL_METRICS_ENABLED"
+              value: "true"
+            # POWERFLEX_SDC_IO_POLL_FREQUENCY: set polling frequency to get sdc metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERFLEX_SDC_IO_POLL_FREQUENCY"
+              value: "10"
+            # POWERFLEX_VOLUME_IO_POLL_FREQUENCY: set polling frequency to get volume metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERFLEX_VOLUME_IO_POLL_FREQUENCY"
+              value: "10"
+            # POWERFLEX_STORAGE_POOL_POLL_FREQUENCY: set polling frequency to get Quota capacity metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERFLEX_STORAGE_POOL_POLL_FREQUENCY"
+              value: "10"
+            # PowerFlex metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERFLEX_LOG_LEVEL"
+              value: "INFO"
+            # PowerFlex Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERFLEX_LOG_FORMAT"
+              value: "TEXT"
+            # Otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"
+
+    # Replication: allows to configure replication
+    # Replication CRDs must be installed before installing driver
+    - name: replication
+      # enabled: Enable/Disable replication feature
+      # Allowed values:
+      #   true: enable replication feature(install dell-csi-replicator sidecar)
+      #   false: disable replication feature(do not install dell-csi-replicator sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.5.0
+      components:
+      - name: dell-csi-replicator
+        # image: Image to use for dell-csi-replicator. This shouldn't be changed
+        # Allowed values: string
+        # Default value: None
+        image: dellemc/dell-csi-replicator:v1.5.0
+        envs:
+          # replicationPrefix: prefix to prepend to storage classes parameters
+          # Allowed values: string
+          # Default value: replication.storage.dell.com
+          - name: "X_CSI_REPLICATION_PREFIX"
+            value: "replication.storage.dell.com"
+          # replicationContextPrefix: prefix to use for naming of resources created by replication feature
+          # Allowed values: string
+          - name: "X_CSI_REPLICATION_CONTEXT_PREFIX"
+            value: "powerflex"
+      
+      - name: dell-replication-controller-manager
+        # image: Defines controller image. This shouldn't be changed
+        # Allowed values: string
+        image: dellemc/dell-replication-controller:v1.5.0
+        envs:
+          # TARGET_CLUSTERS_IDS: comma separated list of cluster IDs of the targets clusters. DO NOT include the source(wherever CSM Operator is deployed) cluster ID
+          # Set the value to "self" in case of stretched/single cluster configuration
+          # Allowed values: string
+          - name: "TARGET_CLUSTERS_IDS"
+            value: "target-cluster-1"
+          # Replication log level
+          # Allowed values: "error", "warn"/"warning", "info", "debug"
+          # Default value: "debug"
+          - name: "REPLICATION_CTRL_LOG_LEVEL"
+            value: "debug"
+          
+          # replicas: Defines number of controller replicas
+          # Allowed values: int
+          # Default value: 1
+          - name: "REPLICATION_CTRL_REPLICAS"
+            value: "1"
+          # retryIntervalMin: Initial retry interval of failed reconcile request.
+          # It doubles with each failure, upto retry-interval-max
+          # Allowed values: time
+          - name: "RETRY_INTERVAL_MIN"
+            value: "1s"
+          # RETRY_INTERVAL_MAX: Maximum retry interval of failed reconcile request
+          # Allowed values: time
+          - name: "RETRY_INTERVAL_MAX"
+            value: "5m"
+      - name: dell-replication-controller-init
+        # image: Defines replication init container image. This shouldn't be changed
+        # Allowed values: string
+        image: dellemc/dell-replication-init:v1.0.1
+
+    - name: resiliency
+      # enabled: Enable/Disable Resiliency feature
+      # Allowed values:
+      #   true: enable Resiliency feature(deploy podmon sidecar)
+      #   false: disable Resiliency feature(do not deploy podmon sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.7.0
+      components:
+        - name: podmon-controller
+          image: dellemc/podmon:v1.7.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--labelvalue=csi-vxflexos"
+            - "--skipArrayConnectionValidation=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
+            # Below 3 args should not be modified.
+            - "--csisock=unix:/var/run/csi/csi.sock"
+            - "--mode=controller"
+            - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
+        - name: podmon-node
+          image: dellemc/podmon:v1.7.0
+          imagePullPolicy: IfNotPresent
+          envs:
+            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
+            # Allowed values: Any valid and free port (string)
+            # Default value: 8083
+            - name: "X_CSI_PODMON_API_PORT"
+              value: "8083"
+          args:
+            - "--labelvalue=csi-vxflexos"
+            - "--leaderelection=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
+            # Below 3 args should not be modified.
+            - "--csisock=unix:/var/lib/kubelet/plugins/vxflexos.emc.dell.com/csi_sock"
+            - "--mode=node"
+            - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
+  modules:
+    # Application Mobility: enable csm-application-mobility module
+    - name: application-mobility
+      # enable: Enable/Disable app-mobility controller
+      enabled: true
+      configVersion: v0.3.0
+      forceRemoveModule: true
+      components:
+      - name: application-mobility-controller-manager
+        # enable: Enable/Disable application mobility controller-manager
+        enabled: true
+        image: 
+        imagePullPolicy: IfNotPresent
+        envs:
+          # Replica count for application mobility
+          # Allowed values: string
+          # Default value: 1
+          - name: "APPLICATION_MOBILITY_REPLICA_COUNT"
+            value: "1"
+
+          # License for application mobility
+          # Default value: license
+          - name: "APPLICATION_MOBILITY_LICENSE_NAME"
+            value: "license" 
+
+      # enabled: Enable/Disable cert-manager
+      # Allowed values:
+      #   true: enable deployment of cert-manager
+      #   false: disable deployment of cert-manager only if it's already deployed
+      # Default value: false
+      - name: cert-manager
+        enabled: true
+      # enabled: Enable/Disable Velero
+      - name: velero
+        image: velero/velero:v1.10.0
+        imagePullPolicy: IfNotPresent
+        enabled: true
+        useVolumeSnapshot: false
+        cleanUpCRDs: false
+        # enabled: Enable/Disable node-agent service
+        deployNodeAgent: true
+        envs:
+          # Backup storage location name
+          # Allowed values: string
+          # Default value: default
+          - name: "BACKUPSTORAGELOCATION_NAME"
+            value: "default"
+          
+          # Velero bucket name
+          # Allowed values: string
+          # Default value: my-bucket
+          - name: "BUCKET_NAME"
+            value: "my-bucket"
+
+          # Based on the objectstore being used, the velero plugin and its configuration may need to change!
+          # default value: aws
+          - name: "CONFIGURATION_PROVIDER"
+            value: "aws"
+
+          # Name of the volume snapshot location where snapshots are being taken. Required.
+          # Volume-snapshot-Location Provider will be same as CONFIGURATION_PROVIDER
+          # Default value : default
+          - name: "VOL_SNAPSHOT_LOCATION_NAME"
+            value: "default"
+          
+          # Name of the backup storage url
+          # This field HAS to be changed to a functional backup storage url 
+          # Default value: localhost:8000
+          - name: "BACKUP_STORAGE_URL"
+            value: ""
+
+          # Name of the secret in velero namespace that has credentials to access object store
+          # We can leave the field empty if there no existing secret in velero installed namespace 
+          # Default value: existing-cred
+          - name: "APPLICATION_MOBILITY_OBJECT_STORE_SECRET_NAME"
+            value: "existing-cred"
+
+        #If velero is not already present in cluster, set enabled to true to create a secret. 
+        #Either this or APPLICATION_MOBILITY_OBJECT_STORE_SECRET_NAME above must be provided.   
+        credentials:
+          - enabled: true  
+            #Specify the name to be used for secret that will be created to hold object store credentials.
+            name: cloud-creds
+            #Specify the object store access credentials to be stored in a secret with key "cloud".
+            secretContents: 
+              aws_access_key_id:   #Provide the access key id here
+              aws_secret_access_key: #provide the access key here 
+              
+
+    # Init containers to be added to the Velero and Node-agent deployment's spec.
+    - initContainer:
+        #initContainer image for the dell velero plugin
+      - name: dell-custom-velero-plugin
+        image:
+
+        #initContainer image for the configuration provider aws
+      - name: velero-plugin-for-aws
+        image:

--- a/tests/e2e/testfiles/csm_application_mobility_cert_manager.yaml
+++ b/tests/e2e/testfiles/csm_application_mobility_cert_manager.yaml
@@ -58,11 +58,6 @@ spec:
           - name: "BUCKET_NAME"
             value: "my-bucket"
 
-          # Namespace for Velero installation
-          # Default value: application-mobility
-          - name: "VELERO_NAMESPACE"
-            value: "application-mobility"
-
           # Based on the objectstore being used, the velero plugin and its configuration may need to change!
           # default value: aws
           - name: "CONFIGURATION_PROVIDER"

--- a/tests/e2e/testfiles/csm_application_mobility_controller_diff_env.yaml
+++ b/tests/e2e/testfiles/csm_application_mobility_controller_diff_env.yaml
@@ -58,11 +58,6 @@ spec:
           - name: "BUCKET_NAME"
             value: "my-bucket"
 
-          # Namespace for Velero installation
-          # Default value: application-mobility
-          - name: "VELERO_NAMESPACE"
-            value: "application-mobility"
-
           # Based on the objectstore being used, the velero plugin and its configuration may need to change!
           # default value: aws
           - name: "CONFIGURATION_PROVIDER"

--- a/tests/e2e/testfiles/csm_application_mobility_test_velero.yaml
+++ b/tests/e2e/testfiles/csm_application_mobility_test_velero.yaml
@@ -58,11 +58,6 @@ spec:
           - name: "BUCKET_NAME"
             value: "my-bucket"
 
-          # Namespace for Velero installation
-          # Default value: application-mobility
-          - name: "VELERO_NAMESPACE"
-            value: "application-mobility"
-
           # Based on the objectstore being used, the velero plugin and its configuration may need to change!
           # default value: aws
           - name: "CONFIGURATION_PROVIDER"

--- a/tests/e2e/testfiles/csm_application_mobility_vanilla.yaml
+++ b/tests/e2e/testfiles/csm_application_mobility_vanilla.yaml
@@ -58,11 +58,6 @@ spec:
           - name: "BUCKET_NAME"
             value: "my-bucket"
 
-          # Namespace for Velero installation
-          # Default value: application-mobility
-          - name: "VELERO_NAMESPACE"
-            value: "application-mobility"
-
           # Based on the objectstore being used, the velero plugin and its configuration may need to change!
           # default value: aws
           - name: "CONFIGURATION_PROVIDER"

--- a/tests/e2e/testfiles/csm_application_mobility_velero_diff_env.yaml
+++ b/tests/e2e/testfiles/csm_application_mobility_velero_diff_env.yaml
@@ -58,11 +58,6 @@ spec:
           - name: "BUCKET_NAME"
             value: "my-alt-bucket"
 
-          # Namespace for Velero installation
-          # Default value: application-mobility
-          - name: "VELERO_NAMESPACE"
-            value: "velero"
-
           # Based on the objectstore being used, the velero plugin and its configuration may need to change!
           # default value: aws
           - name: "CONFIGURATION_PROVIDER"


### PR DESCRIPTION
# Description
This PR updates and fixes deployment of AM for Operator: 
1. Remove VELERO_NAMESPACE parameter 
2. Edit controllers.go to allow for AM and driver deployment from single yaml
   - getDriverConfig now returns nil when no driver is specified instead of error 
   - removeDriver and syncCSM will now check getDriverConfig return before returning nil for cases where there is no driver Before:
  ```
  1.6946133137718441e+09  ERROR   Reconciler error        {"controller": "containerstoragemodule", "controllerGroup": "storage.dell.com", "controllerKind": "ContainerStorageModule", "containerStorageModule": {"name":"application-mobility","namespace":"application-mobility"}, "namespace": "application-mobility", "name": "application-mobility", "reconcileID": "a366e5d9-8d63-454c-8e01-c83f45f88195", "error": "getting  configMap: open /etc/config/dell-csm-operator/driverconfig/driver-config-params.yaml: no such file or directory"}
  ```     
  
   After:
   ```
   2023-09-13T14:36:47.794Z        INFO    controllers/csm_controller.go:993       No driver specified in manifest {"TraceId": "application-mobility-15"}
   ```

3. Fixed yamls- removed hardcoded namespace value and changed name of controller-manager to prevent two pods from having too similar names when deploying AM and driver  
Before: 
```
vxflexos-controller-649dddb799-767vp           5/5     Running   0          8m26s
vxflexos-controller-manager-db868688b-pcnnr    2/2     Running   0          8m27s
```
4. Update status.go to check AM Daemonset - wasn't working earlier: didn't see bug earlier due to short-circuit 
Before: 
```
2023-09-13T14:35:26.564Z        ERROR   utils/status.go:382     HandleSuccess Driver status errorDaemonSet.apps "application-mobility-node" not found   {"TraceId": "application-mobility-11"}
```
After:
```
2023-09-13T16:33:41.810Z        INFO    utils/status.go:163     Changing nodeName for AM        {"TraceId": "application-mobility-15"}
2023-09-13T16:33:41.810Z        INFO    utils/status.go:167     nodeName is application-mobility-node-agent     {"TraceId": "application-mobility-15"}
2023-09-13T16:33:41.810Z        INFO    utils/status.go:186     Changing labels for AM  {"TraceId": "application-mobility-15"}
2023-09-13T16:33:41.810Z        INFO    utils/status.go:195     Label is application-mobility-node-agent        {"TraceId": "application-mobility-15"}
2023-09-13T16:33:41.810Z        INFO    utils/status.go:204     daemonset pod application-mobility-node-agent-kqbr9 : Running   {"TraceId": "application-mobility-15"}
2023-09-13T16:33:41.810Z        INFO    utils/status.go:204     daemonset pod application-mobility-node-agent-l4wm8 : Running   {"TraceId": "application-mobility-15"}
```  
5. Added sample AM + driver manifest: samples/application-mobility/csm_application_mobility_with_driver.yaml 
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran unit tests 
- [x] Ran backup + restore with deployed AM + driver CSM, see below for details ⬇️ 
```
[root@master-1-CMyNgvaXZTEw3 application-mobility]# kubectl create -f real_csm_application_mobility_with_driver.yaml
```
wait for all pods:
```
[root@master-1-CMyNgvaXZTEw3 application-mobility]# kubectl get pods -n vxflexos
NAME                                                      READY   STATUS    RESTARTS   AGE
application-mobility-controller-manager-db868688b-fvv86   2/2     Running   0          40s
application-mobility-node-agent-5z6w4                     1/1     Running   0          39s
application-mobility-node-agent-ng5s5                     1/1     Running   0          39s
application-mobility-velero-77fdb8f44f-78695              1/1     Running   0          39s
cert-manager-86c85f9b65-tlv87                             1/1     Running   0          2m19s
cert-manager-cainjector-55685f7d8c-j5knh                  1/1     Running   0          2m19s
cert-manager-webhook-c74c6bd9f-frfpd                      1/1     Running   0          2m19s
vxflexos-app-mobility-controller-ddc4944df-hb6f6          5/5     Running   0          39s
vxflexos-app-mobility-node-jpd8x                          2/2     Running   0          39s
vxflexos-app-mobility-node-r2kns                          2/2     Running   0          39s
```  
check CSM status:  
```
[root@master-1-CMyNgvaXZTEw3 application-mobility]# kubectl get csm -A
NAMESPACE   NAME                    CREATIONTIME   CSIDRIVERTYPE   CONFIGVERSION   STATE
vxflexos    vxflexos-app-mobility   2m25s          powerflex       v2.8.0          Succeeded
```
create Wordpress App:
```
kubectl apply -n wordpress -k sample-application
```  
check pods and wait sql init (~30 seconds max):
``` 
[root@master-1-CMyNgvaXZTEw3 demo]# kubectl get pods -n wordpress
NAME                               READY   STATUS    RESTARTS   AGE
wordpress-5584ff7f88-bmscq         1/1     Running   0          26s
wordpress-mysql-664b79468d-9wqls   1/1     Running   0          26s
```  
create backup:
 ```
 ./dellctl backup create backup1 --include-namespaces wordpress -n vxflexos
```
verify its created:
```
[root@master-1-CMyNgvaXZTEw3 demo]# ./dellctl backup get -n vxflexos
NAME      STATUS      CREATED                         EXPIRES                         STORAGE LOCATION   DATA MOVER   CLONED   TARGET CLUSTERS
backup1   Completed   2023-09-14 10:10:36 -0400 EDT   2023-10-14 10:10:36 -0400 EDT   default            Restic       false
```
create restore:
```
./dellctl restore create restore1 --from-backup backup1 -n vxflexos --namespace-mappings wordpress:res-wordpress
```
verify its completed:
```
[root@master-1-CMyNgvaXZTEw3 demo]# ./dellctl restore get restore1 -n vxflexos
NAME       BACKUP    STATUS      CREATED                         COMPLETED
restore1   backup1   Completed   2023-09-14 10:11:52 -0400 EDT   NA
```
check pods in restored ns:
```
[root@master-1-CMyNgvaXZTEw3 demo]# kubectl get pods -n res-wordpress
NAME                               READY   STATUS    RESTARTS   AGE
wordpress-5584ff7f88-bmscq         1/1     Running   0          90s
wordpress-mysql-664b79468d-9wqls   1/1     Running   0          90s
```
- [x] Ran above ⬆️ test with driver and AM installed in 2 separate manifests to ensure backwards compatibility 
```
kubectl create -f storage_csm_powerflex_v270.yaml
kubectl create -f csm_application_mobility_v030.yaml
```
```
[root@master-1-CMyNgvaXZTEw3 demo]# kubectl get csm -A
NAMESPACE              NAME                   CREATIONTIME   CSIDRIVERTYPE   CONFIGVERSION   STATE
application-mobility   application-mobility   13m                                            Succeeded
vxflexos               vxflexos               19m            powerflex       v2.7.0          Succeeded

```
