### PR TITLE
[bug-1073]: Use 4096 bit size in certificates

### DIFF
--- a/samples/authorization/certificate_v170.yaml
+++ b/samples/authorization/certificate_v170.yaml
@@ -22,7 +22,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth

--- a/samples/authorization/certificate_v180.yaml
+++ b/samples/authorization/certificate_v180.yaml
@@ -22,7 +22,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth

--- a/samples/authorization/certificate_v190.yaml
+++ b/samples/authorization/certificate_v190.yaml
@@ -22,7 +22,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth

--- a/samples/observability/custom-cert.yaml
+++ b/samples/observability/custom-cert.yaml
@@ -64,7 +64,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth
@@ -94,7 +94,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth

--- a/samples/observability/selfsigned-cert.yaml
+++ b/samples/observability/selfsigned-cert.yaml
@@ -24,7 +24,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth
@@ -54,7 +54,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth

--- a/tests/e2e/testfiles/authorization-templates/csm_authorization_certificate.yaml
+++ b/tests/e2e/testfiles/authorization-templates/csm_authorization_certificate.yaml
@@ -22,7 +22,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth

--- a/tests/e2e/testfiles/observability-cert.yaml
+++ b/tests/e2e/testfiles/observability-cert.yaml
@@ -24,7 +24,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth
@@ -54,7 +54,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048
+    size: 4096
   usages:
     - server auth
     - client auth


### PR DESCRIPTION
# Description
Use 4096 bit size in certificates.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1073|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
