### PR TITLE
fix pscale + obs issue 

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -379,16 +379,16 @@ func (r *ContainerStorageModuleReconciler) handleDeploymentUpdate(oldObj interfa
 
 	//Replicas:               2 desired | 2 updated | 2 total | 2 available | 0 unavailable
 
-	log.Infow("deployment", "desired", desired)
-	log.Infow("deployment", "numberReady", ready)
-	log.Infow("deployment", "available", available)
-	log.Infow("deployment", "numberUnavailable", numberUnavailable)
+	log.Infow("deployment", "deployment name", d.Name, "desired", desired)
+	log.Infow("deployment", "deployment name", d.Name, "numberReady", ready)
+	log.Infow("deployment", "deployment name", d.Name, "available", available)
+	log.Infow("deployment", "deployment name", d.Name, "numberUnavailable", numberUnavailable)
 
 	ns := d.Spec.Template.Labels[constants.CsmNamespaceLabel]
 	if ns == "" {
 		ns = d.Namespace
 	}
-	log.Debugw("deployment", "namespace", ns, "name", name)
+	log.Debugw("csm being modified in handledeployment", "namespace", ns, "name", name)
 	namespacedName := t1.NamespacedName{
 		Name:      name,
 		Namespace: ns,

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -384,7 +384,7 @@ func (r *ContainerStorageModuleReconciler) handleDeploymentUpdate(oldObj interfa
 	log.Infow("deployment", "available", available)
 	log.Infow("deployment", "numberUnavailable", numberUnavailable)
 
-	ns := d.GetLabels()[constants.CsmNamespaceLabel]
+	ns := d.Spec.Template.Labels[constants.CsmNamespaceLabel]
 	if ns == "" {
 		ns = d.Namespace
 	}
@@ -491,7 +491,7 @@ func (r *ContainerStorageModuleReconciler) handleDaemonsetUpdate(oldObj interfac
 	log.Infow("daemonset ", "available", available)
 	log.Infow("daemonset ", "numberUnavailable", numberUnavailable)
 
-	ns := d.GetLabels()[constants.CsmNamespaceLabel]
+	ns := d.Spec.Template.Labels[constants.CsmNamespaceLabel]
 	if ns == "" {
 		ns = d.Namespace
 	}

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -384,7 +384,7 @@ func (r *ContainerStorageModuleReconciler) handleDeploymentUpdate(oldObj interfa
 	log.Infow("deployment", "available", available)
 	log.Infow("deployment", "numberUnavailable", numberUnavailable)
 
-	ns := d.GetLabels()[modules.CSMNameSpace]
+	ns := d.GetLabels()[constants.CsmNamespaceLabel]
 	if ns == "" {
 		ns = d.Namespace
 	}
@@ -424,7 +424,7 @@ func (r *ContainerStorageModuleReconciler) handlePodsUpdate(oldObj interface{}, 
 	p, _ := obj.(*corev1.Pod)
 	name := p.GetLabels()[constants.CsmLabel]
 	//if this pod is an obs. pod, namespace might not match csm namespace
-	ns := p.GetLabels()[modules.CSMNameSpace]
+	ns := p.GetLabels()[constants.CsmNamespaceLabel]
 	if ns == "" {
 		ns = p.Namespace
 	}
@@ -491,7 +491,7 @@ func (r *ContainerStorageModuleReconciler) handleDaemonsetUpdate(oldObj interfac
 	log.Infow("daemonset ", "available", available)
 	log.Infow("daemonset ", "numberUnavailable", numberUnavailable)
 
-	ns := d.GetLabels()[modules.CSMNameSpace]
+	ns := d.GetLabels()[constants.CsmNamespaceLabel]
 	if ns == "" {
 		ns = d.Namespace
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -73,6 +73,8 @@ var PodStatusRemoveString = "rpc error: code = Unknown desc = Error response fro
 // CsmLabel - label driver resources
 var CsmLabel = "csm"
 
+var CsmNamespaceLabel = "csmNamespace"
+
 // AccLabel - label client resources
 var AccLabel = "acc"
 

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -851,6 +851,14 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 	metricsRunning := false
 	topologyRunning := false
 
+	driverName := instance.Spec.Driver.CSIDriverType
+
+	//TODO: PowerScale DriverType should be changed from "isilon" to "powerscale"
+	// this is a temporary fix until we can do that
+	if driverName == "isilon" {
+		driverName = "powerscale"
+	}
+
 	for _, m := range instance.Spec.Modules {
 		if m.Name == csmv1.Observability {
 			for _, c := range m.Components {
@@ -869,7 +877,7 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 						certEnabled = true
 					}
 				}
-				if c.Name == fmt.Sprintf("metrics-%s", instance.Spec.Driver.CSIDriverType) {
+				if c.Name == fmt.Sprintf("metrics-%s", driverName) {
 					if *c.Enabled {
 						metricsEnabled = true
 					}
@@ -901,7 +909,7 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 			if otelEnabled {
 				otelRunning = checkFn(&deployment)
 			}
-		case fmt.Sprintf("%s-metrics-%s", ObservabilityNamespace, instance.Spec.Driver.CSIDriverType):
+		case fmt.Sprintf("%s-metrics-%s", ObservabilityNamespace, driverName):
 			if metricsEnabled {
 				metricsRunning = checkFn(&deployment)
 			}

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -888,6 +888,9 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 	}
 
 	checkFn := func(deployment *appsv1.Deployment) bool {
+		log.Infof("deployment: %s readyreplicas: %s", deployment.Name, deployment.Status.ReadyReplicas)
+		log.Infof("deployment: %s replicas: %s", deployment.Name, *deployment.Spec.Replicas)
+		log.Infof("no pointer deployment: %s replicas: %s", deployment.Name, deployment.Spec.Replicas)
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}
 

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -890,12 +890,12 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 	checkFn := func(deployment *appsv1.Deployment) bool {
 		log.Infof("deployment: %s readyreplicas: %s", deployment.Name, deployment.Status.ReadyReplicas)
 		log.Infof("deployment: %s replicas: %s", deployment.Name, *deployment.Spec.Replicas)
-		log.Infof("no pointer deployment: %s replicas: %s", deployment.Name, deployment.Spec.Replicas)
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}
 
 	for _, deployment := range deploymentList.Items {
 		deployment := deployment
+		log.Infof("deployment: %s in deploymentList.Items", deployment.Name)
 		switch deployment.Name {
 		case "otel-collector":
 			if otelEnabled {
@@ -945,6 +945,7 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 	log.Infof("certManagerCainInjectorRunning: %s", certManagerCainInjectorRunning)
 	log.Infof("certManagerWebhookRunning: %s", certManagerWebhookRunning)
 	log.Infof("otelRunning: %s", otelRunning)
+	log.Infof("metricsEnabled:  %s", metricsEnabled)
 	log.Infof("metricsRunning:  %s", metricsRunning)
 	log.Infof("topologyRunning: %s", topologyRunning)
 

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -515,9 +515,6 @@ func UpdateStatus(ctx context.Context, instance *csmv1.ContainerStorageModule, r
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		log := logger.GetLogger(ctx)
 
-		log.Infow("UpdateStatus", "instance.Name", instance.Name)
-		log.Infow("UpdateStatus", "instance.GetNamespace", instance.GetNamespace())
-
 		csm := new(csmv1.ContainerStorageModule)
 		err := r.GetClient().Get(ctx, t1.NamespacedName{Name: instance.Name,
 			Namespace: instance.GetNamespace()}, csm)
@@ -839,7 +836,6 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 
 // observabilityStatusCheck - calculate success state for observability module
 func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModule, r ReconcileCSM, _ *csmv1.ContainerStorageModuleStatus) (bool, error) {
-	log := logger.GetLogger(ctx)
 	topologyEnabled := false
 	otelEnabled := false
 	certEnabled := false
@@ -896,14 +892,11 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 	}
 
 	checkFn := func(deployment *appsv1.Deployment) bool {
-		log.Infof("deployment: %s readyreplicas: %s", deployment.Name, deployment.Status.ReadyReplicas)
-		log.Infof("deployment: %s replicas: %s", deployment.Name, *deployment.Spec.Replicas)
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}
 
 	for _, deployment := range deploymentList.Items {
 		deployment := deployment
-		log.Infof("deployment: %s in deploymentList.Items", deployment.Name)
 		switch deployment.Name {
 		case "otel-collector":
 			if otelEnabled {
@@ -948,14 +941,6 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 			}
 		}
 	}
-
-	log.Infof("certManagerRunning: %s", certManagerRunning)
-	log.Infof("certManagerCainInjectorRunning: %s", certManagerCainInjectorRunning)
-	log.Infof("certManagerWebhookRunning: %s", certManagerWebhookRunning)
-	log.Infof("otelRunning: %s", otelRunning)
-	log.Infof("metricsEnabled:  %s", metricsEnabled)
-	log.Infof("metricsRunning:  %s", metricsRunning)
-	log.Infof("topologyRunning: %s", topologyRunning)
 
 	if certEnabled && otelEnabled && metricsEnabled && topologyEnabled {
 		return certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && otelRunning && metricsRunning && topologyRunning, nil

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -839,7 +839,7 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 
 // observabilityStatusCheck - calculate success state for observability module
 func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModule, r ReconcileCSM, _ *csmv1.ContainerStorageModuleStatus) (bool, error) {
-
+	log := logger.GetLogger(ctx)
 	topologyEnabled := false
 	otelEnabled := false
 	certEnabled := false
@@ -937,6 +937,13 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 			}
 		}
 	}
+
+	log.Infof("certManagerRunning: %s", certManagerRunning)
+	log.Infof("certManagerCainInjectorRunning: %s", certManagerCainInjectorRunning)
+	log.Infof("certManagerWebhookRunning: %s", certManagerWebhookRunning)
+	log.Infof("otelRunning: %s", otelRunning)
+	log.Infof("metricsRunning:  %s", metricsRunning)
+	log.Infof("topologyRunning: %s", topologyRunning)
 
 	if certEnabled && otelEnabled && metricsEnabled && topologyEnabled {
 		return certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && otelRunning && metricsRunning && topologyRunning, nil


### PR DESCRIPTION
# Description
This PR fixes the CSM status issue that occurred when powerscale and obs were deployed together. 


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] deployed obs + pscale: 
```
[root@master-1-cKPzXSI7IkXr5 csm-operator]# kubectl create -f samples/storage_csm_powerscale_v291.yaml
containerstoragemodule.storage.dell.com/isilon created
[root@master-1-cKPzXSI7IkXr5 csm-operator]# kubectl get pods -n karavi
NAME                                        READY   STATUS    RESTARTS   AGE
karavi-metrics-powerscale-5768d66b6-mfcqd   1/1     Running   0          10s
karavi-topology-df666fdf8-ssdmc             1/1     Running   0          13s
otel-collector-5d4b858897-mctsl             2/2     Running   0          13s
[root@master-1-cKPzXSI7IkXr5 csm-operator]# kubectl get pods -n isilon
NAME                                       READY   STATUS    RESTARTS   AGE
cert-manager-5bc6d79545-8rnmr              1/1     Running   0          19s
cert-manager-cainjector-5d9b646987-7ttw4   1/1     Running   0          19s
cert-manager-webhook-768cdc6d59-7m852      1/1     Running   0          19s
isilon-controller-574fcdf495-mv5t4         6/6     Running   0          22s
isilon-controller-574fcdf495-wxbmx         6/6     Running   0          22s
isilon-node-dpxwt                          2/2     Running   0          22s
isilon-node-hdqzt                          2/2     Running   0          22s
[root@master-1-cKPzXSI7IkXr5 csm-operator]# kubectl get csm
No resources found in default namespace.
[root@master-1-cKPzXSI7IkXr5 csm-operator]# kubectl get csm -A
NAMESPACE   NAME     CREATIONTIME   CSIDRIVERTYPE   CONFIGVERSION   STATE
isilon      isilon   28s            isilon          v2.9.1          Succeeded
```
- [ ] Ran unit tests 
