### PR TITLE
Fix intermittent app-mobility status error

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -334,6 +334,11 @@ func (r *ContainerStorageModuleReconciler) Reconcile(ctx context.Context, req ct
 	// Update the driver
 	syncErr := r.SyncCSM(ctx, *csm, *operatorConfig, r.Client)
 	if syncErr == nil && !requeue.Requeue {
+		err = utils.UpdateStatus(ctx, csm, r, newStatus)
+		if err != nil {
+			log.Error(err, "Failed to update CR status")
+			return utils.LogBannerAndReturn(reconcile.Result{Requeue: true}, err)
+		}
 		r.EventRecorder.Eventf(csm, corev1.EventTypeNormal, csmv1.EventCompleted, "install/update storage component: %s completed OK", csm.Name)
 		return utils.LogBannerAndReturn(reconcile.Result{}, nil)
 	}

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -338,13 +338,13 @@ func (r *ContainerStorageModuleReconciler) Reconcile(ctx context.Context, req ct
 		return utils.LogBannerAndReturn(reconcile.Result{}, nil)
 	}
 
-	// Failed deployment
-	r.EventRecorder.Eventf(csm, corev1.EventTypeWarning, csmv1.EventUpdated, "Failed install: %s", syncErr.Error())
-
 	// syncErr can be nil, even if CSM state = failed
 	if syncErr == nil {
 		syncErr = errors.New("CSM state is failed")
 	}
+
+	// Failed deployment
+	r.EventRecorder.Eventf(csm, corev1.EventTypeWarning, csmv1.EventUpdated, "Failed install: %s", syncErr.Error())
 
 	return utils.LogBannerAndReturn(reconcile.Result{Requeue: true}, syncErr)
 }

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -15,6 +15,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync/atomic"
@@ -339,6 +340,11 @@ func (r *ContainerStorageModuleReconciler) Reconcile(ctx context.Context, req ct
 
 	// Failed deployment
 	r.EventRecorder.Eventf(csm, corev1.EventTypeWarning, csmv1.EventUpdated, "Failed install: %s", syncErr.Error())
+
+	// syncErr can be nil, even if CSM state = failed
+	if syncErr == nil {
+		syncErr = errors.New("CSM state is failed")
+	}
 
 	return utils.LogBannerAndReturn(reconcile.Result{Requeue: true}, syncErr)
 }

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -326,13 +326,13 @@ func (r *ContainerStorageModuleReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	newStatus := csm.GetCSMStatus()
-	_, err = utils.HandleSuccess(ctx, csm, r, newStatus, oldStatus)
+	requeue, err := utils.HandleSuccess(ctx, csm, r, newStatus, oldStatus)
 	if err != nil {
 		log.Error(err, "Failed to update CR status")
 	}
 	// Update the driver
 	syncErr := r.SyncCSM(ctx, *csm, *operatorConfig, r.Client)
-	if syncErr == nil {
+	if syncErr == nil && !requeue.Requeue {
 		r.EventRecorder.Eventf(csm, corev1.EventTypeNormal, csmv1.EventCompleted, "install/update storage component: %s completed OK", csm.Name)
 		return utils.LogBannerAndReturn(reconcile.Result{}, nil)
 	}

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -669,11 +669,13 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 	}
 
 	checkFn := func(deployment *appsv1.Deployment) bool {
+		log.Infof("Deployment: %s has %s ready replicas and %s replicas", deployment.Name, deployment.Status.ReadyReplicas, deployment.Spec.Replicas)
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}
 
 	for _, deployment := range deploymentList.Items {
 		deployment := deployment
+		log.Infof("Checking deployment: %s", deployment.Name)
 		switch deployment.Name {
 		case "cert-manager":
 			if certEnabled {
@@ -709,9 +711,10 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 		return false, err
 	}
 
-	log.Info("podList: %+v\n", podList)
+	//log.Info("podList: %+v\n", podList)
 
 	for _, pod := range podList.Items {
+		log.Infof("Checking Daemonset pod: %s", pod.Name)
 		if pod.Status.Phase == corev1.PodRunning {
 			readyPods++
 		} else {
@@ -724,6 +727,17 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 	} else {
 		daemonRunning = true
 	}
+
+	log.Infof("readyPods: %s", readyPods)
+	log.Infof("notreadyPods: %s", notreadyPods)
+	log.Infof("certEnabled: %s", certEnabled)
+	log.Infof("veleroEnabled: %s", veleroEnabled)
+	log.Infof("certManagerRunning: %s", certManagerRunning)
+	log.Infof("certManagerCainInjectorRunning: %s", certManagerCainInjectorRunning)
+	log.Infof("certManagerWebhookRunning: %s", certManagerWebhookRunning)
+	log.Infof("veleroRunning: %s", veleroRunning)
+	log.Infof("daemonRunning: %s", daemonRunning)
+
 
 	if certEnabled && veleroEnabled {
 		return appMobRunning && certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && veleroRunning && daemonRunning, nil

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -677,7 +677,6 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 	}
 
 	checkFn := func(deployment *appsv1.Deployment) bool {
-		log.Infof("Deployment: %s has %s ready replicas and %s replicas", deployment.Name, deployment.Status.ReadyReplicas, &deployment.Spec.Replicas)
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}
 
@@ -719,8 +718,6 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 		return false, err
 	}
 
-	// log.Info("podList: %+v\n", podList)
-
 	for _, pod := range podList.Items {
 		log.Infof("Checking Daemonset pod: %s", pod.Name)
 		if pod.Status.Phase == corev1.PodRunning {
@@ -735,16 +732,6 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 	} else {
 		daemonRunning = true
 	}
-
-	log.Infof("readyPods: %s", readyPods)
-	log.Infof("notreadyPods: %s", notreadyPods)
-	log.Infof("certEnabled: %s", certEnabled)
-	log.Infof("veleroEnabled: %s", veleroEnabled)
-	log.Infof("certManagerRunning: %s", certManagerRunning)
-	log.Infof("certManagerCainInjectorRunning: %s", certManagerCainInjectorRunning)
-	log.Infof("certManagerWebhookRunning: %s", certManagerWebhookRunning)
-	log.Infof("veleroRunning: %s", veleroRunning)
-	log.Infof("daemonRunning: %s", daemonRunning)
 
 	if certEnabled && veleroEnabled {
 		return appMobRunning && certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && veleroRunning && daemonRunning, nil

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -530,7 +530,7 @@ func HandleSuccess(ctx context.Context, instance *csmv1.ContainerStorageModule, 
 
 	log := logger.GetLogger(ctx)
 
-	// requeue will use reconcile.Result.Requeue field to track if operator should try reconcile again 
+	// requeue will use reconcile.Result.Requeue field to track if operator should try reconcile again
 	requeue := reconcile.Result{}
 	running, err := calculateState(ctx, instance, r, newStatus)
 	log.Info("calculateState returns ", "running: ", running)
@@ -542,9 +542,10 @@ func HandleSuccess(ctx context.Context, instance *csmv1.ContainerStorageModule, 
 		newStatus.State = constants.Succeeded
 	}
 
-	// if not running, state is failed, and we want to reconcile again 
+	// if not running, state is failed, and we want to reconcile again
 	if !running {
-		requeue = reconcile.Result{Requeue: true}  
+		requeue = reconcile.Result{Requeue: true}
+		log.Info("CSM state is failed, will requeue")
 	}
 	log.Infow("HandleSuccess Driver state ", "newStatus.State", newStatus.State)
 	if newStatus.State == constants.Succeeded {
@@ -718,7 +719,7 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 		return false, err
 	}
 
-	//log.Info("podList: %+v\n", podList)
+	// log.Info("podList: %+v\n", podList)
 
 	for _, pod := range podList.Items {
 		log.Infof("Checking Daemonset pod: %s", pod.Name)
@@ -744,7 +745,6 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 	log.Infof("certManagerWebhookRunning: %s", certManagerWebhookRunning)
 	log.Infof("veleroRunning: %s", veleroRunning)
 	log.Infof("daemonRunning: %s", daemonRunning)
-
 
 	if certEnabled && veleroEnabled {
 		return appMobRunning && certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && veleroRunning && daemonRunning, nil

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -669,13 +669,11 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 	}
 
 	checkFn := func(deployment *appsv1.Deployment) bool {
-		log.Infof("Deployment: %s has %s ready replicas and %s replicas", deployment.Name, deployment.Status.ReadyReplicas, deployment.Spec.Replicas)
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}
 
 	for _, deployment := range deploymentList.Items {
 		deployment := deployment
-		log.Infof("Checking deployment: %s", deployment.Name)
 		switch deployment.Name {
 		case "cert-manager":
 			if certEnabled {
@@ -711,10 +709,9 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 		return false, err
 	}
 
-	//log.Info("podList: %+v\n", podList)
+	log.Info("podList: %+v\n", podList)
 
 	for _, pod := range podList.Items {
-		log.Infof("Checking Daemonset pod: %s", pod.Name)
 		if pod.Status.Phase == corev1.PodRunning {
 			readyPods++
 		} else {
@@ -727,17 +724,6 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 	} else {
 		daemonRunning = true
 	}
-
-	log.Infof("readyPods: %s", readyPods)
-	log.Infof("notreadyPods: %s", notreadyPods)
-	log.Infof("certEnabled: %s", certEnabled)
-	log.Infof("veleroEnabled: %s", veleroEnabled)
-	log.Infof("certManagerRunning: %s", certManagerRunning)
-	log.Infof("certManagerCainInjectorRunning: %s", certManagerCainInjectorRunning)
-	log.Infof("certManagerWebhookRunning: %s", certManagerWebhookRunning)
-	log.Infof("veleroRunning: %s", veleroRunning)
-	log.Infof("daemonRunning: %s", daemonRunning)
-
 
 	if certEnabled && veleroEnabled {
 		return appMobRunning && certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && veleroRunning && daemonRunning, nil

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -209,13 +209,6 @@ func getDaemonSetStatus(ctx context.Context, instance *csmv1.ContainerStorageMod
 		ds := &appsv1.DaemonSet{}
 
 		nodeName := instance.GetNodeName()
-
-		// Application-mobility has a different node name than the drivers
-		if instance.GetName() == "application-mobility" {
-			log.Infof("Changing nodeName for application-mobility")
-			nodeName = "application-mobility-node-agent"
-		}
-
 		log.Infof("nodeName is %s", nodeName)
 		err := cluster.ClusterCTRLClient.Get(ctx, t1.NamespacedName{Name: nodeName,
 			Namespace: instance.GetNamespace()}, ds)
@@ -320,7 +313,7 @@ func calculateState(ctx context.Context, instance *csmv1.ContainerStorageModule,
 	// Auth proxy has no daemonset. Putting this if/else in here and setting nodeStatusGood to true by
 	// default is a little hacky but will be fixed when we refactor the status code in CSM 1.10 or 1.11
 	log.Infof("instance.GetName() is %s", instance.GetName())
-	if instance.GetName() != "" && instance.GetName() != string(csmv1.Authorization) {
+	if instance.GetName() != "" && instance.GetName() != string(csmv1.Authorization) && instance.GetName() != string(csmv1.ApplicationMobility) {
 		expected, nodeStatus, daemonSetErr := getDaemonSetStatus(ctx, instance, r)
 		newStatus.NodeStatus = nodeStatus
 		if daemonSetErr != nil {


### PR DESCRIPTION
# Description
Work by @JacobGros . Basically, we fixed two minor bugs with csm status field:
1) When we detected a failed status for a csm object, we weren't necessarily doing anything about it. Now, we requeue the reconciler if we detect a failed state.
2) When we discover a new Succeeded state through SyncCSM, we were updating our local instance object but not writing that update anywhere. Now, we are writing the update back to the cluster by calling UpdateStatus in the HandleSuccess function.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Installed AM 200 times back-to-back and confirmed state was always succeeded.
