### PR TITLE
feat: allowedNetworks added to unity

### DIFF
--- a/config/samples/storage_v1_csm_unity.yaml
+++ b/config/samples/storage_v1_csm_unity.yaml
@@ -16,7 +16,7 @@ spec:
       #   true: enable storage capacity tracking
       #   false: disable storage capacity tracking
       storageCapacity: true
-    # Config version for CSI Unity v2.10.0 driver
+    # Config version for CSI Unity v2.11.0 driver
     configVersion: v2.11.0
     # Controller count
     replicas: 2
@@ -24,7 +24,7 @@ spec:
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      # Image for CSI Unity driver v2.10.0
+      # Image for CSI Unity driver v2.11.0
       image: "dellemc/csi-unity:v2.11.0"
       imagePullPolicy: IfNotPresent
       envs:

--- a/operatorconfig/driverconfig/unity/v2.11.0/controller.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/controller.yaml
@@ -1,0 +1,259 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller  
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update","patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update","patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+# below for snapshotter
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  # below for resizer
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  # Permissions for CSIStorageCapacity
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-controller
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  selector:
+    matchLabels:
+      app: <DriverDefaultReleaseName>-controller
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: <DriverDefaultReleaseName>-controller
+    spec:
+      serviceAccountName: <DriverDefaultReleaseName>-controller
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - <DriverDefaultReleaseName>-controller
+            topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--volume-name-prefix=csivol"
+            - "--volume-name-uuid-length=10"
+            - "--timeout=180s"
+            - "--worker-threads=6"
+            - "--v=5"
+            - "--feature-gates=Topology=true"
+            - "--strict-topology=true"
+            - "--leader-election"
+            - "--leader-election-namespace=<DriverDefaultReleaseNamespace>"
+            - "--default-fstype=ext4"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval=5m"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: snapshotter
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--snapshot-name-prefix=csi-snap"
+            - "--snapshot-name-uuid-length=10"
+            - "--timeout=360s"
+            - "--v=5"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: external-health-monitor
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.11.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--http-endpoint=:8080"
+            - "--enable-node-watcher=true"
+            - "--monitor-interval=60s"
+            - "--timeout=180s"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: driver
+          image: dellemc/csi-unity:v2.11.0
+          args:
+            - "--driver-name=csi-unity.dellemc.com"
+            - "--driver-config=/unity-config/driver-config-params.yaml"
+            - "--driver-secret=/unity-secret/config"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CSI_ENDPOINT
+              value: /var/run/csi/csi.sock
+            - name: X_CSI_MODE
+              value: controller
+            - name: X_CSI_UNITY_AUTOPROBE
+              value: "true"
+            - name: SSL_CERT_DIR
+              value: /certs
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: unity-config
+              mountPath: /unity-config
+            - name: unity-secret
+              mountPath: /unity-secret
+      volumes:
+        - name: certs
+          projected:
+            sources:
+              - secret:
+                  name: <DriverDefaultReleaseName>-certs-0
+                  items:
+                    - key: cert-0
+                      path: cert-0
+        - name: socket-dir
+          emptyDir:
+        - name: unity-config
+          configMap:
+              name: <DriverDefaultReleaseName>-config-params
+        - name: unity-secret
+          secret:
+              secretName: <DriverDefaultReleaseName>-creds

--- a/operatorconfig/driverconfig/unity/v2.11.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/csidriver.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+    name: csi-unity.dellemc.com
+spec:
+    attachRequired: true
+    podInfoOnMount: true
+    storageCapacity: true
+    volumeLifecycleModes:
+      - Persistent
+      - Ephemeral
+    fsGroupPolicy: ReadWriteOnceWithFSType

--- a/operatorconfig/driverconfig/unity/v2.11.0/driver-config-params.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/driver-config-params.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: <DriverDefaultReleaseNamespace>
+data:
+  driver-config-params.yaml: |
+    CSI_LOG_LEVEL: "info"
+    ALLOW_RWO_MULTIPOD_ACCESS: "false"
+    MAX_UNITY_VOLUMES_PER_NODE: 0
+    SYNC_NODE_INFO_TIME_INTERVAL: 15
+    TENANT_NAME: ""

--- a/operatorconfig/driverconfig/unity/v2.11.0/driver-config-params.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/driver-config-params.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "info"
+    CSI_LOG_FORMAT: "JSON"
     ALLOW_RWO_MULTIPOD_ACCESS: "false"
     MAX_UNITY_VOLUMES_PER_NODE: 0
     SYNC_NODE_INFO_TIME_INTERVAL: 15

