### PR TITLE
Fix for controller race, daemon status, and obs namespace 

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -384,7 +384,7 @@ func (r *ContainerStorageModuleReconciler) handleDeploymentUpdate(oldObj interfa
 	log.Infow("deployment", "available", available)
 	log.Infow("deployment", "numberUnavailable", numberUnavailable)
 
-	ns := p.GetLabels()[modules.CSMNameSpace]
+	ns := d.GetLabels()[modules.CSMNameSpace]
 	if ns == "" {
 		ns = d.Namespace
 	}
@@ -491,7 +491,7 @@ func (r *ContainerStorageModuleReconciler) handleDaemonsetUpdate(oldObj interfac
 	log.Infow("daemonset ", "available", available)
 	log.Infow("daemonset ", "numberUnavailable", numberUnavailable)
 
-	ns := p.GetLabels()[modules.CSMNameSpace]
+	ns := d.GetLabels()[modules.CSMNameSpace]
 	if ns == "" {
 		ns = d.Namespace
 	}

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -420,7 +420,11 @@ func (r *ContainerStorageModuleReconciler) handlePodsUpdate(oldObj interface{}, 
 
 	p, _ := obj.(*corev1.Pod)
 	name := p.GetLabels()[constants.CsmLabel]
-	ns := p.Namespace
+	//if this pod is an obs. pod, namespace might not match csm namespace
+	ns := p.GetLabels()[modules.CSMNameSpace]
+	if ns == "" {
+		ns = p.Namespace
+	}
 	if name == "" {
 		return
 	}

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -384,7 +384,10 @@ func (r *ContainerStorageModuleReconciler) handleDeploymentUpdate(oldObj interfa
 	log.Infow("deployment", "available", available)
 	log.Infow("deployment", "numberUnavailable", numberUnavailable)
 
-	ns := d.Namespace
+	ns := p.GetLabels()[modules.CSMNameSpace]
+	if ns == "" {
+		ns = d.Namespace
+	}
 	log.Debugw("deployment", "namespace", ns, "name", name)
 	namespacedName := t1.NamespacedName{
 		Name:      name,
@@ -488,7 +491,10 @@ func (r *ContainerStorageModuleReconciler) handleDaemonsetUpdate(oldObj interfac
 	log.Infow("daemonset ", "available", available)
 	log.Infow("daemonset ", "numberUnavailable", numberUnavailable)
 
-	ns := d.Namespace
+	ns := p.GetLabels()[modules.CSMNameSpace]
+	if ns == "" {
+		ns = d.Namespace
+	}
 	r.Log.Debugw("daemonset ", "ns", ns, "name", name)
 	namespacedName := t1.NamespacedName{
 		Name:      name,

--- a/operatorconfig/moduleconfig/observability/v1.5.0/karavi-metrics-powerflex.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.5.0/karavi-metrics-powerflex.yaml
@@ -111,6 +111,7 @@ spec:
         app.kubernetes.io/name: karavi-metrics-powerflex
         app.kubernetes.io/instance: karavi
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccount: karavi-metrics-powerflex-controller
       containers:

--- a/operatorconfig/moduleconfig/observability/v1.5.0/karavi-metrics-powermax.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.5.0/karavi-metrics-powermax.yaml
@@ -111,6 +111,7 @@ spec:
         app.kubernetes.io/name: karavi-metrics-powermax
         app.kubernetes.io/instance: karavi
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: karavi-metrics-powermax-controller
       containers:

--- a/operatorconfig/moduleconfig/observability/v1.5.0/karavi-metrics-powerscale.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.5.0/karavi-metrics-powerscale.yaml
@@ -113,6 +113,7 @@ spec:
         app.kubernetes.io/name: karavi-metrics-powerscale
         app.kubernetes.io/instance: karavi
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccount: karavi-metrics-powerscale-controller
       containers:

--- a/operatorconfig/moduleconfig/observability/v1.5.0/karavi-otel-collector.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.5.0/karavi-otel-collector.yaml
@@ -113,6 +113,7 @@ spec:
         app.kubernetes.io/name: otel-collector
         app.kubernetes.io/instance: karavi-observability
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       volumes:
         - name: tls-secret

--- a/operatorconfig/moduleconfig/observability/v1.5.0/karavi-topology.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.5.0/karavi-topology.yaml
@@ -89,6 +89,7 @@ spec:
         app.kubernetes.io/name: karavi-topology
         app.kubernetes.io/instance: karavi-observability
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       volumes:
         - name: karavi-topology-secret-volume

--- a/operatorconfig/moduleconfig/observability/v1.6.0/karavi-metrics-powerflex.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.6.0/karavi-metrics-powerflex.yaml
@@ -111,6 +111,7 @@ spec:
         app.kubernetes.io/name: karavi-metrics-powerflex
         app.kubernetes.io/instance: karavi
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccount: karavi-metrics-powerflex-controller
       containers:

--- a/operatorconfig/moduleconfig/observability/v1.6.0/karavi-metrics-powermax.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.6.0/karavi-metrics-powermax.yaml
@@ -111,6 +111,7 @@ spec:
         app.kubernetes.io/name: karavi-metrics-powermax
         app.kubernetes.io/instance: karavi
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: karavi-metrics-powermax-controller
       containers:

--- a/operatorconfig/moduleconfig/observability/v1.6.0/karavi-metrics-powerscale.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.6.0/karavi-metrics-powerscale.yaml
@@ -113,6 +113,7 @@ spec:
         app.kubernetes.io/name: karavi-metrics-powerscale
         app.kubernetes.io/instance: karavi
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccount: karavi-metrics-powerscale-controller
       containers:

--- a/operatorconfig/moduleconfig/observability/v1.6.0/karavi-otel-collector.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.6.0/karavi-otel-collector.yaml
@@ -113,6 +113,7 @@ spec:
         app.kubernetes.io/name: otel-collector
         app.kubernetes.io/instance: karavi-observability
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       volumes:
         - name: tls-secret

--- a/operatorconfig/moduleconfig/observability/v1.6.0/karavi-topology.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.6.0/karavi-topology.yaml
@@ -89,6 +89,7 @@ spec:
         app.kubernetes.io/name: karavi-topology
         app.kubernetes.io/instance: karavi-observability
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       volumes:
         - name: karavi-topology-secret-volume

--- a/operatorconfig/moduleconfig/observability/v1.7.0/karavi-metrics-powerflex.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.7.0/karavi-metrics-powerflex.yaml
@@ -111,6 +111,7 @@ spec:
         app.kubernetes.io/name: karavi-metrics-powerflex
         app.kubernetes.io/instance: karavi
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccount: karavi-metrics-powerflex-controller
       containers:

--- a/operatorconfig/moduleconfig/observability/v1.7.0/karavi-metrics-powermax.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.7.0/karavi-metrics-powermax.yaml
@@ -111,6 +111,7 @@ spec:
         app.kubernetes.io/name: karavi-metrics-powermax
         app.kubernetes.io/instance: karavi
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: karavi-metrics-powermax-controller
       containers:

--- a/operatorconfig/moduleconfig/observability/v1.7.0/karavi-metrics-powerscale.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.7.0/karavi-metrics-powerscale.yaml
@@ -113,6 +113,7 @@ spec:
         app.kubernetes.io/name: karavi-metrics-powerscale
         app.kubernetes.io/instance: karavi
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccount: karavi-metrics-powerscale-controller
       containers:

--- a/operatorconfig/moduleconfig/observability/v1.7.0/karavi-otel-collector.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.7.0/karavi-otel-collector.yaml
@@ -113,6 +113,7 @@ spec:
         app.kubernetes.io/name: otel-collector
         app.kubernetes.io/instance: karavi-observability
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       volumes:
         - name: tls-secret

--- a/operatorconfig/moduleconfig/observability/v1.7.0/karavi-topology.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.7.0/karavi-topology.yaml
@@ -89,6 +89,7 @@ spec:
         app.kubernetes.io/name: karavi-topology
         app.kubernetes.io/instance: karavi-observability
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       volumes:
         - name: karavi-topology-secret-volume

--- a/pkg/modules/observability.go
+++ b/pkg/modules/observability.go
@@ -171,6 +171,9 @@ const (
 
 	// PMaxObsYamlFile - powermax metrics yaml file
 	PMaxObsYamlFile string = "karavi-metrics-powermax.yaml"
+
+	// CSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	CSMNameSpace = "<CSM_NAMESPACE>"
 )
 
 // ObservabilitySupportedDrivers is a map containing the CSI Drivers supported by CSM Replication. The key is driver name and the value is the driver plugin identifier
@@ -292,6 +295,7 @@ func getTopology(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (stri
 	}
 
 	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
+	YamlString = strings.ReplaceAll(YamlString, CSMNameSpace, cr.Namespace)
 	YamlString = strings.ReplaceAll(YamlString, TopologyLogLevel, logLevel)
 	YamlString = strings.ReplaceAll(YamlString, TopologyImage, topologyImage)
 	return YamlString, nil

--- a/pkg/modules/observability.go
+++ b/pkg/modules/observability.go
@@ -360,6 +360,7 @@ func getOtelCollector(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) 
 	}
 
 	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
+	YamlString = strings.ReplaceAll(YamlString, CSMNameSpace, cr.Namespace)
 	YamlString = strings.ReplaceAll(YamlString, OtelCollectorImage, otelCollectorImage)
 	YamlString = strings.ReplaceAll(YamlString, NginxProxyImage, nginxProxyImage)
 	return YamlString, nil
@@ -506,6 +507,7 @@ func getPowerScaleMetricsObjects(op utils.OperatorConfig, cr csmv1.ContainerStor
 	}
 
 	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
+	YamlString = strings.ReplaceAll(YamlString, CSMNameSpace, cr.Namespace)
 	YamlString = strings.ReplaceAll(YamlString, PowerScaleImage, pscaleImage)
 	YamlString = strings.ReplaceAll(YamlString, PowerscaleLogLevel, logLevel)
 	YamlString = strings.ReplaceAll(YamlString, PowerScaleMaxConcurrentQueries, maxConcurrentQueries)
@@ -707,6 +709,7 @@ func getPowerFlexMetricsObject(op utils.OperatorConfig, cr csmv1.ContainerStorag
 	}
 
 	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
+	YamlString = strings.ReplaceAll(YamlString, CSMNameSpace, cr.Namespace)
 	YamlString = strings.ReplaceAll(YamlString, PowerflexImage, pflexImage)
 	YamlString = strings.ReplaceAll(YamlString, PowerflexLogLevel, logLevel)
 	YamlString = strings.ReplaceAll(YamlString, PowerflexMaxConcurrentQueries, maxConcurrentQueries)
@@ -928,6 +931,7 @@ func getPowerMaxMetricsObject(op utils.OperatorConfig, cr csmv1.ContainerStorage
 	}
 
 	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
+	YamlString = strings.ReplaceAll(YamlString, CSMNameSpace, cr.Namespace)
 	YamlString = strings.ReplaceAll(YamlString, PmaxObsImage, pmaxImage)
 	YamlString = strings.ReplaceAll(YamlString, PmaxLogLevel, logLevel)
 	YamlString = strings.ReplaceAll(YamlString, PmaxLogFormat, logFormat)

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -70,6 +70,10 @@ func getDeploymentStatus(ctx context.Context, instance *csmv1.ContainerStorageMo
 		log.Infof("deployment status for cluster: %s", cluster.ClusterID)
 		msg += fmt.Sprintf("error message for %s \n", cluster.ClusterID)
 
+		log.Infof("DEBUG: instance being looked at is: %v", instance)
+		log.Infof("DEBUG: instance name being looked at is: %v", instance.Name)
+		log.Infof("DEBUG: instance spec being looked at is: %v", instance.GetContainerStorageModuleSpec())
+
 		err = cluster.ClusterCTRLClient.Get(ctx, t1.NamespacedName{Name: instance.GetControllerName(),
 			Namespace: instance.GetNamespace()}, deployment)
 		if err != nil {

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -50,6 +50,7 @@ func getInt32(pointer *int32) int32 {
 	return *pointer
 }
 
+// calculates deployment state of drivers only; module deployment status will be checked in checkModuleStatus
 func getDeploymentStatus(ctx context.Context, instance *csmv1.ContainerStorageModule, r ReconcileCSM) (int32, csmv1.PodStatus, error) {
 	log := logger.GetLogger(ctx)
 	var msg string
@@ -70,9 +71,10 @@ func getDeploymentStatus(ctx context.Context, instance *csmv1.ContainerStorageMo
 		log.Infof("deployment status for cluster: %s", cluster.ClusterID)
 		msg += fmt.Sprintf("error message for %s \n", cluster.ClusterID)
 
-		log.Infof("DEBUG: instance being looked at is: %v", instance)
-		log.Infof("DEBUG: instance name being looked at is: %v", instance.Name)
-		log.Infof("DEBUG: instance spec being looked at is: %v", instance.GetContainerStorageModuleSpec())
+		if instance.Name == "" {
+			log.Infof("Not a driver instance, will not check deploymentstatus")
+			return 0, csmv1.PodStatus{}, err
+		}
 
 		err = cluster.ClusterCTRLClient.Get(ctx, t1.NamespacedName{Name: instance.GetControllerName(),
 			Namespace: instance.GetNamespace()}, deployment)

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -393,7 +393,7 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 	// TODO: Can be uncommented once this issues gets sorted out
 	controllerReplicas, controllerStatus, controllerErr := getDeploymentStatus(ctx, instance, r)
 	if controllerErr != nil {
-		log.Infof("eror from getDeploymentStatus: %s", controllerErr.Error())
+		log.Infof("error from getDeploymentStatus: %s", controllerErr.Error())
 	}
 
 	newStatus.ControllerStatus = controllerStatus

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -285,6 +285,7 @@ func getDaemonSetStatus(ctx context.Context, instance *csmv1.ContainerStorageMod
 	totalAvialable := int32(0)
 	totalDesired := int32(0)
 	totalFailedCount := 0
+	totalRunning := int32(0)
 
 	_, clusterClients, err := GetDefaultClusters(ctx, *instance, r)
 	if err != nil {
@@ -356,16 +357,19 @@ func getDaemonSetStatus(ctx context.Context, instance *csmv1.ContainerStorageMod
 					}
 				}
 			}
+			if pod.Status.Phase == corev1.PodRunning {
+				totalRunning++
+			}
 		}
 		for k, v := range errMap {
 			msg += k + "=" + v
 		}
 
-		log.Infof("daemonset status available pods %d", ds.Status.NumberAvailable)
+		log.Infof("daemonset status available pods %d", totalRunning)
 		log.Infof("daemonset status failedCount pods %d", failedCount)
 		log.Infof("daemonset status desired pods %d", ds.Status.DesiredNumberScheduled)
 
-		totalAvialable += ds.Status.NumberAvailable
+		totalAvialable += totalRunning
 		totalDesired += ds.Status.DesiredNumberScheduled
 		totalFailedCount += failedCount
 

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -73,7 +73,7 @@ func getDeploymentStatus(ctx context.Context, instance *csmv1.ContainerStorageMo
 
 		if instance.Name == "" {
 			log.Infof("Not a driver instance, will not check deploymentstatus")
-			return 0, csmv1.PodStatus{}, err
+			return 0, csmv1.PodStatus{}, nil
 		}
 
 		err = cluster.ClusterCTRLClient.Get(ctx, t1.NamespacedName{Name: instance.GetControllerName(),


### PR DESCRIPTION
# Description
This PR makes a few adjustments to fix rare cases where csm status was not the correct:
1. Add getDeploymentStatus to calculateState, to prevent cases where an old failed status would overwrite the more recent correct status. I still left the current gds commented in as it looks like we plan to re-use that method at some point in the future
2. GetDaemonsetStatus will now use its own counter of running pods to determine available pods. This prevents a rare (1/1000 runs) issue where ds.Status.NumberAvailable was not updated in time, resulting in the CSM being marked as failed even though the operator saw there were 2 running pods
3. CSM namespace label has been added to obs. This is because the pod namespace might not be the same namespace as the csm object; resulting in the csm status failing to update since the csm obj could not be found in karavi ns 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1137 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [x] Ran deployment of pflex driver 1000x to ensure no race condition was hit 
- [x] Ran unit tests
