### PR TITLE
fix AM deployment bug

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -965,7 +965,7 @@ rules:
   resources:
   - backups/finalizers
   verbs:
-  - upate
+  - update
 - apiGroups:
   - velero.io
   resources:

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -173,7 +173,7 @@ var (
 // +kubebuilder:rbac:groups="mobility.storage.dell.com",resources=schedules,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="mobility.storage.dell.com",resources=schedules/status,verbs=get;patch;update
 // +kubebuilder:rbac:groups="velero.io",resources=backups,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups="velero.io",resources=backups/finalizers,verbs=upate
+// +kubebuilder:rbac:groups="velero.io",resources=backups/finalizers,verbs=update
 // +kubebuilder:rbac:groups="velero.io",resources=backups/status,verbs=get;list;patch;update
 // +kubebuilder:rbac:groups="velero.io",resources=backupstoragelocations,verbs=get;list;patch;update;watch
 // +kubebuilder:rbac:groups="velero.io",resources=deletebackuprequests,verbs=create;delete;get;list;watch

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1009,7 +1009,7 @@ rules:
   resources:
   - backups/finalizers
   verbs:
-  - upate
+  - update
 - apiGroups:
   - velero.io
   resources:
@@ -1102,6 +1102,8 @@ rules:
   - list
   - update
   - watch
+  - get
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1161,6 +1161,31 @@ subjects:
   namespace: dell-csm-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: application-mobility-velero-server
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: application-mobility-velero-server-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: application-mobility-velero-server
+subjects:
+- kind: ServiceAccount
+  name: dell-csm-operator-manager-service-account
+  namespace: dell-csm-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: dell-csm-operator-proxy-rolebinding


### PR DESCRIPTION
# Description
A bug was introduced last week that impacts AM (and possibly PowerFlex driver) deployment:
```
2024-01-03T14:07:38Z    ERROR   Reconciler error        {"controller": "containerstoragemodule", "controllerGroup": "storage.dell.com", "controllerKind": "ContainerStorageModule", "ContainerStorageModule": {"name":"vxflexos-app-mobility","namespace":"vxflexos"}, "namespace": "vxflexos", "name": "vxflexos-app-mobility", "reconcileID": "0cf852a6-5564-472b-a11e-32b13f3b72cd", "error": "failed to deploy application mobility: unable to reconcile Application Mobility controller Manager: clusterroles.rbac.authorization.k8s.io \"vxflexos-manager-role\" is forbidden: user \"system:serviceaccount:dell-csm-operator:dell-csm-operator-manager-service-account\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:dell-csm-operator\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"velero.io\"], Resources:[\"backups/finalizers\"], Verbs:[\"update\"]}\n{APIGroups:[\"volumegroup.storage.dell.com\"], Resources:[\"dellcsivolumegroupsnapshots\"], Verbs:[\"get\" \"patch\"]}"}
```

This PR tweaks operator.yaml to fix issue. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Deployed AM + Pflex to verify error was fixed
```
[root@master-1-trV5z0Oe32ZgH csm-pipeline]#  kubectl get pods -n vxflexos
NAME                                                       READY   STATUS    RESTARTS   AGE
application-mobility-controller-manager-585bfd986d-dztcx   2/2     Running   0          3m11s
application-mobility-node-agent-q9p4g                      1/1     Running   0          3m11s
application-mobility-node-agent-s2wm2                      1/1     Running   0          3m11s
application-mobility-velero-7b99d9bc6-fp9jc                1/1     Running   0          3m11s
cert-manager-86c85f9b65-ghl5c                              1/1     Running   0          4m56s
cert-manager-cainjector-55685f7d8c-wzvtp                   1/1     Running   0          4m56s
cert-manager-webhook-c74c6bd9f-22vft                       1/1     Running   0          4m56s
vxflexos-app-mobility-controller-dfd9b8d84-pmcwc           5/5     Running   0          105s
vxflexos-app-mobility-node-4c9sr                           2/2     Running   0          105s
vxflexos-app-mobility-node-7cqjt                           2/2     Running   0          105s

```