--- a/operatorconfig/driverconfig/unity/v2.11.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/node.yaml
@@ -1,0 +1,191 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["create", "delete", "get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["privileged"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-node
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-node
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: <DriverDefaultReleaseName>-node
+  template:
+    metadata:
+      labels:
+        app: <DriverDefaultReleaseName>-node
+    spec:
+      serviceAccountName: <DriverDefaultReleaseName>-node
+      hostIPC: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: driver
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: dellemc/csi-unity:v2.11.0
+          imagePullPolicy:  IfNotPresent
+          args:
+            - "--driver-name=csi-unity.dellemc.com"
+            - "--driver-config=/unity-config/driver-config-params.yaml"
+            - "--driver-secret=/unity-secret/config"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/kubelet/plugins/unity.emc.dell.com/csi_sock
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_UNITY_AUTOPROBE
+              value: "true"
+            - name: X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS
+              value: "false"
+            - name: X_CSI_PRIVATE_MOUNT_DIR
+              value: "/var/lib/kubelet/plugins/unity.emc.dell.com/disks"
+            - name: X_CSI_EPHEMERAL_STAGING_PATH
+              value: "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+            - name: X_CSI_ISCSI_CHROOT
+              value: "/noderoot"
+            - name: X_CSI_UNITY_NODENAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: SSL_CERT_DIR
+              value: /certs
+            - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL
+              value: "15"
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
+            - name: X_CSI_ALLOWED_NETWORKS
+              value: "<X_CSI_ALLOWED_NETWORKS>"
+          volumeMounts:
+            - name: driver-path
+              mountPath: /var/lib/kubelet/plugins/unity.emc.dell.com
+            - name: volumedevices-path
+              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+              mountPropagation: "Bidirectional"
+            - name: pods-path
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+            - name: dev
+              mountPath: /dev
+            - name: noderoot
+              mountPath: /noderoot
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: unity-config
+              mountPath: /unity-config
+            - name: unity-secret
+              mountPath: /unity-secret
+        - name: registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/unity.emc.dell.com/csi_sock
+          env:
+            - name: ADDRESS
+              value: /csi/csi_sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: registration-dir
+              mountPath: /registration
+            - name: driver-path
+              mountPath: /csi
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: driver-path
+          hostPath:
+            path: /var/lib/kubelet/plugins/unity.emc.dell.com
+            type: DirectoryOrCreate
+        - name: volumedevices-path
+          hostPath:
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi
+            type: DirectoryOrCreate
+        - name: pods-path
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: noderoot
+          hostPath:
+            path: /
+            type: Directory
+        - name: certs
+          projected:
+            sources:
+              - secret:
+                  name: <DriverDefaultReleaseName>-certs-0
+                  items:
+                    - key: cert-0
+                      path: cert-0
+        - name: unity-config
+          configMap:
+              name: <DriverDefaultReleaseName>-config-params
+        - name: unity-secret
+          secret:
+              secretName: <DriverDefaultReleaseName>-creds

--- a/operatorconfig/driverconfig/unity/v2.11.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/upgrade-path.yaml
@@ -1,1 +1,1 @@
-minUpgradePath: v2.9.1
+minUpgradePath: v2.10.0

--- a/operatorconfig/driverconfig/unity/v2.11.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/upgrade-path.yaml
@@ -1,0 +1,1 @@
+minUpgradePath: v2.9.1

--- a/pkg/drivers/unity.go
+++ b/pkg/drivers/unity.go
@@ -50,6 +50,9 @@ const (
 
 	// TenantName - Name of the tenant
 	TenantName = "<TENANT_NAME>"
+
+	// Allowed networks - list of networks that can be used for NFS traffic
+	AllowedNetworks = "<X_CSI_ALLOWED_NETWORKS>"
 )
 
 // PrecheckUnity do input validation
@@ -112,6 +115,7 @@ func ModifyUnityCR(yamlString string, cr csmv1.ContainerStorageModule, fileType 
 	healthMonitorNode := ""
 	healthMonitorController := ""
 	storageCapacity := "false"
+	allowedNetworks := ""
 
 	switch fileType {
 	case "Node":
@@ -119,8 +123,12 @@ func ModifyUnityCR(yamlString string, cr csmv1.ContainerStorageModule, fileType 
 			if env.Name == "X_CSI_HEALTH_MONITOR_ENABLED" {
 				healthMonitorNode = env.Value
 			}
+			if env.Name == "X_CSI_ALLOWED_NETWORKS" {
+				allowedNetworks = env.Value
+			}
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorNode)
+		yamlString = strings.ReplaceAll(yamlString, AllowedNetworks, allowedNetworks)
 	case "Controller":
 		for _, env := range cr.Spec.Driver.Controller.Envs {
 			if env.Name == "X_CSI_HEALTH_MONITOR_ENABLED" {

--- a/pkg/drivers/unity.go
+++ b/pkg/drivers/unity.go
@@ -51,7 +51,7 @@ const (
 	// TenantName - Name of the tenant
 	TenantName = "<TENANT_NAME>"
 
-	// Allowed networks - list of networks that can be used for NFS traffic
+	// AllowedNetworks - list of networks that can be used for NFS traffic
 	AllowedNetworks = "<X_CSI_ALLOWED_NETWORKS>"
 )
 

--- a/samples/storage_csm_unity_v2110.yaml
+++ b/samples/storage_csm_unity_v2110.yaml
@@ -16,7 +16,7 @@ spec:
       #   true: enable storage capacity tracking
       #   false: disable storage capacity tracking
       storageCapacity: true
-    # Config version for CSI Unity v2.10.0 driver
+    # Config version for CSI Unity v2.11.0 driver
     configVersion: v2.11.0
     # Controller count
     replicas: 2
@@ -24,7 +24,7 @@ spec:
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      # Image for CSI Unity driver v2.10.0
+      # Image for CSI Unity driver v2.11.0
       image: "dellemc/csi-unity:v2.11.0"
       imagePullPolicy: IfNotPresent
       envs:

--- a/samples/storage_csm_unity_v2110.yaml
+++ b/samples/storage_csm_unity_v2110.yaml
@@ -57,6 +57,11 @@ spec:
         # Default value: "info"
         - name: CSI_LOG_LEVEL
           value: debug
+        # CSI driver log format
+        # Allowed values: "TEXT" or "JSON"
+        # Default value: "TEXT"
+        - name: CSI_LOG_FORMAT
+          value: "TEXT"
         # TENANT_NAME - Tenant name that need to added while adding host entry to the array.
         # Allowed values: string
         # Default value: ""


### PR DESCRIPTION
# Description
This PR adds `allowedNetworks`  parameter to CSM CR when Unity is being installed. This enables the user to select which networks should be used for node <-> array communication.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1222|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Manually tested installation with the new fieid in `envs` section of CR, and without new field to make sure no regression happend.
- Ran unit tests.
