### PR TITLE
Adding CSMVersion

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -91,12 +91,16 @@ const (
 
 	// CSMFinalizerName -
 	CSMFinalizerName = "finalizer.dell.emc.com"
+
+	//CSMVersion -
+	CSMVersion = "v1.8.0"
 )
 
 var (
 	dMutex                          sync.RWMutex
 	configVersionKey                = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMOperatorConfigVersion")
 	previouslyAppliedCustomResource = fmt.Sprintf("%s/%s", MetadataPrefix, "previously-applied-configuration")
+	CSMVersionKey                   = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMVersion")
 
 	// StopWatch - watcher stop handle
 	StopWatch = make(chan struct{})
@@ -1245,6 +1249,9 @@ func applyConfigVersionAnnotations(ctx context.Context, instance *csmv1.Containe
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
+	annotations[CSMVersionKey] = CSMVersion
+	instance.SetAnnotations(annotations)
+
 	if _, ok := annotations[configVersionKey]; !ok {
 		annotations[configVersionKey] = instance.Spec.Driver.ConfigVersion
 		isUpdated = true

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -100,7 +100,8 @@ var (
 	dMutex                          sync.RWMutex
 	configVersionKey                = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMOperatorConfigVersion")
 	previouslyAppliedCustomResource = fmt.Sprintf("%s/%s", MetadataPrefix, "previously-applied-configuration")
-        // CSMVersionKey - CSM Module version
+
+        // CSMVersionKey - 
 	CSMVersionKey = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMVersion")
 
 	// StopWatch - watcher stop handle

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -92,7 +92,7 @@ const (
 	// CSMFinalizerName -
 	CSMFinalizerName = "finalizer.dell.emc.com"
 
-	//CSMVersion -
+	// CSMVersion -
 	CSMVersion = "v1.8.0"
 )
 
@@ -100,6 +100,7 @@ var (
 	dMutex                          sync.RWMutex
 	configVersionKey                = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMOperatorConfigVersion")
 	previouslyAppliedCustomResource = fmt.Sprintf("%s/%s", MetadataPrefix, "previously-applied-configuration")
+        // CSMVersionKey - CSM Module version
 	CSMVersionKey                   = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMVersion")
 
 	// StopWatch - watcher stop handle

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -101,7 +101,7 @@ var (
 	configVersionKey                = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMOperatorConfigVersion")
 	previouslyAppliedCustomResource = fmt.Sprintf("%s/%s", MetadataPrefix, "previously-applied-configuration")
 
-        // CSMVersionKey - 
+       // CSMVersionKey - 
 	CSMVersionKey = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMVersion")
 
 	// StopWatch - watcher stop handle

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -101,7 +101,7 @@ var (
 	configVersionKey                = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMOperatorConfigVersion")
 	previouslyAppliedCustomResource = fmt.Sprintf("%s/%s", MetadataPrefix, "previously-applied-configuration")
 
-       // CSMVersionKey - 
+	// CSMVersionKey -
 	CSMVersionKey = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMVersion")
 
 	// StopWatch - watcher stop handle

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -101,7 +101,7 @@ var (
 	configVersionKey                = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMOperatorConfigVersion")
 	previouslyAppliedCustomResource = fmt.Sprintf("%s/%s", MetadataPrefix, "previously-applied-configuration")
         // CSMVersionKey - CSM Module version
-	CSMVersionKey                   = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMVersion")
+	CSMVersionKey = fmt.Sprintf("%s/%s", MetadataPrefix, "CSMVersion")
 
 	// StopWatch - watcher stop handle
 	StopWatch = make(chan struct{})


### PR DESCRIPTION
# Description
Adding CSMVersion to annotation as a metadata that can be pulled and displayed in UI
current CSMVersion : V1.8.0

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
<img width="1028" alt="image" src="https://github.com/dell/csm-operator/assets/32352976/ed28499c-47e9-4141-93e0-957fc2fca6dd">

Ran e2e test for powerscale 
--------------------------------------------------------------

[2023-10-16 16:36:29]  INFO Avg time of a run:   244.79s
[2023-10-16 16:36:29]  INFO Avg time of a del:   12.01s
[2023-10-16 16:36:29]  INFO Avg time of all:     260.38s
[2023-10-16 16:36:29]  INFO During this run 100.0% of suites succeeded
Oct 16 16:36:29.152: INFO: Running /bin/bash [check_parameters.sh testfiles/powerscale_health_monitor_values.csv dell powerscale]
6 occurences of external-health-monitor with value  found in controller
1 occurences of X_CSI_HEALTH_MONITOR_ENABLED with value true found in controller
1 occurences of X_CSI_HEALTH_MONITOR_ENABLED with value true found in node
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 10/16/23 16:36:29.631
  STEP:      Executing  Delete custom resource [1] @ 10/16/23 16:36:29.651
  STEP:      Executing  Restore template [testfiles/powerscale-templates/powerscale-secret-template.yaml] for [pscale] @ 10/16/23 16:36:29.663
  STEP:      Executing  Restore template [testfiles/powerscale-templates/powerscale-storageclass-template.yaml] for [pscale] @ 10/16/23 16:36:29.718
  STEP: Ending: Install PowerScale Driver with health monitor
   @ 10/16/23 16:36:29.822
• [1095.477 seconds]
------------------------------

Ran 1 of 1 Specs in 1095.488 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 19m1.122352087s
Test Suite Passed

