### PR TITLE
PowerFlex: Adding noderoot mount path

### DIFF
--- a/operatorconfig/driverconfig/powerflex/v2.9.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.9.0/node.yaml
@@ -118,6 +118,8 @@ spec:
             - name: pods-path
               mountPath: <KUBELET_CONFIG_DIR>/pods
               mountPropagation: "Bidirectional"
+            - name: noderoot
+              mountPath: /noderoot
             - name: dev
               mountPath: /dev
             - name: vxflexos-config
@@ -219,6 +221,10 @@ spec:
         - name: pods-path
           hostPath:
             path: <KUBELET_CONFIG_DIR>/pods
+            type: Directory
+        - name: noderoot
+          hostPath:
+            path: /
             type: Directory
         - name: dev
           hostPath:


### PR DESCRIPTION
# Description
Adding noderoot mount path to access root directory of the host from the node pod. We need this to run query_mdm command from the node pod on the worker host when driver calls the goscaleio call DrvCfgQuerySystems to fetch all the system ID's configured.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1020 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran make unit-test
![image](https://github.com/dell/csm-operator/assets/109594002/a5daf427-57b0-4f5e-890e-94050f979a3d)

