### PR TITLE
Remove "minio" as the region for the Velero resources

### DIFF
--- a/operatorconfig/moduleconfig/application-mobility/v1.0.0/velero-backupstoragelocation.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.0/velero-backupstoragelocation.yaml
@@ -13,6 +13,6 @@ spec:
     bucket: <BUCKET_NAME>
   default: true
   config: 
-      region: minio
+      region: <BACKUP_REGION_URL>
       s3ForcePathStyle: true
       s3Url: <BACKUP_STORAGE_URL>

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -43,9 +43,9 @@ const (
 	VeleroManifest = "velero-deployment.yaml"
 	// AppMobCertManagerManifest - filename of Cert-manager manifest for app-mobility
 	AppMobCertManagerManifest = "cert-manager.yaml"
-	//UseVolSnapshotManifest - filename of use volume snapshot manifest for velero
+	// UseVolSnapshotManifest - filename of use volume snapshot manifest for velero
 	UseVolSnapshotManifest = "velero-volumesnapshotlocation.yaml"
-	//BackupStorageLoc - filename of backupstoragelocation manifest for velero
+	// BackupStorageLoc - filename of backupstoragelocation manifest for velero
 	BackupStorageLoc = "velero-backupstoragelocation.yaml"
 	// CleanupCrdManifest - filename of Cleanup Crds manifest for app-mobility
 	CleanupCrdManifest = "cleanupcrds.yaml"
@@ -55,10 +55,10 @@ const (
 	VeleroAccessManifest = "velero-secret.yaml"
 	// CertManagerIssuerCertManifest - filename of the issuer and cert for app-mobility
 	CertManagerIssuerCertManifest = "certificate.yaml"
-	//NodeAgentCrdManifest - filename of node-agent manifest for app-mobility
+	// NodeAgentCrdManifest - filename of node-agent manifest for app-mobility
 	NodeAgentCrdManifest = "node-agent.yaml"
 
-	//ControllerImg - image for app-mobility-controller
+	// ControllerImg - image for app-mobility-controller
 	ControllerImg = "<CONTROLLER_IMAGE>"
 	// ControllerImagePullPolicy - default image pull policy in yamls
 	ControllerImagePullPolicy = "<CONTROLLER_IMAGE_PULLPOLICY>"
@@ -68,14 +68,18 @@ const (
 	AppMobReplicaCount = "<APPLICATION_MOBILITY_REPLICA_COUNT>"
 	// AppMobObjStoreSecretName - Secret name for object store
 	AppMobObjStoreSecretName = "<APPLICATION_MOBILITY_OBJECT_STORE_SECRET_NAME>"
-	//BackupStorageLocation - name for Backup Storage Location
+	// BackupStorageLocation - name for Backup Storage Location
 	BackupStorageLocation = "<BACKUPSTORAGELOCATION_NAME>"
-	//VeleroBucketName - name for the used velero bucket
+	// VeleroBucketName - name for the used velero bucket
 	VeleroBucketName = "<BUCKET_NAME>"
-	//VolSnapshotlocation - name for Volume Snapshot location
+	// VolSnapshotlocation - name for Volume Snapshot location
 	VolSnapshotlocation = "<VOL_SNAPSHOT_LOCATION_NAME>"
-	//BackupStorageURL - cloud url for backup storage location
+	// BackupStorageURL - cloud url for backup storage location
 	BackupStorageURL = "<BACKUP_STORAGE_URL>"
+	// BackupStorageRegion - region for backup to take place in
+	BackupStorageRegion = "<BACKUP_REGION_URL>"
+	// BackupStorageRegionDefault - default value if BACKUP_REGION_URL is not specified
+	BackupStorageRegionDefault = "region"
 	// ConfigProvider - configurations provider
 	ConfigProvider = "<CONFIGURATION_PROVIDER>"
 	// VeleroImage - Image for velero
@@ -84,19 +88,19 @@ const (
 	VeleroImagePullPolicy = "<VELERO_IMAGE_PULLPOLICY>"
 	// VeleroAccess  -  Secret name for velero
 	VeleroAccess = "<VELERO_ACCESS>"
-	//AWSInitContainerName - Name of init container for velero - aws
+	// AWSInitContainerName - Name of init container for velero - aws
 	AWSInitContainerName = "<AWS_INIT_CONTAINER_NAME>"
-	//AWSInitContainerImage - Image of init container for velero -aws
+	// AWSInitContainerImage - Image of init container for velero -aws
 	AWSInitContainerImage = "<AWS_INIT_CONTAINER_IMAGE>"
-	//DELLInitContainerName - Name of init container for velero - dell
+	// DELLInitContainerName - Name of init container for velero - dell
 	DELLInitContainerName = "<DELL_INIT_CONTAINER_NAME>"
-	//DELLInitContainerImage - Image of init container for velero - dell
+	// DELLInitContainerImage - Image of init container for velero - dell
 	DELLInitContainerImage = "<DELL_INIT_CONTAINER_IMAGE>"
-	//AccessContents - contents of the object store secret
+	// AccessContents - contents of the object store secret
 	AccessContents = "<CRED_CONTENTS>"
-	//AKeyID - contains the aws access key id
+	// AKeyID - contains the aws access key id
 	AKeyID = "<KEY_ID>"
-	//AKey - contains the aws access key
+	// AKey - contains the aws access key
 	AKey = "<KEY>"
 
 	// AppMobCtrlMgrComponent - component name in cr for app-mobility controller-manager
@@ -139,7 +143,6 @@ func getVeleroCrdDeploy(op utils.OperatorConfig, cr csmv1.ContainerStorageModule
 
 // VeleroCrdDeploy - apply and delete Velero crds deployment
 func VeleroCrdDeploy(ctx context.Context, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
-
 	yamlString, err := getVeleroCrdDeploy(op, cr)
 	if err != nil {
 		return err
@@ -183,7 +186,6 @@ func getAppMobCrdDeploy(op utils.OperatorConfig, cr csmv1.ContainerStorageModule
 
 // AppMobCrdDeploy - apply and delete Velero crds deployment
 func AppMobCrdDeploy(ctx context.Context, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
-
 	yamlString, err := getAppMobCrdDeploy(op, cr)
 	if err != nil {
 		return err
@@ -205,7 +207,6 @@ func AppMobCrdDeploy(ctx context.Context, op utils.OperatorConfig, cr csmv1.Cont
 
 // getAppMobilityModuleDeployment - updates deployment manifest with app mobility CRD values
 func getAppMobilityModuleDeployment(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (string, error) {
-
 	yamlString := ""
 	appMob, err := getAppMobilityModule(cr)
 	if err != nil {
@@ -261,7 +262,6 @@ func getAppMobilityModuleDeployment(op utils.OperatorConfig, cr csmv1.ContainerS
 
 // AppMobilityDeployment - apply and delete controller manager deployment
 func AppMobilityDeployment(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
-
 	yamlString, err := getAppMobilityModuleDeployment(op, cr)
 	if err != nil {
 		return err
@@ -412,7 +412,6 @@ func ApplicationMobilityPrecheck(ctx context.Context, op utils.OperatorConfig, a
 
 // AppMobilityCertManager - Install/Delete cert-manager
 func AppMobilityCertManager(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
-
 	yamlString, err := getCertManager(op, cr)
 	if err != nil {
 		return err
@@ -428,7 +427,6 @@ func AppMobilityCertManager(ctx context.Context, isDeleting bool, op utils.Opera
 
 // CreateVeleroAccess - Install/Delete velero-secret yaml from operator config
 func CreateVeleroAccess(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
-
 	yamlString, err := getCreateVeleroAccess(op, cr)
 	if err != nil {
 		return err
@@ -444,7 +442,6 @@ func CreateVeleroAccess(ctx context.Context, isDeleting bool, op utils.OperatorC
 
 // getCreateVeleroAccess - gets the velero-secret manifest from operatorconfig
 func getCreateVeleroAccess(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (string, error) {
-
 	yamlString := ""
 
 	appMob, err := getAppMobilityModule(cr)
@@ -494,7 +491,6 @@ func getCreateVeleroAccess(op utils.OperatorConfig, cr csmv1.ContainerStorageMod
 
 // AppMobilityVelero - Install/Delete velero along with its features - use volume snapshot location and cleanup crds
 func AppMobilityVelero(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
-
 	var useSnap bool
 	var nodeAgent bool
 	envCredName := ""
@@ -527,12 +523,12 @@ func AppMobilityVelero(ctx context.Context, isDeleting bool, op utils.OperatorCo
 						}
 					}
 					for _, cred := range c.ComponentCred {
-						//if createWithInstall is enabled then create a secret
+						// if createWithInstall is enabled then create a secret
 						if cred.CreateWithInstall {
 							compCredName = string(cred.Name)
 							foundCred, _ := utils.GetSecret(ctx, compCredName, cr.Namespace, ctrlClient)
 							if foundCred == nil {
-								//creation of a secret
+								// creation of a secret
 								err := CreateVeleroAccess(ctx, isDeleting, op, cr, ctrlClient)
 								if err != nil {
 									return fmt.Errorf("\n Unable to deploy velero-secret for Application Mobility: %v", err)
@@ -551,7 +547,7 @@ func AppMobilityVelero(ctx context.Context, isDeleting bool, op utils.OperatorCo
 		}
 	}
 
-	//create volume snapshot location
+	// create volume snapshot location
 	if useSnap {
 
 		vsName, yamlString2, err := getUseVolumeSnapshot(ctx, op, cr, ctrlClient)
@@ -578,7 +574,7 @@ func AppMobilityVelero(ctx context.Context, isDeleting bool, op utils.OperatorCo
 		}
 	}
 
-	//enable node agent
+	// enable node agent
 	if nodeAgent {
 		yamlString4, err := getNodeAgent(op, cr)
 		if err != nil {
@@ -629,7 +625,6 @@ func getVelero(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (string
 				if strings.Contains(AppMobObjStoreSecretName, env.Name) {
 					objectSecretName = env.Value
 				}
-
 			}
 			for _, cred := range component.ComponentCred {
 				if cred.CreateWithInstall {
@@ -667,7 +662,6 @@ func getVelero(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (string
 
 // getUseVolumeSnapshot - gets the velero - volume snapshot location manifest
 func getUseVolumeSnapshot(ctx context.Context, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) (string, string, error) {
-
 	yamlString := ""
 
 	appMob, err := getAppMobilityModule(cr)
@@ -724,6 +718,7 @@ func getBackupStorageLoc(ctx context.Context, op utils.OperatorConfig, cr csmv1.
 	provider := ""
 	bucketName := ""
 	backupURL := ""
+	backupRegion := ""
 	for _, component := range appMob.Components {
 		if component.Name == AppMobVeleroComponent {
 			for _, env := range component.Envs {
@@ -739,8 +734,16 @@ func getBackupStorageLoc(ctx context.Context, op utils.OperatorConfig, cr csmv1.
 				if strings.Contains(BackupStorageURL, env.Name) {
 					backupURL = env.Value
 				}
+				if strings.Contains(BackupStorageRegion, env.Name) {
+					backupRegion = env.Value
+				}
 			}
 		}
+	}
+
+	// if BackupStorageRegion is not provided - use default variable
+	if backupRegion == "" {
+		backupRegion = BackupStorageRegionDefault
 	}
 
 	yamlString = strings.ReplaceAll(yamlString, AppMobNamespace, cr.Namespace)
@@ -748,13 +751,13 @@ func getBackupStorageLoc(ctx context.Context, op utils.OperatorConfig, cr csmv1.
 	yamlString = strings.ReplaceAll(yamlString, VeleroBucketName, bucketName)
 	yamlString = strings.ReplaceAll(yamlString, BackupStorageURL, backupURL)
 	yamlString = strings.ReplaceAll(yamlString, ConfigProvider, provider)
+	yamlString = strings.ReplaceAll(yamlString, BackupStorageRegion, backupRegion)
 
 	return backupStorageLocationName, yamlString, nil
 }
 
 // UseBackupStorageLoc - Apply/Delete velero-backupstoragelocation yaml from operator config
 func UseBackupStorageLoc(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
-
 	log := logger.GetLogger(ctx)
 	bslName, yamlString, err := getBackupStorageLoc(ctx, op, cr, ctrlClient)
 	if err != nil {
@@ -813,7 +816,6 @@ func getNodeAgent(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (str
 				if strings.Contains(AppMobObjStoreSecretName, env.Name) {
 					objectSecretName = env.Value
 				}
-
 			}
 			for _, cred := range component.ComponentCred {
 				if cred.CreateWithInstall {
@@ -833,7 +835,6 @@ func getNodeAgent(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (str
 
 // applyDeleteObjects - Applies/Deletes the object based on boolean value
 func applyDeleteObjects(ctx context.Context, ctrlClient crclient.Client, yamlString string, isDeleting bool) error {
-
 	ctrlObjects, err := utils.GetModuleComponentObj([]byte(yamlString))
 	if err != nil {
 		return err
@@ -852,5 +853,4 @@ func applyDeleteObjects(ctx context.Context, ctrlClient crclient.Client, yamlStr
 	}
 
 	return nil
-
 }

--- a/pkg/modules/application_mobility_test.go
+++ b/pkg/modules/application_mobility_test.go
@@ -98,7 +98,6 @@ func TestAppMobilityModuleDeployment(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			success, isDeleting, cr, sourceClient, op := tc(t)
 
 			err := AppMobilityDeployment(context.TODO(), isDeleting, op, cr, sourceClient)
@@ -107,10 +106,10 @@ func TestAppMobilityModuleDeployment(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }
+
 func TestAppMobilityWebhookService(t *testing.T) {
 	tests := map[string]func(t *testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig){
 		"success - deleting": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
@@ -182,20 +181,18 @@ func TestAppMobilityWebhookService(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			success, isDeleting, cr, sourceClient, op := tc(t)
 
 			err := AppMobilityWebhookService(context.TODO(), isDeleting, op, cr, sourceClient)
 			if success {
 				assert.NoError(t, err)
-
 			} else {
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }
+
 func TestControllerManagerMetricService(t *testing.T) {
 	tests := map[string]func(t *testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig){
 		"success - deleting": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
@@ -268,17 +265,14 @@ func TestControllerManagerMetricService(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			success, isDeleting, cr, sourceClient, op := tc(t)
 
 			err := ControllerManagerMetricService(context.TODO(), isDeleting, op, cr, sourceClient)
 			if success {
 				assert.NoError(t, err)
-
 			} else {
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }
@@ -372,10 +366,10 @@ func TestApplicationMobilityIssuerCertService(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }
+
 func TestApplicationMobilityPrecheck(t *testing.T) {
 	type fakeControllerRuntimeClientWrapper func(clusterConfigData []byte) (ctrlClient.Client, error)
 
@@ -479,14 +473,13 @@ func TestApplicationMobilityPrecheck(t *testing.T) {
 			err := ApplicationMobilityPrecheck(context.TODO(), operatorConfig, appMobility, tmpCR, &fakeReconcile)
 			if success {
 				assert.NoError(t, err)
-
 			} else {
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }
+
 func TestAppMobilityVelero(t *testing.T) {
 	tests := map[string]func(t *testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig){
 		"success - deleting": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
@@ -576,10 +569,10 @@ func TestAppMobilityVelero(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }
+
 func TestAppMobilityCertManager(t *testing.T) {
 	tests := map[string]func(t *testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig){
 		"success - deleting": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
@@ -640,20 +633,18 @@ func TestAppMobilityCertManager(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			success, isDeleting, cr, sourceClient, op := tc(t)
 
 			err := AppMobilityCertManager(ctx, isDeleting, op, cr, sourceClient)
 			if success {
 				assert.NoError(t, err)
-
 			} else {
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }
+
 func TestVeleroCrdDeploy(t *testing.T) {
 	tests := map[string]func(t *testing.T) (bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig){
 		"success - deleting": func(*testing.T) (bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
@@ -726,20 +717,18 @@ func TestVeleroCrdDeploy(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			success, cr, sourceClient, op := tc(t)
 
 			err := VeleroCrdDeploy(ctx, op, cr, sourceClient)
 			if success {
 				assert.NoError(t, err)
-
 			} else {
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }
+
 func TestAppMobCrdDeploy(t *testing.T) {
 	tests := map[string]func(t *testing.T) (bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig){
 		"success - deleting": func(*testing.T) (bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
@@ -812,20 +801,18 @@ func TestAppMobCrdDeploy(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			success, cr, sourceClient, op := tc(t)
 
 			err := AppMobCrdDeploy(ctx, op, cr, sourceClient)
 			if success {
 				assert.NoError(t, err)
-
 			} else {
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }
+
 func TestBackupStorageLoc(t *testing.T) {
 	tests := map[string]func(t *testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig){
 		"success - deleting": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
@@ -910,11 +897,59 @@ func TestBackupStorageLoc(t *testing.T) {
 			err := UseBackupStorageLoc(ctx, isDeleting, op, cr, sourceClient)
 			if success {
 				assert.NoError(t, err)
-
 			} else {
 				assert.Error(t, err)
 			}
+		})
+	}
+}
 
+func TestBackupStorageLocYaml(t *testing.T) {
+	tests := map[string]func(t *testing.T) (bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig){
+		"region default value": func(*testing.T) (bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_application_mobility.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			tmpCR := customResource
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+			return true, tmpCR, sourceClient, operatorConfig
+		},
+		"region custom value": func(*testing.T) (bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			customResource, err := getCustomResource("./testdata/cr_application_mobility_custom_region.yaml")
+			if err != nil {
+				panic(err)
+			}
+			tmpCR := customResource
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+			return false, tmpCR, sourceClient, operatorConfig
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldNewControllerRuntimeClientWrapper := utils.NewControllerRuntimeClientWrapper
+			oldNewK8sClientWrapper := utils.NewK8sClientWrapper
+			defer func() {
+				utils.NewControllerRuntimeClientWrapper = oldNewControllerRuntimeClientWrapper
+				utils.NewK8sClientWrapper = oldNewK8sClientWrapper
+			}()
+			defaultRegion, cr, sourceClient, op := tc(t)
+
+			bslName, bslYaml, err := getBackupStorageLoc(ctx, op, cr, sourceClient)
+			if defaultRegion {
+				// fields we set in testdata/cr_application_mobility.yaml
+				assert.Equal(t, bslName, "default")
+				// region is not set in cr_application_mobility.yaml, so default value should be used
+				assert.Contains(t, bslYaml, "region: region")
+				assert.NoError(t, err)
+			} else {
+				// fields we set in testdata/cr_application_mobility_custom_region.yaml
+				assert.Equal(t, bslName, "my-new-location")
+				assert.Contains(t, bslYaml, "region: custom")
+				assert.NoError(t, err)
+
+			}
 		})
 	}
 }

--- a/pkg/modules/testdata/cr_application_mobility_custom_region.yaml
+++ b/pkg/modules/testdata/cr_application_mobility_custom_region.yaml
@@ -1,0 +1,103 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: application-mobility
+  namespace: application-mobility
+spec:
+  modules:
+    # Application Mobility: enable csm-application-mobility module
+    - name: application-mobility
+      # enable: Enable/Disable app-mobility controller
+      enabled: true
+      configVersion: v1.0.0
+      forceRemoveModule: true
+      components:
+      - name: application-mobility-controller-manager
+        # enable: Enable/Disable application mobility controller-manager
+        enabled: true
+        image: dellemc/csm-application-mobility-controller:v0.3.0
+        imagePullPolicy: IfNotPresent
+        envs:
+          # Replica count for application mobility
+          # Allowed values: string
+          # Default value: 1
+          - name: "APPLICATION_MOBILITY_REPLICA_COUNT"
+            value: "1"
+
+      # enabled: Enable/Disable cert-manager
+      # Allowed values:
+      #   true: enable deployment of cert-manager
+      #   false: disable deployment of cert-manager only if it's already deployed
+      # Default value: false
+      - name: cert-manager
+        enabled: true
+      # enabled: Enable/Disable Velero
+      - name: velero
+        image: velero/velero:v1.10.0
+        imagePullPolicy: IfNotPresent
+        enabled: true
+        useVolumeSnapshot: true
+        # enabled: Enable/Disable node-agent service
+        deployNodeAgent: true
+        envs:
+          # Backup storage location name
+          # Allowed values: string
+          # Default value: default
+          - name: "BACKUPSTORAGELOCATION_NAME"
+            value: "my-new-location"
+          
+          # Velero bucket name
+          # Allowed values: string
+          # Default value: my-bucket
+          - name: "BUCKET_NAME"
+            value: "my-bucket"
+            
+          # Region where the bucket is located
+          - name: "BACKUP_REGION_URL"
+            value: "custom"
+
+          # Based on the objectstore being used, the velero plugin and its configuration may need to change!
+          # default value: aws
+          - name: "CONFIGURATION_PROVIDER"
+            value: "aws"
+
+          # Name of the volume snapshot location where snapshots are being taken. Required.
+          # Volume-snapshot-Location Provider will be same as CONFIGURATION_PROVIDER
+          # Default value : default
+          - name: "VOL_SNAPSHOT_LOCATION_NAME"
+            value: "default"
+          
+          # Name of the backup storage url
+          # This field has to be changed to a functional backup storage url 
+          # Default value: localhost:8000
+          - name: "BACKUP_STORAGE_URL"
+            value: "localhost:8000"
+
+          # Name of the secret in velero namespace that has credentials to access object store
+          # We can leave the field empty if there no existing secret in velero installed namespace 
+          # Default value: existing-cred
+          - name: "APPLICATION_MOBILITY_OBJECT_STORE_SECRET_NAME"
+            value: "existing-cred"
+
+        #If velero is not already present in cluster, set createWithInstall to true to create a secret. 
+        #Either this or APPLICATION_MOBILITY_OBJECT_STORE_SECRET_NAME above must be provided.   
+        credentials:
+          - createWithInstall: true  
+            #Specify the name to be used for secret that will be created to hold object store credentials.
+            name: cloud-creds
+            #Specify the object store access credentials to be stored in a secret with key "cloud".
+            secretContents: 
+              aws_access_key_id: #Provide the access key id here
+              aws_secret_access_key: #provide the access key here 
+              
+
+    # Init containers to be added to the Velero deployment's pod spec.
+    # If the value is a string then it is evaluated as a template.
+    - initContainer:
+        #initContainer image for the dell velero plugin
+      - name: dell-custom-velero-plugin
+        image: dellemc/csm-application-mobility-velero-plugin:latest
+
+        #initContainer image for the configuration provider aws
+      - name: velero-plugin-for-aws
+        image: velero/velero-plugin-for-aws:v1.5.0


### PR DESCRIPTION
# Description
This PR removes "minio" as the region for the Velero resources deployed by the Operator. 
If no region is provided in the CR, we use a generic "region" string instead. 
Region can be customized by placing this env variable in your velero component value section:
```
         # Region where the bucket is located
          - name: "BACKUP_REGION_URL"
            value: "custom"

```


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
