### PR TITLE
Fix make build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt"
 
 #Generate semver.mk
 gen-semver: generate


### PR DESCRIPTION
# Description
This PR fixes make build commands to build csm-operator image.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1091 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
make podman-build passed:
![image](https://github.com/dell/csm-operator/assets/92028646/42819554-1c31-4fbc-9027-179aa1273f98)
make docker-build passed:
![image](https://github.com/dell/csm-operator/assets/92028646/98dc65c0-cb19-4405-bf34-0f45a9568ea7)

make bundle passed:
![image](https://github.com/dell/csm-operator/assets/92028646/ff9d2b93-459a-4248-992a-a983e979fe53)
