### PR TITLE
Add storage cluster roles

### DIFF
--- a/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
@@ -285,8 +285,14 @@ metadata:
   name: storage-service
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "patch", "post"]
+    resources: ["secrets", "events"]
+    verbs: ["get", "patch","post", create]
+  - apiGroups: ["csm-authorization.storage.dell.com"]
+    resources: ["storages", "csmtenants", "csmroles"]
+    verbs: ["get", "list"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "update", "get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
# Description
Add missing cluster roles to the authorization storage service.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1281 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Install Authorization and ensured that storage service was running without errors. Also, add storage, role, and tenant to ensure everything is working as expected.
