### PR TITLE
Restrict access to the kube-proxy to local pod connections only

### DIFF
--- a/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/statefulset.yaml
+++ b/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/statefulset.yaml
@@ -213,21 +213,9 @@ spec:
           args:
             - "proxy"
             - "--port=8001"
-            - "--address=0.0.0.0"
-            - "--accept-hosts=^.*$"
+            - "--address=127.0.0.1"
+            - "--accept-hosts=^localhost$,^127.0.0.1$"
             - "--v=5"
-          ports:
-            - containerPort: 8001
-          livenessProbe:
-            httpGet:
-              path: /api/v1
-              port: 8001
-              scheme: HTTP
-            initialDelaySeconds: 5
-            timeoutSeconds: 2
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: false

--- a/tests/config/clientconfig/apex/v1.0.0/statefulset.yaml
+++ b/tests/config/clientconfig/apex/v1.0.0/statefulset.yaml
@@ -204,21 +204,9 @@ spec:
           args:
             - "proxy"
             - "--port=8001"
-            - "--address=0.0.0.0"
-            - "--accept-hosts=^.*$"
+            - "--address=127.0.0.1"
+            - "--accept-hosts=^localhost$,^127.0.0.1$"
             - "--v=5"
-          ports:
-            - containerPort: 8001
-          livenessProbe:
-            httpGet:
-              path: /api/v1
-              port: 8001
-              scheme: HTTP
-            initialDelaySeconds: 5
-            timeoutSeconds: 2
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 3
         - name: cert-persister
           image: "<CERT_PERSISTER_IMAGE>"
           imagePullPolicy: Always


### PR DESCRIPTION
# Description
Previously merged to main via PR  [516](https://github.com/dell/csm-operator/pull/516)
This PR restricts the access of the kube-proxy port to only connections within the client pod.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|[1029](https://github.com/dell/csm-operator/pull/516)|

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [X ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

1. Deployed the client and validated that the access to the proxy from outside the pod, within the cluster is blocked. The service is not exported outside the cluster.
