### PR TITLE
Auth proxy status fix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,7 +1,7 @@
 name: Workflow
 on:
   push:
-    branches: [ auth-proxy-status-fix ]
+    branches: [ main ]
   pull_request:
     branches: [ '**' ]
 jobs:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,7 +1,7 @@
 name: Workflow
 on:
   push:
-    branches: [ main ]
+    branches: [ auth-proxy-status-fix ]
   pull_request:
     branches: [ '**' ]
 jobs:

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -1194,7 +1194,7 @@ func (r *ContainerStorageModuleReconciler) removeDriver(ctx context.Context, ins
 	return nil
 }
 
-// removeModule - remove authorization proxy server
+// removeModule - remove standalone modules
 func (r *ContainerStorageModuleReconciler) removeModule(ctx context.Context, instance csmv1.ContainerStorageModule, operatorConfig utils.OperatorConfig, ctrlClient client.Client) error {
 	log := logger.GetLogger(ctx)
 

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -677,7 +677,8 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 	log := logger.GetLogger(ctx)
 
 	// Create/Update Authorization Proxy Server
-	if authorizationEnabled, _ := utils.IsModuleEnabled(ctx, cr, csmv1.AuthorizationServer); authorizationEnabled {
+	authorizationEnabled, _ := utils.IsModuleEnabled(ctx, cr, csmv1.AuthorizationServer)
+	if authorizationEnabled {
 		log.Infow("Create/Update authorization")
 		if err := r.reconcileAuthorization(ctx, false, operatorConfig, cr, ctrlClient); err != nil {
 			return fmt.Errorf("failed to deploy authorization proxy server: %v", err)

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -841,9 +841,11 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 			return err
 		}
 
-		// Create/Update DeamonSet
-		if err = daemonset.SyncDaemonset(ctx, node.DaemonSetApplyConfig, cluster.ClusterK8sClient, cr.Name); err != nil {
-			return err
+		// Create/Update DeamonSet, except for auth proxy
+		if !authorizationEnabled {
+			if err = daemonset.SyncDaemonset(ctx, node.DaemonSetApplyConfig, cluster.ClusterK8sClient, cr.Name); err != nil {
+				return err
+			}
 		}
 
 		if replicationEnabled {

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -370,7 +370,7 @@ func (r *ContainerStorageModuleReconciler) handleDeploymentUpdate(oldObj interfa
 		return
 	}
 
-	log.Debugw("deployment modified generation", d.Generation, old.Generation)
+	log.Debugw("deployment modified generation", d.Name, d.Generation, old.Generation)
 
 	desired := d.Status.Replicas
 	available := d.Status.AvailableReplicas

--- a/operatorconfig/moduleconfig/authorization/v1.7.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.7.0/deployment.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: proxy-server
     spec:
       containers:
@@ -92,6 +93,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: tenant-service
     spec:
       containers:
@@ -176,6 +178,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: role-service
     spec:
       serviceAccountName: role-service
@@ -254,6 +257,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: storage-service
     spec:
       serviceAccountName: storage-service
@@ -316,6 +320,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: redis
         role: primary
         tier: backend
@@ -367,6 +372,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: redis-commander
         tier: backend
     spec:

--- a/operatorconfig/moduleconfig/authorization/v1.7.0/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.7.0/nginx-ingress-controller.yaml
@@ -426,6 +426,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx

--- a/operatorconfig/moduleconfig/authorization/v1.8.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.8.0/deployment.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: proxy-server
     spec:
       containers:
@@ -92,6 +93,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: tenant-service
     spec:
       containers:
@@ -176,6 +178,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: role-service
     spec:
       serviceAccountName: role-service
@@ -254,6 +257,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: storage-service
     spec:
       serviceAccountName: storage-service
@@ -316,6 +320,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: redis
         role: primary
         tier: backend
@@ -367,6 +372,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: redis-commander
         tier: backend
     spec:

--- a/operatorconfig/moduleconfig/authorization/v1.8.0/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.8.0/nginx-ingress-controller.yaml
@@ -426,6 +426,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx

--- a/operatorconfig/moduleconfig/authorization/v1.9.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.9.0/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: proxy-server
+        csm: <NAME>
     spec:
       containers:
       - name: proxy-server
@@ -93,6 +94,7 @@ spec:
     metadata:
       labels:
         app: tenant-service
+        csm: <NAME>
     spec:
       containers:
       - name: tenant-service
@@ -176,6 +178,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: role-service
     spec:
       serviceAccountName: role-service
@@ -254,6 +257,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: storage-service
     spec:
       serviceAccountName: storage-service
@@ -316,6 +320,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: redis
         role: primary
         tier: backend
@@ -367,6 +372,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: redis-commander
         tier: backend
     spec:

--- a/operatorconfig/moduleconfig/authorization/v1.9.0/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.9.0/nginx-ingress-controller.yaml
@@ -426,6 +426,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx

--- a/operatorconfig/moduleconfig/authorization/v1.9.1/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.9.1/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: proxy-server
+        csm: <NAME>
     spec:
       containers:
       - name: proxy-server
@@ -93,6 +94,7 @@ spec:
     metadata:
       labels:
         app: tenant-service
+        csm: <NAME>
     spec:
       containers:
       - name: tenant-service
@@ -176,6 +178,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: role-service
     spec:
       serviceAccountName: role-service
@@ -255,6 +258,7 @@ spec:
     metadata:
       labels:
         app: storage-service
+        csm: <NAME>
     spec:
       serviceAccountName: storage-service
       containers:
@@ -319,6 +323,7 @@ spec:
         app: redis
         role: primary
         tier: backend
+        csm: <NAME>
     spec:
       containers:
       - name: primary
@@ -369,6 +374,7 @@ spec:
       labels:
         app: redis-commander
         tier: backend
+        csm: <NAME>
     spec:
       containers:
       - name: redis-commander

--- a/operatorconfig/moduleconfig/authorization/v1.9.1/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.9.1/nginx-ingress-controller.yaml
@@ -429,6 +429,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx
+        csm: <NAME>
     spec:
       containers:
       - args:

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -105,8 +105,6 @@ const (
 	AppMobCertManagerComponent = "cert-manager"
 	// AppMobVeleroComponent - velero component
 	AppMobVeleroComponent = "velero"
-	// CSMName - name
-	CSMName = "<NAME>"
 )
 
 // getAppMobilityModule - get instance of app mobility module

--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -678,7 +678,6 @@ func getPolicies(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (stri
 	YamlString = string(buf)
 	authNamespace := cr.Namespace
 	YamlString = strings.ReplaceAll(YamlString, AuthNamespace, authNamespace)
-	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
 
 	return YamlString, nil
 }

--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -493,6 +493,7 @@ func getAuthorizationServerDeployment(op utils.OperatorConfig, cr csmv1.Containe
 			YamlString = strings.ReplaceAll(YamlString, AuthStorageServiceImage, component.StorageService)
 			YamlString = strings.ReplaceAll(YamlString, AuthRedisImage, component.Redis)
 			YamlString = strings.ReplaceAll(YamlString, AuthRedisCommanderImage, component.Commander)
+			YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
 
 			for _, env := range component.Envs {
 				if env.Name == "REDIS_STORAGE_CLASS" {
@@ -504,6 +505,7 @@ func getAuthorizationServerDeployment(op utils.OperatorConfig, cr csmv1.Containe
 
 	YamlString = strings.ReplaceAll(YamlString, AuthNamespace, authNamespace)
 	YamlString = strings.ReplaceAll(YamlString, AuthRedisStorageClass, redisStorageClass)
+	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
 
 	return YamlString, nil
 }
@@ -570,6 +572,7 @@ func getAuthorizationIngressRules(op utils.OperatorConfig, cr csmv1.ContainerSto
 	YamlString = strings.ReplaceAll(YamlString, AuthProxyHost, authHostname)
 	YamlString = strings.ReplaceAll(YamlString, AuthProxyIngressHost, proxyIngressHost)
 	YamlString = strings.ReplaceAll(YamlString, AuthProxyIngressClassName, proxyIngressClassName)
+	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
 
 	return YamlString, nil
 }
@@ -625,6 +628,7 @@ func getNginxIngressController(op utils.OperatorConfig, cr csmv1.ContainerStorag
 	YamlString = string(buf)
 	authNamespace := cr.Namespace
 	YamlString = strings.ReplaceAll(YamlString, AuthNamespace, authNamespace)
+	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
 
 	return YamlString, nil
 }
@@ -674,6 +678,7 @@ func getPolicies(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (stri
 	YamlString = string(buf)
 	authNamespace := cr.Namespace
 	YamlString = strings.ReplaceAll(YamlString, AuthNamespace, authNamespace)
+	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
 
 	return YamlString, nil
 }

--- a/pkg/modules/commonconfig.go
+++ b/pkg/modules/commonconfig.go
@@ -33,6 +33,8 @@ const (
 	CertManagerManifest = "cert-manager.yaml"
 	// CommonNamespace -
 	CommonNamespace = "<NAMESPACE>"
+	// CSMName - name
+	CSMName = "<NAME>"
 )
 
 // SupportedDriverParam -

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -347,7 +347,7 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 	// Auth proxy has no daemonset. Putting this if/else in here and setting nodeStatusGood to true by
 	// default is a little hacky but will be fixed when we refactor the status code in CSM 1.10 or 1.11
 	log.Infof("instance.GetName() is %s", instance.GetName())
-	if instance.GetName() != "authorization" {
+	if instance.GetName() != string(csmv1.Authorization) {
 		expected, nodeStatus, daemonSetErr := getDaemonSetStatus(ctx, instance, r)
 		newStatus.NodeStatus = nodeStatus
 		if daemonSetErr != nil {
@@ -394,6 +394,7 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 		newStatus.State = constants.Failed
 	}
 
+	log.Infof("setting status to ", "newStatus", newStatus)
 	SetStatus(ctx, r, instance, newStatus)
 	return running, err
 }

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -420,7 +420,7 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 	log.Infof("deployment controllerReplicas [%s]", controllerReplicas)
 	log.Infof("deployment controllerStatus.Available [%s]", controllerStatus.Available)
 
-	if (controllerReplicas == controllerStatus.Available) && nodeStatusGood {
+	if (fmt.Sprintf("%d", controllerReplicas) == controllerStatus.Available) && nodeStatusGood {
 
 
 		for _, module := range instance.Spec.Modules {

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -1007,7 +1007,4 @@ func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageM
 	log.Info("auth proxy deployment successful")
 
 	return true, nil
-
-	//return proxyServerRunning && redisCommanderRunning && redisPrimaryRunning && roleServiceRunning && storageServiceRunning && tenantServiceRunning &&
-		//(!certEnabled || (certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning)) && (!nginxEnabled || nginxRunning), nil
 }

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -968,5 +968,5 @@ func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageM
 	}
 
 	return proxyServerRunning && redisCommanderRunning && redisPrimaryRunning && roleServiceRunning && storageServiceRunning && tenantServiceRunning && 
-		(!certEnabled || (certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning)) && (!nginxEnabled or nginxRunning)
+		(!certEnabled || (certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning)) && (!nginxEnabled || nginxRunning)
 }

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -909,7 +909,7 @@ func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageM
 	tenantServiceRunning := false
 
 	for _, m := range instance.Spec.Modules {
-		if m.Name == csmv1.Observability {
+		if m.Name == csmv1.AuthorizationServer {
 			for _, c := range m.Components {
 				if c.Name == "ingress-nginx" && *c.Enabled {
 					nginxEnabled = true
@@ -965,8 +965,9 @@ func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageM
 			storageServiceRunning = checkFn(&deployment)
 		case "tenant-service":
 			tenantServiceRunning = checkFn(&deployment)
+		}
 	}
 
 	return proxyServerRunning && redisCommanderRunning && redisPrimaryRunning && roleServiceRunning && storageServiceRunning && tenantServiceRunning && 
-		(!certEnabled || (certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning)) && (!nginxEnabled || nginxRunning)
+		(!certEnabled || (certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning)) && (!nginxEnabled || nginxRunning), nil
 }

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -908,7 +908,7 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 
 // authProxyStatusCheck - calculate success state for auth proxy
 func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModule, r ReconcileCSM, _ *csmv1.ContainerStorageModuleStatus) (bool, error) {
-
+	log := logger.GetLogger(ctx)
 	certEnabled := false
 	nginxEnabled := false
 	certManagerRunning := false
@@ -953,35 +953,67 @@ func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageM
 		switch deployment.Name {
 		case "authorization-ingress-nginx-controller":
 			if nginxEnabled {
-				nginxRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in auth proxy deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		case "cert-manager":
 			if certEnabled {
-				certManagerRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in auth proxy deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		case "cert-manager-cainjector":
 			if certEnabled {
-				certManagerCainInjectorRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in auth proxy deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		case "cert-manager-webhook":
 			if certEnabled {
-				certManagerWebhookRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in auth proxy deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		case "proxy-server":
-			proxyServerRunning = checkFn(&deployment)
+			if !checkFn(&deployment) {
+				log.Info("%s component not running in auth proxy deployment", deployment.Name)
+				return false, nil
+			}
 		case "redis-commander":
-			redisCommanderRunning = checkFn(&deployment)
+			if !checkFn(&deployment) {
+				log.Info("%s component not running in auth proxy deployment", deployment.Name)
+				return false, nil
+			}
 		case "redis-primary":
-			redisPrimaryRunning = checkFn(&deployment)
+			if !checkFn(&deployment) {
+				log.Info("%s component not running in auth proxy deployment", deployment.Name)
+				return false, nil
+			}
 		case "role-service":
-			roleServiceRunning = checkFn(&deployment)
+			if !checkFn(&deployment) {
+				log.Info("%s component not running in auth proxy deployment", deployment.Name)
+				return false, nil
+			}
 		case "storage-service":
-			storageServiceRunning = checkFn(&deployment)
+			if !checkFn(&deployment) {
+				log.Info("%s component not running in auth proxy deployment", deployment.Name)
+				return false, nil
+			}
 		case "tenant-service":
-			tenantServiceRunning = checkFn(&deployment)
+			if !checkFn(&deployment) {
+				log.Info("%s component not running in auth proxy deployment", deployment.Name)
+				return false, nil
+			}
 		}
 	}
 
-	return proxyServerRunning && redisCommanderRunning && redisPrimaryRunning && roleServiceRunning && storageServiceRunning && tenantServiceRunning &&
-		(!certEnabled || (certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning)) && (!nginxEnabled || nginxRunning), nil
+	return true, nil
+
+	//return proxyServerRunning && redisCommanderRunning && redisPrimaryRunning && roleServiceRunning && storageServiceRunning && tenantServiceRunning &&
+		//(!certEnabled || (certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning)) && (!nginxEnabled || nginxRunning), nil
 }

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -379,7 +379,7 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 				if !moduleRunning {
 					running = false
 					newStatus.State = constants.Failed
-					log.Infof("%s module not running", module)
+					log.Infof("%s module not running", module.Name)
 					break
 				}
 				log.Infof("%s module running", module.Name)

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -573,13 +573,15 @@ func HandleSuccess(ctx context.Context, instance *csmv1.ContainerStorageModule, 
 		newStatus.State = constants.Failed
 	}
 	if running {
-		newStatus.State = constants.Running
+		newStatus.State = constants.Succeeded
 	}
 	log.Infow("HandleSuccess Driver state ", "newStatus.State", newStatus.State)
-	if newStatus.State == constants.Running {
+	if newStatus.State == constants.Succeeded {
 		// If previously we were in running state
-		if oldStatus.State == constants.Running {
-			log.Info("HandleSuccess Driver state didn't change from Running")
+		if oldStatus.State == constants.Succeeded {
+			log.Info("HandleSuccess Driver state didn't change from Succeeded")
+		} else {
+			UpdateStatus(ctx, instance, r, newStatus)
 		}
 		return reconcile.Result{}, nil
 	}

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -336,6 +336,7 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 	running := true
 	var err error = nil
 	nodeStatusGood := true
+	newStatus.State = constants.Succeeded
 	// TODO: Currently commented this block of code as the API used to get the latest deployment status is not working as expected
 	// TODO: Can be uncommented once this issues gets sorted out
 	/* controllerReplicas, controllerStatus, controllerErr := getDeploymentStatus(ctx, instance, r)
@@ -362,7 +363,6 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 	controllerReplicas := newStatus.ControllerStatus.Desired
 	controllerStatus := newStatus.ControllerStatus
 
-	newStatus.State = constants.Succeeded
 	log.Infof("deployment controllerReplicas [%s]", controllerReplicas)
 	log.Infof("deployment controllerStatus.Available [%s]", controllerStatus.Available)
 
@@ -382,9 +382,14 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 					log.Infof("%s module not running", module)
 					break
 				}
+				log.Infof("%s module running", module.Name)
 			}
 		}
 	} else {
+		log.Infof("either controllerReplicas != controllerStatus.Available or nodeStatus is bad")
+		log.Infof("controllerReplicas", controllerReplicas)
+		log.Infof("controllerStatus.Available", controllerStatus.Available)
+		log.Infof("nodeStatusGood", nodeStatusGood)
 		running = false
 		newStatus.State = constants.Failed
 	}

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -911,16 +911,6 @@ func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageM
 	log := logger.GetLogger(ctx)
 	certEnabled := false
 	nginxEnabled := false
-	certManagerRunning := false
-	certManagerCainInjectorRunning := false
-	certManagerWebhookRunning := false
-	nginxRunning := false
-	proxyServerRunning := false
-	redisCommanderRunning := false
-	redisPrimaryRunning := false
-	roleServiceRunning := false
-	storageServiceRunning := false
-	tenantServiceRunning := false
 
 	for _, m := range instance.Spec.Modules {
 		if m.Name == csmv1.AuthorizationServer {

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -1002,6 +1002,8 @@ func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageM
 		}
 	}
 
+	log.Info("auth proxy deployment successful")
+
 	return true, nil
 
 	//return proxyServerRunning && redisCommanderRunning && redisPrimaryRunning && roleServiceRunning && storageServiceRunning && tenantServiceRunning &&

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -346,7 +346,7 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 	// Auth proxy has no daemonset. Putting this if/else in here and setting nodeStatusGood to true by
 	// default is a little hacky but will be fixed when we refactor the status code in CSM 1.10 or 1.11
 	log.Infof("instance.GetName() is %s", instance.GetName())
-	if instance.GetName() != string(csmv1.AuthorizationServer) {
+	if instance.GetName() != "authorization" {
 		expected, nodeStatus, daemonSetErr := getDaemonSetStatus(ctx, instance, r)
 		newStatus.NodeStatus = nodeStatus
 		if daemonSetErr != nil {

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -345,6 +345,7 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 
 	// Auth proxy has no daemonset. Putting this if/else in here and setting nodeStatusGood to true by
 	// default is a little hacky but will be fixed when we refactor the status code in CSM 1.10 or 1.11
+	log.Infof("instance.GetName() is %s", instance.GetName())
 	if instance.GetName() != string(csmv1.AuthorizationServer) {
 		expected, nodeStatus, daemonSetErr := getDaemonSetStatus(ctx, instance, r)
 		newStatus.NodeStatus = nodeStatus

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -581,7 +581,7 @@ func HandleSuccess(ctx context.Context, instance *csmv1.ContainerStorageModule, 
 		if oldStatus.State == constants.Succeeded {
 			log.Info("HandleSuccess Driver state didn't change from Succeeded")
 		} else {
-			UpdateStatus(ctx, instance, r, newStatus)
+			log.Info("HandleSuccess Driver stat changed to Succeeded")
 		}
 		return reconcile.Result{}, nil
 	}

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -976,6 +976,6 @@ func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageM
 		}
 	}
 
-	return proxyServerRunning && redisCommanderRunning && redisPrimaryRunning && roleServiceRunning && storageServiceRunning && tenantServiceRunning && 
+	return proxyServerRunning && redisCommanderRunning && redisPrimaryRunning && roleServiceRunning && storageServiceRunning && tenantServiceRunning &&
 		(!certEnabled || (certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning)) && (!nginxEnabled || nginxRunning), nil
 }

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -955,22 +955,16 @@ func authProxyStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageM
 			}
 		case "proxy-server":
 			proxyServerRunning = checkFn(&deployment)
-		}
 		case "redis-commander":
 			redisCommanderRunning = checkFn(&deployment)
-		}
 		case "redis-primary":
 			redisPrimaryRunning = checkFn(&deployment)
-		}
 		case "role-service":
 			roleServiceRunning = checkFn(&deployment)
-		}
 		case "storage-service":
 			storageServiceRunning = checkFn(&deployment)
-		}
 		case "tenant-service":
 			tenantServiceRunning = checkFn(&deployment)
-		}
 	}
 
 	return proxyServerRunning && redisCommanderRunning && redisPrimaryRunning && roleServiceRunning && storageServiceRunning && tenantServiceRunning && 

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -422,7 +422,6 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 
 	if (fmt.Sprintf("%d", controllerReplicas) == controllerStatus.Available) && nodeStatusGood {
 
-
 		for _, module := range instance.Spec.Modules {
 			moduleStatus, exists := checkModuleStatus[module.Name]
 			if exists && module.Enabled {


### PR DESCRIPTION
# Description
Currently, the authorization proxy server status is always failed in csm-operator. This is for a couple reasons:
1) We are attempting to calculate the status of the daemonset, but since auth proxy has no daemonset, it always fails. To fix this, the daemonset is no longer considered when checking the auth proxy deployment.
2) Beyond that, the handleDeploymentUpdate function is now looking for a csm label on the deployment objects. If it doesn't find it, the handler exits without doing anything else. To fix this, labels were added to all of the auth proxy deployment objects.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1143 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
Ran auth proxy e2e test. Will run full e2e tests before fixed-release-v1.4.2 is released.
