### PR TITLE
Set default container to driver

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -6,6 +6,7 @@ general:
     - CVE-2019-1010022
     - CVE-2023-0286
     - CVE-2023-4911 # this will be removed with the glibc library is updated in the UBI image
+    - CVE-2024-2961 # Another unfixed glibc CVE
 
   bestPracticeViolations:
     # list of best practies violatied that needs a fix

--- a/operatorconfig/driverconfig/powerflex/v2.10.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.10.0/controller.yaml
@@ -104,6 +104,8 @@ spec:
     metadata:
       labels:
         name: <DriverDefaultReleaseName>-controller
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       affinity:
         nodeSelector:

--- a/operatorconfig/driverconfig/powerflex/v2.10.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.10.0/node.yaml
@@ -70,6 +70,8 @@ spec:
       labels:
         app: <DriverDefaultReleaseName>-node
         driver.dellemc.com: dell-storage
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccount: <DriverDefaultReleaseName>-node
       dnsPolicy: ClusterFirstWithHostNet

--- a/operatorconfig/driverconfig/powermax/v2.10.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.10.0/controller.yaml
@@ -122,6 +122,8 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccount: <DriverDefaultReleaseName>-controller
       affinity:

--- a/operatorconfig/driverconfig/powermax/v2.10.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.10.0/node.yaml
@@ -73,6 +73,8 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccount: <DriverDefaultReleaseName>-node
       #nodeSelector:

--- a/operatorconfig/driverconfig/powerscale/v2.10.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.10.0/controller.yaml
@@ -113,6 +113,8 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccount: <DriverDefaultReleaseName>-controller
       affinity:

--- a/operatorconfig/driverconfig/powerscale/v2.10.0/node.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.10.0/node.yaml
@@ -61,6 +61,8 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccount: <DriverDefaultReleaseName>-node
       #nodeSelector:

--- a/operatorconfig/driverconfig/powerstore/v2.10.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.10.0/controller.yaml
@@ -117,6 +117,8 @@ spec:
     metadata:
       labels:
         name: <DriverDefaultReleaseName>-controller
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccountName: <DriverDefaultReleaseName>-controller
       affinity:

--- a/operatorconfig/driverconfig/powerstore/v2.10.0/node.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.10.0/node.yaml
@@ -77,6 +77,8 @@ spec:
       labels:
         app: <DriverDefaultReleaseName>-node
         driver.dellemc.com: dell-storage
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       #nodeSelector:
       #tolerations:

--- a/operatorconfig/driverconfig/unity/v2.10.0/controller.yaml
+++ b/operatorconfig/driverconfig/unity/v2.10.0/controller.yaml
@@ -106,6 +106,8 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccountName: <DriverDefaultReleaseName>-controller
       affinity:

--- a/operatorconfig/driverconfig/unity/v2.10.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.10.0/node.yaml
@@ -63,6 +63,8 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccountName: <DriverDefaultReleaseName>-node
       hostIPC: true


### PR DESCRIPTION
# Description
Make the default container to driver so it is easier to capture log and consistent with Helm Charts

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
This hasn't been tested with the Operator ; the label is present in Helm Chart since several months : https://github.com/dell/helm-charts/blame/905c3951da497421276b54540a092712dc66b2b1/charts/csi-vxflexos/templates/controller.yaml#L171

Please share the protocol to try it out if any.