### PR TITLE
Powermax csi-node-driver-registrar downgrade 

### DIFF
--- a/operatorconfig/driverconfig/powermax/v2.9.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.9.0/node.yaml
@@ -193,7 +193,7 @@ spec:
             - name: node-topology-config
               mountPath: /node-topology-config
         - name: registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.2
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/tests/config/driverconfig/powermax/v2.9.0/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.9.0/node.yaml
@@ -189,7 +189,7 @@ spec:
             - name: node-topology-config
               mountPath: /node-topology-config
         - name: registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.2
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"


### PR DESCRIPTION
# Description

Downgrade csi-node-driver-registrar to v2.9.1 due to the pull issue of `v2.9.2` image. Refer to : https://github.com/kubernetes-csi/node-driver-registrar/issues/359

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1012 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran Sanity test
