### PR TITLE
fix am disable

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -625,7 +625,7 @@ func (r *ContainerStorageModuleReconciler) oldStandAloneModuleCleanup(ctx contex
 		}
 
 		//check if application mobility needs to be uninstalled
-		oldApplicationmobilityEnabled, oldObs := utils.IsModuleEnabled(ctx, *oldCR, csmv1.ApplicationMobility)
+		oldApplicationmobilityEnabled, _ := utils.IsModuleEnabled(ctx, *oldCR, csmv1.ApplicationMobility)
 		newApplicationmobilityEnabled, _ := utils.IsModuleEnabled(ctx, *newCR, csmv1.ApplicationMobility)
 
 		if oldApplicationmobilityEnabled && !newApplicationmobilityEnabled {

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -610,17 +610,16 @@ func (suite *CSMControllerTestSuite) TestRemoveModule() {
 func (suite *CSMControllerTestSuite) TestOldStandAloneModuleCleanup() {
 	tests := map[string]func(t *testing.T) (csm *csmv1.ContainerStorageModule, errorInjector *bool, expectedErr string){
 		"Success - Enable all modules": func(*testing.T) (*csmv1.ContainerStorageModule, *bool, string) {
-			suite.makeFakeCSM(csmName, suite.namespace, false, append(getReplicaModule(), getObservabilityModule()...))
-
+			suite.makeFakeCSM(csmName, suite.namespace, false, append(append(getReplicaModule(), getObservabilityModule()...), getAppMob()...))
 			csm := &csmv1.ContainerStorageModule{}
 			key := types.NamespacedName{Namespace: suite.namespace, Name: csmName}
 			err := suite.fakeClient.Get(ctx, key, csm)
 			assert.Nil(suite.T(), err)
-			csm.Spec.Modules = append(getReplicaModule(), getObservabilityModule()...)
+			csm.Spec.Modules = append(append(getReplicaModule(), getObservabilityModule()...), getAppMob()...)
 			return csm, &[]bool{false}[0], ""
 		},
 		"Success - Disable all modules": func(*testing.T) (*csmv1.ContainerStorageModule, *bool, string) {
-			suite.makeFakeCSM(csmName, suite.namespace, false, append(getReplicaModule(), getObservabilityModule()...))
+			suite.makeFakeCSM(csmName, suite.namespace, false, append(append(getReplicaModule(), getObservabilityModule()...), getAppMob()...))
 
 			csm := &csmv1.ContainerStorageModule{}
 			key := types.NamespacedName{Namespace: suite.namespace, Name: csmName}
@@ -628,13 +627,15 @@ func (suite *CSMControllerTestSuite) TestOldStandAloneModuleCleanup() {
 			assert.Nil(suite.T(), err)
 			replica := getReplicaModule()
 			replica[0].Enabled = false
+			appMob := getAppMob()
+			appMob[0].Enabled = false
 			obs := getObservabilityModule()
 			obs[0].Enabled = false
-			csm.Spec.Modules = append(replica, obs...)
+			csm.Spec.Modules = append(append(replica, obs...), appMob...)
 			return csm, &[]bool{false}[0], ""
 		},
 		"Success - Disable Components": func(*testing.T) (*csmv1.ContainerStorageModule, *bool, string) {
-			suite.makeFakeCSM(csmName, suite.namespace, false, append(getReplicaModule(), getObservabilityModule()...))
+			suite.makeFakeCSM(csmName, suite.namespace, false, append(append(getReplicaModule(), getObservabilityModule()...), getAppMob()...))
 
 			csm := &csmv1.ContainerStorageModule{}
 			key := types.NamespacedName{Namespace: suite.namespace, Name: csmName}
@@ -642,7 +643,9 @@ func (suite *CSMControllerTestSuite) TestOldStandAloneModuleCleanup() {
 			assert.Nil(suite.T(), err)
 			obs := getObservabilityModule()
 			obs[0].Components[0].Enabled = &[]bool{false}[0]
-			csm.Spec.Modules = append(getReplicaModule(), obs...)
+			appMob := getAppMob()
+			appMob[0].Components[0].Enabled = &[]bool{false}[0]
+			csm.Spec.Modules = append(append(getReplicaModule(), getObservabilityModule()...), getAppMob()...)
 			return csm, &[]bool{false}[0], ""
 		},
 	}


### PR DESCRIPTION
# Description
This PR fixes an issue I found while working on AM E2E tests for Operator

Issue:

You cannot "disable" AM module from CR. If we flip this value from true to false:
```  modules:
    # Application Mobility: enable csm-application-mobility module
    - name: application-mobility
      # enable: Enable/Disable app-mobility controller
      enabled: false
```
The AM pods remain 

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran new OP e2e [test ](https://github.com/dell/csm-operator/commit/4f1c7fbefab105573326e60b051e085081bd4bf2)to discover and verify this issue is fixed 
- [x] Ran controller unit test
