### PR TITLE
Adding back k8s versions file to support n-2 driver

### DIFF
--- a/operatorconfig/driverconfig/common/k8s-1.24-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.24-values.yaml
@@ -1,0 +1,30 @@
+# IT IS RECOMMENDED YOU DO NOT CHANGE THE IMAGES TO BE DOWNLOADED.
+images:
+  # "images.attacher" defines the container images used for the csi attacher
+  # container.
+  attacher: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+
+  # "images.provisioner" defines the container images used for the csi provisioner
+  # container.
+  provisioner: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+
+  # "images.snapshotter" defines the container image used for the csi snapshotter
+  snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
+
+  # "images.registrar" defines the container images used for the csi registrar
+  # container.
+  registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+  
+  # "images.resizer" defines the container images used for the csi resizer
+  # container.
+  resizer: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
+
+  # "images.externalhealthmonitorcontroller" defines the container images used for the csi external health monitor controller
+  # container.
+  externalhealthmonitorcontroller: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.11.0
+
+  # "images.sdcmonitor" defines the container images used to monitor sdc container
+  sdcmonitor: dellemc/sdc:4.5.1
+
+  #"images.metadataretriever" defines the container images used for csi metadata retriever
+  metadataretriever: dellemc/csi-metadata-retriever:v1.7.0

--- a/operatorconfig/driverconfig/common/k8s-1.25-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.25-values.yaml
@@ -1,0 +1,30 @@
+# IT IS RECOMMENDED YOU DO NOT CHANGE THE IMAGES TO BE DOWNLOADED.
+images:
+  # "images.attacher" defines the container images used for the csi attacher
+  # container.
+  attacher: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+
+  # "images.provisioner" defines the container images used for the csi provisioner
+  # container.
+  provisioner: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+
+  # "images.snapshotter" defines the container image used for the csi snapshotter
+  snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
+
+  # "images.registrar" defines the container images used for the csi registrar
+  # container.
+  registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+  
+  # "images.resizer" defines the container images used for the csi resizer
+  # container.
+  resizer: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
+
+  # "images.externalhealthmonitorcontroller" defines the container images used for the csi external health monitor controller
+  # container.
+  externalhealthmonitorcontroller: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.11.0
+
+  # "images.sdcmonitor" defines the container images used to monitor sdc container
+  sdcmonitor: dellemc/sdc:4.5.1
+
+  #"images.metadataretriever" defines the container images used for csi metadata retriever
+  metadataretriever: dellemc/csi-metadata-retriever:v1.7.0

--- a/operatorconfig/driverconfig/common/k8s-1.26-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.26-values.yaml
@@ -1,0 +1,30 @@
+# IT IS RECOMMENDED YOU DO NOT CHANGE THE IMAGES TO BE DOWNLOADED.
+images:
+  # "images.attacher" defines the container images used for the csi attacher
+  # container.
+  attacher: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+
+  # "images.provisioner" defines the container images used for the csi provisioner
+  # container.
+  provisioner: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+
+  # "images.snapshotter" defines the container image used for the csi snapshotter
+  snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
+
+  # "images.registrar" defines the container images used for the csi registrar
+  # container.
+  registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+  
+  # "images.resizer" defines the container images used for the csi resizer
+  # container.
+  resizer: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
+
+  # "images.externalhealthmonitorcontroller" defines the container images used for the csi external health monitor controller
+  # container.
+  externalhealthmonitorcontroller: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.11.0
+
+  # "images.sdcmonitor" defines the container images used to monitor sdc container
+  sdcmonitor: dellemc/sdc:4.5.1
+
+  #"images.metadataretriever" defines the container images used for csi metadata retriever
+  metadataretriever: dellemc/csi-metadata-retriever:v1.7.0


### PR DESCRIPTION
# Description
This PR reverts the changes done to remove 1.21-1.26 k8s files to support n-2 and n-1 drivers

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1091 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Installation of csm-operator followed by 2.8.0 version of Unity driver
