### PR TITLE
Update authorization 1.10 files to work with status logic

### DIFF
--- a/operatorconfig/moduleconfig/authorization/v1.10.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.10.0/deployment.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: proxy-server
     spec:
       containers:
@@ -92,6 +93,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: tenant-service
     spec:
       containers:
@@ -176,6 +178,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: role-service
     spec:
       serviceAccountName: role-service
@@ -254,6 +257,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: storage-service
     spec:
       serviceAccountName: storage-service
@@ -316,6 +320,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: redis
         role: primary
         tier: backend
@@ -367,6 +372,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app: redis-commander
         tier: backend
     spec:

--- a/operatorconfig/moduleconfig/authorization/v1.10.0/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.10.0/nginx-ingress-controller.yaml
@@ -426,6 +426,7 @@ spec:
   template:
     metadata:
       labels:
+        csm: <NAME>
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx


### PR DESCRIPTION
# Description
In the v1.4.2 patch release, labels were added to the config files for authorization so that we could process them in the csm status calculation logic. However, these labels were not in the 1.10 config files -- this PR adds them.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1091 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Successfully installed auth proxy:
```
[root@master-1-Zaglt7mQUY8Wg e2e]# kubectl get pods -A
NAMESPACE           NAME                                                      READY   STATUS    RESTARTS      AGE
authorization       authorization-ingress-nginx-controller-7686cb6886-bvzkp   1/1     Running   0             48s
authorization       cert-manager-765754f9cd-z5knk                             1/1     Running   0             48s
authorization       cert-manager-cainjector-759bbd747b-l7zt9                  1/1     Running   0             48s
authorization       cert-manager-webhook-6fd48c65c8-99qkh                     1/1     Running   0             48s
authorization       proxy-server-56fc569dc8-wh6mw                             3/3     Running   0             51s
authorization       redis-commander-d55d67d46-6mptc                           1/1     Running   0             50s
authorization       redis-primary-65ddb4dcdd-p8r5r                            1/1     Running   0             51s
authorization       role-service-54fccd94d6-xtpqk                             1/1     Running   0             51s
authorization       storage-service-748bf79f4c-8cmtv                          1/1     Running   0             51s
authorization       tenant-service-6586cb867c-9sgkj                           1/1     Running   0             51s
dell-csm-operator   dell-csm-operator-controller-manager-779f6cdd47-j28fg     1/1     Running   0             7m59s
kube-flannel        kube-flannel-ds-5vmqz                                     1/1     Running   0             124d
kube-flannel        kube-flannel-ds-nwfs9                                     1/1     Running   0             124d
kube-flannel        kube-flannel-ds-z2875                                     1/1     Running   1 (92d ago)   124d
kube-system         coredns-5d78c9869d-5p48t                                  1/1     Running   1 (92d ago)   124d
kube-system         coredns-5d78c9869d-kkntt                                  1/1     Running   1 (92d ago)   124d
kube-system         etcd-master-1-zaglt7mquy8wg.domain                        1/1     Running   2 (72d ago)   124d
kube-system         kube-apiserver-master-1-zaglt7mquy8wg.domain              1/1     Running   2 (72d ago)   124d
kube-system         kube-controller-manager-master-1-zaglt7mquy8wg.domain     1/1     Running   1 (92d ago)   124d
kube-system         kube-proxy-gf2ws                                          1/1     Running   0             124d
kube-system         kube-proxy-k2sch                                          1/1     Running   1 (92d ago)   124d
kube-system         kube-proxy-tq6nr                                          1/1     Running   0             124d
kube-system         kube-scheduler-master-1-zaglt7mquy8wg.domain              1/1     Running   1 (92d ago)   124d
kube-system         snapshot-controller-55687d7977-2lhqg                      1/1     Running   1 (92d ago)   96d
kube-system         snapshot-controller-55687d7977-x46c6                      1/1     Running   0             96d
minio               minio-0                                                   1/1     Running   0             111d
minio               minio-1                                                   1/1     Running   0             111d
minio               minio-2                                                   1/1     Running   0             111d
minio               minio-3                                                   1/1     Running   0             111d
[root@master-1-Zaglt7mQUY8Wg e2e]# kubectl get csm -A
NAMESPACE       NAME            CREATIONTIME   CSIDRIVERTYPE   CONFIGVERSION   STATE
authorization   authorization   56s                                            Succeeded
[root@master-1-Zaglt7mQUY8Wg e2e]#
```