### PR TITLE
[bug-1205]: Fix Authorization running in non-authorization namespace

### DIFF
--- a/operatorconfig/moduleconfig/authorization/v1.10.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.10.0/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         image: <AUTHORIZATION_OPA_KUBEMGMT_IMAGE>
         imagePullPolicy: IfNotPresent
         args:
-        - "--policies=authorization"
+        - "--policies=<NAMESPACE>"
         - "--enable-data"
       volumes:
       - name: config-volume
@@ -448,10 +448,10 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
 subjects:
   - kind: Group
-    name: system:serviceaccounts:authorization
+    name: system:serviceaccounts:<NAMESPACE>
     namespace: <NAMESPACE>
 roleRef:
   kind: ClusterRole
@@ -475,7 +475,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
   apiGroup: rbac.authorization.k8s.io
 ---
 # Define role for OPA/kube-mgmt to update configmaps with policy status.
@@ -501,5 +501,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
   apiGroup: rbac.authorization.k8s.io

--- a/operatorconfig/moduleconfig/authorization/v1.8.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.8.0/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         image: <AUTHORIZATION_OPA_KUBEMGMT_IMAGE>
         imagePullPolicy: IfNotPresent
         args:
-        - "--policies=authorization"
+        - "--policies=<NAMESPACE>"
         - "--enable-data"
       volumes:
       - name: config-volume
@@ -448,10 +448,10 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
 subjects:
   - kind: Group
-    name: system:serviceaccounts:authorization
+    name: system:serviceaccounts:<NAMESPACE>
     namespace: <NAMESPACE>
 roleRef:
   kind: ClusterRole
@@ -475,7 +475,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
   apiGroup: rbac.authorization.k8s.io
 ---
 # Define role for OPA/kube-mgmt to update configmaps with policy status.
@@ -501,5 +501,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
   apiGroup: rbac.authorization.k8s.io

--- a/operatorconfig/moduleconfig/authorization/v1.9.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.9.0/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         image: <AUTHORIZATION_OPA_KUBEMGMT_IMAGE>
         imagePullPolicy: IfNotPresent
         args:
-        - "--policies=authorization"
+        - "--policies=<NAMESPACE>"
         - "--enable-data"
       volumes:
       - name: config-volume
@@ -448,10 +448,10 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
 subjects:
   - kind: Group
-    name: system:serviceaccounts:authorization
+    name: system:serviceaccounts:<NAMESPACE>
     namespace: <NAMESPACE>
 roleRef:
   kind: ClusterRole
@@ -475,7 +475,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
   apiGroup: rbac.authorization.k8s.io
 ---
 # Define role for OPA/kube-mgmt to update configmaps with policy status.
@@ -501,5 +501,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
   apiGroup: rbac.authorization.k8s.io

--- a/operatorconfig/moduleconfig/authorization/v1.9.1/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.9.1/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         image: <AUTHORIZATION_OPA_KUBEMGMT_IMAGE>
         imagePullPolicy: IfNotPresent
         args:
-        - "--policies=authorization"
+        - "--policies=<NAMESPACE>"
         - "--enable-data"
       volumes:
       - name: config-volume
@@ -448,10 +448,10 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
 subjects:
   - kind: Group
-    name: system:serviceaccounts:authorization
+    name: system:serviceaccounts:<NAMESPACE>
     namespace: <NAMESPACE>
 roleRef:
   kind: ClusterRole
@@ -475,7 +475,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
   apiGroup: rbac.authorization.k8s.io
 ---
 # Define role for OPA/kube-mgmt to update configmaps with policy status.
@@ -501,5 +501,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group
-  name: system:serviceaccounts:authorization
+  name: system:serviceaccounts:<NAMESPACE>
   apiGroup: rbac.authorization.k8s.io

--- a/samples/authorization/csm_authorization_proxy_server_v1100.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v1100.yaml
@@ -2,7 +2,6 @@ apiVersion: storage.dell.com/v1
 kind: ContainerStorageModule
 metadata:
   name: authorization
-  namespace: authorization
 spec:
   modules:
     # Authorization: enable csm-authorization proxy server for RBAC

--- a/samples/authorization/csm_authorization_proxy_server_v1100.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v1100.yaml
@@ -66,7 +66,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: csm-config-params
-  namespace: authorization
 data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10

--- a/samples/authorization/csm_authorization_proxy_server_v180.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v180.yaml
@@ -65,7 +65,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: csm-config-params
-  namespace: authorization
 data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10

--- a/samples/authorization/csm_authorization_proxy_server_v180.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v180.yaml
@@ -2,7 +2,6 @@ apiVersion: storage.dell.com/v1
 kind: ContainerStorageModule
 metadata:
   name: authorization
-  namespace: authorization
 spec:
   modules:
     # Authorization: enable csm-authorization proxy server for RBAC

--- a/samples/authorization/csm_authorization_proxy_server_v190.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v190.yaml
@@ -65,7 +65,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: csm-config-params
-  namespace: authorization
 data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10

--- a/samples/authorization/csm_authorization_proxy_server_v190.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v190.yaml
@@ -2,7 +2,6 @@ apiVersion: storage.dell.com/v1
 kind: ContainerStorageModule
 metadata:
   name: authorization
-  namespace: authorization
 spec:
   modules:
     # Authorization: enable csm-authorization proxy server for RBAC

--- a/samples/authorization/csm_authorization_proxy_server_v191.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v191.yaml
@@ -65,7 +65,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: csm-config-params
-  namespace: authorization
 data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10

--- a/samples/authorization/csm_authorization_proxy_server_v191.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v191.yaml
@@ -2,7 +2,6 @@ apiVersion: storage.dell.com/v1
 kind: ContainerStorageModule
 metadata:
   name: authorization
-  namespace: authorization
 spec:
   modules:
     # Authorization: enable csm-authorization proxy server for RBAC

--- a/samples/authorization/karavi-storage-secret.yaml
+++ b/samples/authorization/karavi-storage-secret.yaml
@@ -3,6 +3,5 @@ kind: Secret
 type: Opaque
 metadata:
   name: karavi-storage-secret
-  namespace: authorization
 data:
   storage-systems.yaml: c3RvcmFnZToK


### PR DESCRIPTION
# Description

- Makes namespace configurable for OPA to look for policy configmaps
- Makes namespace configurable for cluster roles and bindings for OPA
- Removes namespace from Authorization sample files

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1205 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Existing unit tests and manual volume creation with driver and Authorization installed in non-authorization namespace.
