### PR TITLE
Add PFlex v2.9.2 to version-values.yaml

### DIFF
--- a/operatorconfig/moduleconfig/common/version-values.yaml
+++ b/operatorconfig/moduleconfig/common/version-values.yaml
@@ -47,6 +47,11 @@ powerflex:
       observability: "v1.7.0"
       replication: "v1.7.1"
       resiliency: "v1.8.1"
+  v2.9.2:
+      authorization: "v1.9.1"
+      observability: "v1.7.0"
+      replication: "v1.7.1"
+      resiliency: "v1.8.1"
 powerstore:
   # List of Driver versions and modules that supports the version
   v2.7.0:


### PR DESCRIPTION
# Description
Found a small defect while running e2e tests -- there was no entry for powerflex v2.9.2 in version-values.yaml, so I added one.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1164 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Running e2e tests