### PR TITLE
Fix serviceaccount error for ApexConnectivityClient

### DIFF
--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -2337,7 +2337,7 @@ spec:
         - apiGroups:
           - cache.example.com
           resources:
-          - ApexConnectivityClient
+          - apexconnectivityclients
           verbs:
           - create
           - delete
@@ -2349,13 +2349,13 @@ spec:
         - apiGroups:
           - cache.example.com
           resources:
-          - ApexConnectivityClient/finalizers
+          - apexconnectivityclients/finalizers
           verbs:
           - update
         - apiGroups:
           - cache.example.com
           resources:
-          - ApexConnectivityClient/status
+          - apexconnectivityclients/status
           verbs:
           - get
           - patch

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -2335,7 +2335,7 @@ spec:
           - update
           - watch
         - apiGroups:
-          - cache.example.com
+          - storage.dell.com
           resources:
           - apexconnectivityclients
           verbs:
@@ -2347,13 +2347,13 @@ spec:
           - update
           - watch
         - apiGroups:
-          - cache.example.com
+          - storage.dell.com
           resources:
           - apexconnectivityclients/finalizers
           verbs:
           - update
         - apiGroups:
-          - cache.example.com
+          - storage.dell.com
           resources:
           - apexconnectivityclients/status
           verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -298,32 +298,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cache.example.com
-  resources:
-  - ApexConnectivityClient
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cache.example.com
-  resources:
-  - ApexConnectivityClient/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - cache.example.com
-  resources:
-  - ApexConnectivityClient/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - cert-manager.io
   resources:
   - '*/*'
@@ -687,6 +661,32 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - storage.dell.com
+  resources:
+  - apexconnectivityclients
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.dell.com
+  resources:
+  - apexconnectivityclients/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - storage.dell.com
+  resources:
+  - apexconnectivityclients/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - storage.dell.com
   resources:

--- a/controllers/acc_controller.go
+++ b/controllers/acc_controller.go
@@ -98,9 +98,9 @@ var (
 	AccStopWatch = make(chan struct{})
 )
 
-//+kubebuilder:rbac:groups=cache.example.com,resources=ApexConnectivityClient,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=cache.example.com,resources=ApexConnectivityClient/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=cache.example.com,resources=ApexConnectivityClient/finalizers,verbs=update
+//+kubebuilder:rbac:groups=storage.dell.com,resources=apexconnectivityclients,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=storage.dell.com,resources=apexconnectivityclients/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=storage.dell.com,resources=apexconnectivityclients/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -344,7 +344,7 @@ rules:
 - apiGroups:
   - cache.example.com
   resources:
-  - ApexConnectivityClient
+  - apexconnectivityclients
   verbs:
   - create
   - delete
@@ -356,13 +356,13 @@ rules:
 - apiGroups:
   - cache.example.com
   resources:
-  - ApexConnectivityClient/finalizers
+  - apexconnectivityclients/finalizers
   verbs:
   - update
 - apiGroups:
   - cache.example.com
   resources:
-  - ApexConnectivityClient/status
+  - apexconnectivityclients/status
   verbs:
   - get
   - patch

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -342,7 +342,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cache.example.com
+  - storage.dell.com
   resources:
   - apexconnectivityclients
   verbs:
@@ -354,13 +354,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cache.example.com
+  - storage.dell.com
   resources:
   - apexconnectivityclients/finalizers
   verbs:
   - update
 - apiGroups:
-  - cache.example.com
+  - storage.dell.com
   resources:
   - apexconnectivityclients/status
   verbs:

--- a/operatorconfig/clientconfig/apexconnectivityclient/v0.1.0/statefulset.yaml
+++ b/operatorconfig/clientconfig/apexconnectivityclient/v0.1.0/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     helm.sh/chart: apex-client-k8s-0.2.0
     app.kubernetes.io/name: connectivity-client-docker-k8s
-    app.kubernetes.io/instance: ApexConnectivityClienttivityClient
+    app.kubernetes.io/instance: ApexConnectivityClient
     app.kubernetes.io/version: "0.2.0"
     app.kubernetes.io/managed-by: CSMOperator
 ---
@@ -87,7 +87,7 @@ metadata:
   labels:
     helm.sh/chart: apex-client-k8s-0.2.0
     app.kubernetes.io/name: connectivity-client-docker-k8s
-    app.kubernetes.io/instance: ApexConnectivityClienttivityClient
+    app.kubernetes.io/instance: ApexConnectivityClient
     app.kubernetes.io/version: "0.2.0"
     app.kubernetes.io/managed-by: CSMOperator
 spec:

--- a/tests/config/clientconfig/apex/v0.1.0/statefulset.yaml
+++ b/tests/config/clientconfig/apex/v0.1.0/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     helm.sh/chart: apex-client-k8s-0.2.0
     app.kubernetes.io/name: connectivity-client-docker-k8s
-    app.kubernetes.io/instance: ApexConnectivityClienttivityClient
+    app.kubernetes.io/instance: ApexConnectivityClient
     app.kubernetes.io/version: "0.2.0"
     app.kubernetes.io/managed-by: CSMOperator
 ---
@@ -87,7 +87,7 @@ metadata:
   labels:
     helm.sh/chart: apex-client-k8s-0.2.0
     app.kubernetes.io/name: connectivity-client-docker-k8s
