### PR TITLE
Restrict access to the kube-proxy to local pod connections only

### DIFF
--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
                   "name": "kubernetes-proxy"
                 },
                 {
-                  "image": "dellemc/connectivity-cert-persister-k8s:0.7.0",
+                  "image": "dellemc/connectivity-cert-persister-k8s:0.11.0",
                   "imagePullPolicy": "IfNotPresent",
                   "name": "cert-persister"
                 }
@@ -3572,7 +3572,7 @@ spec:
     name: metadataretriever
   - image: docker.io/dellemc/connectivity-client-docker-k8s:1.2.3
     name: dell-connectivity-client
-  - image: docker.io/dellemc/connectivity-cert-persister-k8s:0.7.0
+  - image: docker.io/dellemc/connectivity-cert-persister-k8s:0.11.0
     name: cert-persister
   skips:
   - dell-csm-operator.v1.4.2

--- a/config/samples/storage_v1_csm_connectivity_client.yaml
+++ b/config/samples/storage_v1_csm_connectivity_client.yaml
@@ -22,7 +22,7 @@ spec:
         image: bitnami/kubectl:1.28
         imagePullPolicy: IfNotPresent
       - name: cert-persister
-        image: dellemc/connectivity-cert-persister-k8s:0.7.0
+        image: dellemc/connectivity-cert-persister-k8s:0.11.0
         imagePullPolicy: IfNotPresent
 ---
 apiVersion: v1

--- a/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/statefulset.yaml
+++ b/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/statefulset.yaml
@@ -126,7 +126,7 @@ spec:
       containers:
         - name: connectivity-client-docker-k8s
           image: "<CONNECTIVITY_CLIENT_IMAGE>"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           args:
             - "--aggregator"
             - <AGGREGATOR_URL>
@@ -208,7 +208,7 @@ spec:
                 - ALL
         - name: kubernetes-proxy
           image: "<KUBERNETES_PROXY_IMAGE>"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           command: [ "kubectl" ]
           args:
             - "proxy"
@@ -226,7 +226,7 @@ spec:
                 - ALL
         - name: cert-persister
           image: "<CERT_PERSISTER_IMAGE>"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: DCM_IDENTITY_LOCATION
               valueFrom:
@@ -247,7 +247,7 @@ spec:
       initContainers:
         - name: connectivity-client-init
           image: "<ACC_INIT_CONTAINER_IMAGE>"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: DCM_IDENTITY_LOCATION
               valueFrom:

--- a/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/statefulset.yaml
+++ b/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/statefulset.yaml
@@ -213,21 +213,9 @@ spec:
           args:
             - "proxy"
             - "--port=8001"
-            - "--address=0.0.0.0"
-            - "--accept-hosts=^.*$"
+            - "--address=127.0.0.1"
+            - "--accept-hosts=^localhost$,^127.0.0.1$"
             - "--v=5"
-          ports:
-            - containerPort: 8001
-          livenessProbe:
-            httpGet:
-              path: /api/v1
-              port: 8001
-              scheme: HTTP
-            initialDelaySeconds: 5
-            timeoutSeconds: 2
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: false

--- a/samples/connectivity_client_v100.yaml
+++ b/samples/connectivity_client_v100.yaml
@@ -22,7 +22,7 @@ spec:
         image: bitnami/kubectl:1.28
         imagePullPolicy: IfNotPresent
       - name: cert-persister
-        image: dellemc/connectivity-cert-persister-k8s:0.7.0
+        image: dellemc/connectivity-cert-persister-k8s:0.11.0
         imagePullPolicy: IfNotPresent
 ---
 apiVersion: v1

--- a/tests/config/clientconfig/apex/v1.0.0/statefulset.yaml
+++ b/tests/config/clientconfig/apex/v1.0.0/statefulset.yaml
@@ -204,21 +204,9 @@ spec:
           args:
             - "proxy"
             - "--port=8001"
-            - "--address=0.0.0.0"
-            - "--accept-hosts=^.*$"
+            - "--address=127.0.0.1"
+            - "--accept-hosts=^localhost$,^127.0.0.1$"
             - "--v=5"
-          ports:
-            - containerPort: 8001
-          livenessProbe:
-            httpGet:
-              path: /api/v1
-              port: 8001
-              scheme: HTTP
-            initialDelaySeconds: 5
-            timeoutSeconds: 2
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 3
         - name: cert-persister
           image: "<CERT_PERSISTER_IMAGE>"
           imagePullPolicy: Always

--- a/tests/config/clientconfig/apex/v1.0.0/statefulset.yaml
+++ b/tests/config/clientconfig/apex/v1.0.0/statefulset.yaml
@@ -125,7 +125,7 @@ spec:
           securityContext:
             {}
           image: "<CONNECTIVITY_CLIENT_IMAGE>"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           args:
             - "--aggregator"
             - <AGGREGATOR_URL>
@@ -199,7 +199,7 @@ spec:
             failureThreshold: 3
         - name: kubernetes-proxy
           image: "<KUBERNETES_PROXY_IMAGE>"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           command: [ "kubectl" ]
           args:
             - "proxy"
@@ -209,7 +209,7 @@ spec:
             - "--v=5"
         - name: cert-persister
           image: "<CERT_PERSISTER_IMAGE>"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: DCM_IDENTITY_LOCATION
               valueFrom:
@@ -222,7 +222,7 @@ spec:
       initContainers:
         - name: connectivity-client-init
           image: "<ACC_INIT_CONTAINER_IMAGE>"
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: DCM_IDENTITY_LOCATION
               valueFrom:


### PR DESCRIPTION
# Description
This PR consists of three items:
1. Restrict the access of the kube-proxy port to only connections within the client pod.
2. Update cert-persister version to the latest build and what we are testing now. 
3. Set image pull policy to reduce image downloads.

# GitHub Issues

| GitHub Issue # |
| -------------- |
|[1029](https://github.com/dell/csm/issues/1029) |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [XI have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

1. Deployed the client and validated that the access to the proxy from outside the pod, within the cluster is blocked. The service is not exported outside the cluster.
2. Onboarded the cluster and validated that the discovery of the cluster objects was successful, including newly created objects. Checked the client pod logs to validate that incoming watcher connections are being established.