### PR TITLE
[bug-1120]: Update Authorization sidecar to use insecure flag

### DIFF
--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -78,6 +78,8 @@ const (
 
 	// AuthProxyHost -
 	AuthProxyHost = "<AUTHORIZATION_HOSTNAME>"
+	//AuthProxyHostInsecure -
+	AuthProxyHostInsecure = "<ProxyHostInsecure>"
 	// AuthProxyIngressHost -
 	AuthProxyIngressHost = "<PROXY_INGRESS_HOST>"
 	// AuthProxyIngressClassName -
@@ -173,7 +175,7 @@ NAME_LOOP:
 }
 
 // CheckApplyContainersAuth --
-func CheckApplyContainersAuth(containers []acorev1.ContainerApplyConfiguration, drivertype string) error {
+func CheckApplyContainersAuth(containers []acorev1.ContainerApplyConfiguration, drivertype string, skipCertificateValidation bool) error {
 	authString := "karavi-authorization-proxy"
 	for _, cnt := range containers {
 		if *cnt.Name == authString {
@@ -189,9 +191,19 @@ func CheckApplyContainersAuth(containers []acorev1.ContainerApplyConfiguration, 
 			}
 
 			for _, env := range cnt.Env {
-				if *env.Name == "SKIP_CERTIFICATE_VALIDATION" {
+				if *env.Name == "SKIP_CERTIFICATE_VALIDATION" || *env.Name == "INSECURE" {
 					if _, err := strconv.ParseBool(*env.Value); err != nil {
 						return fmt.Errorf("%s is an invalid value for SKIP_CERTIFICATE_VALIDATION: %v", *env.Value, err)
+					}
+
+					if skipCertificateValidation {
+						if *env.Value != "true" {
+							return fmt.Errorf("expected SKIP_CERTIFICATE_VALIDATION/INSECURE to be true")
+						}
+					} else {
+						if *env.Value != "false" {
+							return fmt.Errorf("expected SKIP_CERTIFICATE_VALIDATION/INSECURE to be false")
+						}
 					}
 				}
 				if *env.Name == "PROXY_HOST" && *env.Value == "" {
@@ -243,7 +255,7 @@ func getAuthApplyCR(cr csmv1.ContainerStorageModule, op utils.OperatorConfig) (*
 
 	skipCertValid := false
 	for _, env := range authModule.Components[0].Envs {
-		if env.Name == "SKIP_CERTIFICATE_VALIDATION" {
+		if env.Name == "INSECURE" || env.Name == "SKIP_CERTIFICATE_VALIDATION" {
 			skipCertValid, _ = strconv.ParseBool(env.Value)
 		}
 	}
@@ -254,6 +266,14 @@ func getAuthApplyCR(cr csmv1.ContainerStorageModule, op utils.OperatorConfig) (*
 			if *c.Name == certString {
 				container.VolumeMounts[i] = container.VolumeMounts[len(container.VolumeMounts)-1]
 				container.VolumeMounts = container.VolumeMounts[:len(container.VolumeMounts)-1]
+			}
+
+		}
+	} else {
+		for i, e := range container.Env {
+			if *e.Name == "INSECURE" || *e.Name == "SKIP_CERTIFICATE_VALIDATION" {
+				value := strconv.FormatBool(skipCertValid)
+				container.Env[i].Value = &value
 			}
 
 		}

--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -78,8 +78,6 @@ const (
 
 	// AuthProxyHost -
 	AuthProxyHost = "<AUTHORIZATION_HOSTNAME>"
-	//AuthProxyHostInsecure -
-	AuthProxyHostInsecure = "<ProxyHostInsecure>"
 	// AuthProxyIngressHost -
 	AuthProxyIngressHost = "<PROXY_INGRESS_HOST>"
 	// AuthProxyIngressClassName -

--- a/pkg/modules/testdata/cr_powerscale_auth_validate_cert.yaml
+++ b/pkg/modules/testdata/cr_powerscale_auth_validate_cert.yaml
@@ -1,0 +1,30 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: isilon
+  namespace: isilon
+spec:
+  driver:
+    csiDriverType: "isilon"
+    configVersion: v2.9.0
+    authSecret: isilon-creds-custom 
+    replicas: 1
+    common:
+      image: "dellemc/csi-isilon:v2.9.0"
+      imagePullPolicy: IfNotPresent
+
+  modules:
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: true
+      components:
+      - name: karavi-authorization-proxy
+        image: dellemc/csm-authorization-sidecar:v1.7.0
+        envs:
+          # proxyHost: hostname of the csm-authorization server
+          - name: "PROXY_HOST"
+            value: "testing-proxy-host"
+        
+          # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server       
+          - name: "SKIP_CERTIFICATE_VALIDATION"
+            value: "false"


### PR DESCRIPTION
# Description

Updates the karavi-authorization-proxy container INSECURE env with the value of the SKIP CERTIFICATE VALIDATION env in the CR.

If `SKIP_CERTIFICATE_VALIDATION` is true, we keep the default value in `operatorconfig/moduleconfig/authorization/<release>/container.yaml`. If it's false, we set the env value to false.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1120 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

New unit test and manual installation.
