### PR TITLE
Powerstore: Added configurable volume prefix option

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -5,6 +5,7 @@ general:
     - CVE-2022-47629 # this will be removed with the libskba library is updated in the UBI image
     - CVE-2019-1010022
     - CVE-2023-0286
+    - CVE-2023-4911
 
   bestPracticeViolations:
     # list of best practies violatied that needs a fix

--- a/config/samples/storage_v1_csm_powerstore.yaml
+++ b/config/samples/storage_v1_csm_powerstore.yaml
@@ -57,6 +57,10 @@ spec:
           value: debug
 
     sideCars:
+      # 'csivol' represents a string prepended to each volume created by the CSI driver
+      - name: provisioner
+        args: ["--volume-name-prefix=csivol"]
+
       # health monitor is disabled by default, refer to driver documentation before enabling it
       - name: external-health-monitor
         enabled: false

--- a/samples/storage_csm_powerstore_v260.yaml
+++ b/samples/storage_csm_powerstore_v260.yaml
@@ -57,6 +57,10 @@ spec:
           value: debug
 
     sideCars:
+      # 'csivol' represents a string prepended to each volume created by the CSI driver
+      - name: provisioner
+        args: ["--volume-name-prefix=csivol"]
+
       # health monitor is disabled by default, refer to driver documentation before enabling it
       - name: external-health-monitor
         enabled: false

--- a/samples/storage_csm_powerstore_v270.yaml
+++ b/samples/storage_csm_powerstore_v270.yaml
@@ -57,6 +57,10 @@ spec:
           value: debug
 
     sideCars:
+      # 'csivol' represents a string prepended to each volume created by the CSI driver
+      - name: provisioner
+        args: ["--volume-name-prefix=csivol"]
+
       # health monitor is disabled by default, refer to driver documentation before enabling it
       - name: external-health-monitor
         enabled: false

--- a/samples/storage_csm_powerstore_v280.yaml
+++ b/samples/storage_csm_powerstore_v280.yaml
@@ -57,6 +57,10 @@ spec:
           value: debug
 
     sideCars:
+      # 'csivol' represents a string prepended to each volume created by the CSI driver
+      - name: provisioner
+        args: ["--volume-name-prefix=csivol"]
+
       # health monitor is disabled by default, refer to driver documentation before enabling it
       - name: external-health-monitor
         enabled: false


### PR DESCRIPTION
# Description
Added `volume-name-prefix` argument in `provisioner` sidecar for updating volume prefix 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/989 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Verified by updating the volume prefix in sample yaml, installed the driver, created volumes. The new prefix was getting updated.
