### PR TITLE
Fix observability status check

### DIFF
--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -833,6 +833,7 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 
 // observabilityStatusCheck - calculate success state for observability module
 func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModule, r ReconcileCSM, _ *csmv1.ContainerStorageModuleStatus) (bool, error) {
+	log := logger.GetLogger(ctx)
 	topologyEnabled := false
 	otelEnabled := false
 	certEnabled := false

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -837,43 +837,29 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 	otelEnabled := false
 	certEnabled := false
 	metricsEnabled := false
-	certManagerRunning := false
-	certManagerCainInjectorRunning := false
-	certManagerWebhookRunning := false
-	otelRunning := false
-	metricsRunning := false
-	topologyRunning := false
 
 	driverName := instance.Spec.Driver.CSIDriverType
 
-	// TODO: PowerScale DriverType should be changed from "isilon" to "powerscale"
+	// PowerScale DriverType should be changed from "isilon" to "powerscale"
 	// this is a temporary fix until we can do that
-	if driverName == "isilon" {
-		driverName = "powerscale"
+	if driverName == csmv1.PowerScale {
+		driverName = csmv1.PowerScaleName
 	}
 
 	for _, m := range instance.Spec.Modules {
 		if m.Name == csmv1.Observability {
 			for _, c := range m.Components {
-				if c.Name == "topology" {
-					if *c.Enabled {
-						topologyEnabled = true
-					}
+				if c.Name == "topology" && *c.Enabled {
+					topologyEnabled = true
 				}
-				if c.Name == "otel-collector" {
-					if *c.Enabled {
-						otelEnabled = true
-					}
+				if c.Name == "otel-collector" && *c.Enabled {
+					otelEnabled = true
 				}
-				if c.Name == "cert-manager" {
-					if *c.Enabled {
-						certEnabled = true
-					}
+				if c.Name == "cert-manager" && *c.Enabled {
+					certEnabled = true
 				}
-				if c.Name == fmt.Sprintf("metrics-%s", driverName) {
-					if *c.Enabled {
-						metricsEnabled = true
-					}
+				if c.Name == fmt.Sprintf("metrics-%s", driverName) && *c.Enabled {
+					metricsEnabled = true
 				}
 			}
 		}
@@ -897,15 +883,24 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 		switch deployment.Name {
 		case "otel-collector":
 			if otelEnabled {
-				otelRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in observability deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		case fmt.Sprintf("%s-metrics-%s", ObservabilityNamespace, driverName):
 			if metricsEnabled {
-				metricsRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in observability deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		case fmt.Sprintf("%s-topology", ObservabilityNamespace):
 			if topologyEnabled {
-				topologyRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in observability deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		}
 	}
@@ -926,44 +921,29 @@ func observabilityStatusCheck(ctx context.Context, instance *csmv1.ContainerStor
 		switch deployment.Name {
 		case "cert-manager":
 			if certEnabled {
-				certManagerRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in observability deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		case "cert-manager-cainjector":
 			if certEnabled {
-				certManagerCainInjectorRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in observability deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		case "cert-manager-webhook":
 			if certEnabled {
-				certManagerWebhookRunning = checkFn(&deployment)
+				if !checkFn(&deployment) {
+					log.Info("%s component not running in observability deployment", deployment.Name)
+					return false, nil
+				}
 			}
 		}
 	}
 
-	if certEnabled && otelEnabled && metricsEnabled && topologyEnabled {
-		return certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && otelRunning && metricsRunning && topologyRunning, nil
-	}
-
-	if !certEnabled && otelEnabled && metricsEnabled && topologyEnabled {
-		return otelRunning && metricsRunning && topologyRunning, nil
-	}
-
-	if certEnabled && otelEnabled && metricsEnabled && !topologyEnabled {
-		return certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && otelRunning && metricsRunning, nil
-	}
-
-	if !certEnabled && otelEnabled && metricsEnabled && !topologyEnabled {
-		return otelRunning && metricsRunning, nil
-	}
-
-	if certEnabled && metricsEnabled && !topologyEnabled && !otelEnabled {
-		return certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && metricsRunning, nil
-	}
-
-	if !certEnabled && metricsEnabled && !topologyEnabled && !otelEnabled {
-		return metricsRunning, nil
-	}
-
-	return false, nil
+	return true, nil
 }
 
 // authProxyStatusCheck - calculate success state for auth proxy


### PR DESCRIPTION
# Description
Currently, the observability status check implicitly requires all components of observability to be deployed, but in fact there are legitimate use cases where the customer only deploys some of the components. This PR changes the logic of the status check to only check the status of the enabled modules.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|need to create one filling this in in a few minutes|

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Installed happy-path and negative cases of all valid component combinations (topology, otel+metrics, topology+otel+metrics). For negative test cases, just used an invalid image value for the observability component to force a pod to fail. Made sure the csm status field always reflected the state of the deployment.

Additionally, this PR adds a few E2E test scenarios where we only install topology and only install otel+metrics -- these scenarios will cover this defect as well. https://github.com/dell/csm-operator/pull/494