### PR TITLE
Add username and password to rediscommander

### DIFF
--- a/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
   password: K@ravi123!
+  commander_user: dev
 ---
 # Proxy service
 apiVersion: v1
@@ -552,6 +553,16 @@ spec:
             secretKeyRef:
               name: redis-csm-secret
               key: password
+        - name: HTTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: redis-csm-secret
+              key: password          
+        - name: HTTP_USER
+          valueFrom:
+            secretKeyRef:
+              name: redis-csm-secret
+              key: commander_user
         ports:
         - name: <AUTHORIZATION_REDIS_COMMANDER>
           containerPort: 8081


### PR DESCRIPTION
# Description
Add login username and password to rediscommander web portal so that it's not exposed to anyone on the cluster.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1281|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Deployed rediscommander on k8s cluster with operator and manually tested.