-    app.kubernetes.io/instance: ApexConnectivityClienttivityClient
+    app.kubernetes.io/instance: ApexConnectivityClient
     app.kubernetes.io/version: "0.2.0"
     app.kubernetes.io/managed-by: CSMOperator
 spec:


### PR DESCRIPTION
# Description
[NOTE: this PR is for deploy-dcm-client, not main]
When deploying operator, the following ApexConnectivityClient-related error would show up in the operator logs and the pod would eventually go into a failed state: 

```
W1025 17:11:42.483744       1 reflector.go:533] pkg/mod/k8s.io/client-go@v0.27.2/tools/cache/reflector.go:231: failed to list *v1.ApexConnectivityClient: apexconnectivityclients.storage.dell.com is forbidden: User "system:serviceaccount:dell-csm-operator:dell-csm-operator-manager-service-account" cannot list resource "apexconnectivityclients" in API group "storage.dell.com" at the cluster scope
E1025 17:11:42.483773       1 reflector.go:148] pkg/mod/k8s.io/client-go@v0.27.2/tools/cache/reflector.go:231: Failed to watch *v1.ApexConnectivityClient: failed to list *v1.ApexConnectivityClient: apexconnectivityclients.storage.dell.com is forbidden: User "system:serviceaccount:dell-csm-operator:dell-csm-operator-manager-service-account" cannot list resource "apexconnectivityclients" in API group "storage.dell.com" at the cluster scope
```

This was fixed by updating the apigroup the ApexConnectivityClient from `cache.example.com` to `storage.dell.com` and by changing the resource name from `ApexConnectivityClient*` to `apexconnectivityclients*`.

Additionally, some typos were fixed.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Successfully installed csm-operator:
```
[root@rhel-ctrl csm-operator]# k logs -n dell-csm-operator   dell-csm-operator-controller-manager-6f6ff4cdcd-lwmbh
2023-10-25T21:39:37.324Z        DEBUG   workspace/main.go:82    Operator Version        {"TraceId": "main", "Version": "1.3.0+12", "Commit ID": "3c0a8d9bf49621682987cb63a7a37d71b8172935", "Commit SHA": "Wed, 25 Oct 2023 21:35:30 UTC"}
2023-10-25T21:39:37.324Z        DEBUG   workspace/main.go:83    Go Version: go1.21.3    {"TraceId": "main"}
2023-10-25T21:39:37.324Z        DEBUG   workspace/main.go:84    Go OS/Arch: linux/amd64 {"TraceId": "main"}
2023-10-25T21:39:37.377Z        INFO    workspace/main.go:98    Kubernetes environment  {"TraceId": "main"}
2023-10-25T21:39:37.378Z        INFO    workspace/main.go:135   Current kubernetes version is 1.27 which is a supported version         {"TraceId": "main"}
2023-10-25T21:39:37.378Z        INFO    workspace/main.go:146   Use ConfigDirectory /etc/config/dell-csm-operator       {"TraceId": "main"}
2023-10-25T21:39:37Z    INFO    controller-runtime.metrics      Metrics server is starting to listen    {"addr": ":8082"}
2023-10-25T21:39:37Z    INFO    setup   starting manager
2023-10-25T21:39:37Z    INFO    starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8082"}
2023-10-25T21:39:37Z    INFO    Starting server {"kind": "health probe", "addr": "[::]:8081"}
I1025 21:39:37.380719       1 leaderelection.go:245] attempting to acquire leader lease dell-csm-operator/090cae6a.dell.com...
I1025 21:39:53.998278       1 leaderelection.go:255] successfully acquired lease dell-csm-operator/090cae6a.dell.com
2023-10-25T21:39:53Z    DEBUG   events  dell-csm-operator-controller-manager-6f6ff4cdcd-lwmbh_f968222f-2490-4bec-bf4c-bc2ad0e3a90e became leader        {"type": "Normal", "object": {"kind":"Lease","namespace":"dell-csm-operator","name":"090cae6a.dell.com","uid":"d792d2a2-ac4d-4013-8ad5-fcda007296cd","apiVersion":"coordination.k8s.io/v1","resourceVersion":"8946479"}, "reason": "LeaderElection"}
2023-10-25T21:39:53Z    INFO    Starting EventSource    {"controller": "containerstoragemodule", "controllerGroup": "storage.dell.com", "controllerKind": "ContainerStorageModule", "source": "kind source: *v1.ContainerStorageModule"}
2023-10-25T21:39:53Z    INFO    Starting EventSource    {"controller": "apexconnectivityclient", "controllerGroup": "storage.dell.com", "controllerKind": "ApexConnectivityClient", "source": "kind source: *v1.ApexConnectivityClient"}
2023-10-25T21:39:53Z    INFO    Starting Controller     {"controller": "containerstoragemodule", "controllerGroup": "storage.dell.com", "controllerKind": "ContainerStorageModule"}
2023-10-25T21:39:53Z    INFO    Starting Controller     {"controller": "apexconnectivityclient", "controllerGroup": "storage.dell.com", "controllerKind": "ApexConnectivityClient"}
2023-10-25T21:39:54Z    INFO    Starting workers        {"controller": "containerstoragemodule", "controllerGroup": "storage.dell.com", "controllerKind": "ContainerStorageModule", "worker count": 1}
2023-10-25T21:39:54Z    INFO    Starting workers        {"controller": "apexconnectivityclient", "controllerGroup": "storage.dell.com", "controllerKind": "ApexConnectivityClient", "worker count": 1}
[root@rhel-ctrl csm-operator]#
```
