### PR TITLE
Removes storageCapacity from unsupported CSI PMAX versions

### DIFF
--- a/samples/storage_csm_powermax_v270.yaml
+++ b/samples/storage_csm_powermax_v270.yaml
@@ -26,11 +26,6 @@ spec:
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
       fSGroupPolicy: "ReadWriteOnceWithFSType"
-      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
-      # Allowed values:
-      #   true: enable storage capacity tracking
-      #   false: disable storage capacity tracking
-      storageCapacity: false
     # Config version for CSI PowerMax v2.7.0 driver
     configVersion: v2.7.0
     # replica: Define the number of PowerMax controller nodes

--- a/tests/config/driverconfig/powermax/v2.9.0/controller.yaml
+++ b/tests/config/driverconfig/powermax/v2.9.0/controller.yaml
@@ -315,7 +315,7 @@ spec:
               mountPath: /certs
               readOnly: true
             - name: powermax-config-params
-              mountPath: /csi-isilon-config-params
+              mountPath: /csi-powermax-config-params
       volumes:
         - name: socket-dir
           emptyDir:


### PR DESCRIPTION
Removes param that enables an unsupported feature in some CSI Powermax versions/samples.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/983 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
