### PR TITLE
[bug-1174]: Update KUBELET_CONFIG_DIR comment

### DIFF
--- a/samples/storage_csm_powerflex_v2100.yaml
+++ b/samples/storage_csm_powerflex_v2100.yaml
@@ -33,7 +33,7 @@ spec:
           value: "true"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"

--- a/samples/storage_csm_powerflex_v280.yaml
+++ b/samples/storage_csm_powerflex_v280.yaml
@@ -33,7 +33,7 @@ spec:
           value: "true"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"

--- a/samples/storage_csm_powerflex_v290.yaml
+++ b/samples/storage_csm_powerflex_v290.yaml
@@ -33,7 +33,7 @@ spec:
           value: "true"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"

--- a/samples/storage_csm_powerflex_v291.yaml
+++ b/samples/storage_csm_powerflex_v291.yaml
@@ -33,7 +33,7 @@ spec:
           value: "true"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"

--- a/samples/storage_csm_powerflex_v292.yaml
+++ b/samples/storage_csm_powerflex_v292.yaml
@@ -33,7 +33,7 @@ spec:
           value: "true"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
         - name: "CERT_SECRET_COUNT"

--- a/samples/storage_csm_powermax_v2100.yaml
+++ b/samples/storage_csm_powermax_v2100.yaml
@@ -75,7 +75,7 @@ spec:
           value: "XYZ"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         # X_CSI_POWERMAX_PORTGROUPS: Define the set of existing port groups that the driver will use.

--- a/samples/storage_csm_powermax_v280.yaml
+++ b/samples/storage_csm_powermax_v280.yaml
@@ -75,7 +75,7 @@ spec:
           value: "XYZ"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         # X_CSI_POWERMAX_PORTGROUPS: Define the set of existing port groups that the driver will use.

--- a/samples/storage_csm_powermax_v290.yaml
+++ b/samples/storage_csm_powermax_v290.yaml
@@ -75,7 +75,7 @@ spec:
           value: "XYZ"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         # X_CSI_POWERMAX_PORTGROUPS: Define the set of existing port groups that the driver will use.

--- a/samples/storage_csm_powermax_v291.yaml
+++ b/samples/storage_csm_powermax_v291.yaml
@@ -75,7 +75,7 @@ spec:
           value: "XYZ"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         # X_CSI_POWERMAX_PORTGROUPS: Define the set of existing port groups that the driver will use.

--- a/samples/storage_csm_powerscale_v2100.yaml
+++ b/samples/storage_csm_powerscale_v2100.yaml
@@ -99,7 +99,7 @@ spec:
 
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
 

--- a/samples/storage_csm_powerscale_v280.yaml
+++ b/samples/storage_csm_powerscale_v280.yaml
@@ -99,7 +99,7 @@ spec:
 
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
 

--- a/samples/storage_csm_powerscale_v290.yaml
+++ b/samples/storage_csm_powerscale_v290.yaml
@@ -99,7 +99,7 @@ spec:
 
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
 

--- a/samples/storage_csm_powerscale_v291.yaml
+++ b/samples/storage_csm_powerscale_v291.yaml
@@ -99,7 +99,7 @@ spec:
 
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: "/var/lib/kubelet"
 

--- a/samples/storage_csm_powerstore_v2100.yaml
+++ b/samples/storage_csm_powerstore_v2100.yaml
@@ -51,6 +51,9 @@ spec:
           value: "csi-node"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         - name: CSI_LOG_LEVEL

--- a/samples/storage_csm_powerstore_v280.yaml
+++ b/samples/storage_csm_powerstore_v280.yaml
@@ -51,6 +51,9 @@ spec:
           value: "csi-node"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         - name: CSI_LOG_LEVEL

--- a/samples/storage_csm_powerstore_v290.yaml
+++ b/samples/storage_csm_powerstore_v290.yaml
@@ -51,6 +51,9 @@ spec:
           value: "csi-node"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         - name: CSI_LOG_LEVEL

--- a/samples/storage_csm_powerstore_v291.yaml
+++ b/samples/storage_csm_powerstore_v291.yaml
@@ -51,6 +51,9 @@ spec:
           value: "csi-node"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         - name: CSI_LOG_LEVEL

--- a/samples/storage_csm_unity_v2100.yaml
+++ b/samples/storage_csm_unity_v2100.yaml
@@ -49,7 +49,7 @@ spec:
           value: "15"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         # CSI_LOG_LEVEL is used to set the logging level of the driver.

--- a/samples/storage_csm_unity_v280.yaml
+++ b/samples/storage_csm_unity_v280.yaml
@@ -49,7 +49,7 @@ spec:
           value: "15"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         # CSI_LOG_LEVEL is used to set the logging level of the driver.

--- a/samples/storage_csm_unity_v290.yaml
+++ b/samples/storage_csm_unity_v290.yaml
@@ -49,7 +49,7 @@ spec:
           value: "15"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         # CSI_LOG_LEVEL is used to set the logging level of the driver.

--- a/samples/storage_csm_unity_v291.yaml
+++ b/samples/storage_csm_unity_v291.yaml
@@ -49,7 +49,7 @@ spec:
           value: "15"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
-        # Default value: None
+        # Default value: /var/lib/kubelet
         - name: KUBELET_CONFIG_DIR
           value: /var/lib/kubelet
         # CSI_LOG_LEVEL is used to set the logging level of the driver.


### PR DESCRIPTION
# Description

Change default value comment of KUBELET_CONFIG_DIR from `None` to `/var/lib/kubelet`.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1174|

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
