### PR TITLE
Fix daemonset name mismatch for standalone app mobility install

### DIFF
--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -248,6 +248,12 @@ func getDaemonSetStatus(ctx context.Context, instance *csmv1.ContainerStorageMod
 
 		nodeName := instance.GetNodeName()
 
+		// Application-mobility has a different node name than the drivers
+		if instance.GetName() == "application-mobility" {
+			log.Infof("Changing nodeName for application-mobility")
+			nodeName = "application-mobility-node-agent"
+		}
+
 		log.Infof("nodeName is %s", nodeName)
 		err := cluster.ClusterCTRLClient.Get(ctx, t1.NamespacedName{Name: nodeName,
 			Namespace: instance.GetNamespace()}, ds)
@@ -260,6 +266,17 @@ func getDaemonSetStatus(ctx context.Context, instance *csmv1.ContainerStorageMod
 		opts := []client.ListOption{
 			client.InNamespace(instance.GetNamespace()),
 			client.MatchingLabels{"app": label},
+		}
+
+		//if instance is AM, need to search for different named daemonset
+		if instance.GetName() == "application-mobility" {
+			log.Infof("Changing labels for application-mobility")
+			label = "application-mobility-node-agent"
+			opts = []client.ListOption{
+				client.InNamespace(instance.GetNamespace()),
+				client.MatchingLabels{"name": label},
+			}
+
 		}
 
 		log.Infof("Label is %s", label)


### PR DESCRIPTION
# Description
When application-mobility was deployed standalone, the daemonset name was not what operator expected, and so the csm object would be marked as failed, even though the deployment had succeeded. This PR fixes that by rolling back in old code that we had to address this use case.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1133 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Successfully replicated the issue, then fixed it and confirmed the install was working afterward. Running e2e tests now and will pull this out of draft when they pass.
