### PR TITLE
Add bucket cacert for application mobility

### DIFF
--- a/operatorconfig/moduleconfig/application-mobility/v1.0.0/velero-backupstoragelocation.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.0/velero-backupstoragelocation.yaml
@@ -11,6 +11,7 @@ spec:
   accessMode: ReadWrite
   objectStorage:
     bucket: <BUCKET_NAME>
+    cacert: <BUCKET_CACERT>
   default: true
   config: 
       region: <BACKUP_REGION_URL>

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.1/velero-backupstoragelocation.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.1/velero-backupstoragelocation.yaml
@@ -11,6 +11,7 @@ spec:
   accessMode: ReadWrite
   objectStorage:
     bucket: <BUCKET_NAME>
+    cacert: <BUCKET_CACERT>
   default: true
   config: 
       region: <BACKUP_REGION_URL>

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.2/velero-backupstoragelocation.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.2/velero-backupstoragelocation.yaml
@@ -11,6 +11,7 @@ spec:
   accessMode: ReadWrite
   objectStorage:
     bucket: <BUCKET_NAME>
+    cacert: <BUCKET_CACERT>
   default: true
   config: 
       region: <BACKUP_REGION_URL>

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -72,6 +72,8 @@ const (
 	BackupStorageLocation = "<BACKUPSTORAGELOCATION_NAME>"
 	// VeleroBucketName - name for the used velero bucket
 	VeleroBucketName = "<BUCKET_NAME>"
+	// VeleroCaCert - name for the used velero cacert
+	VeleroCaCert = "<BUCKET_CACERT>"
 	// VolSnapshotlocation - name for Volume Snapshot location
 	VolSnapshotlocation = "<VOL_SNAPSHOT_LOCATION_NAME>"
 	// BackupStorageURL - cloud url for backup storage location
@@ -729,6 +731,7 @@ func getBackupStorageLoc(_ context.Context, op utils.OperatorConfig, cr csmv1.Co
 	bucketName := ""
 	backupURL := ""
 	backupRegion := ""
+	bucketCacert := ""
 	for _, component := range appMob.Components {
 		if component.Name == AppMobVeleroComponent {
 			for _, env := range component.Envs {
@@ -747,6 +750,9 @@ func getBackupStorageLoc(_ context.Context, op utils.OperatorConfig, cr csmv1.Co
 				if strings.Contains(BackupStorageRegion, env.Name) {
 					backupRegion = env.Value
 				}
+				if strings.Contains(VeleroCaCert, env.Name) {
+					bucketCacert = env.Value
+				}
 			}
 		}
 	}
@@ -762,6 +768,7 @@ func getBackupStorageLoc(_ context.Context, op utils.OperatorConfig, cr csmv1.Co
 	yamlString = strings.ReplaceAll(yamlString, BackupStorageURL, backupURL)
 	yamlString = strings.ReplaceAll(yamlString, ConfigProvider, provider)
 	yamlString = strings.ReplaceAll(yamlString, BackupStorageRegion, backupRegion)
+	yamlString = strings.ReplaceAll(yamlString, VeleroCaCert, bucketCacert)
 
 	return backupStorageLocationName, yamlString, nil
 }


### PR DESCRIPTION
# Description
Add cacert parameter  for application mobility so user can setup velero BSL with cacert.


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have not allowed coverage numbers to degenerate
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Feature is about parameter in custom resource, so test refer deploy CSM resource.

- [x] deploy with parameter 
- [x] deploy without parameter 
