### PR TITLE
Fix cert-manager deployment, go mod updates

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -941,6 +941,14 @@ func (r *ContainerStorageModuleReconciler) reconcileObservability(ctx context.Co
 // reconcileAuthorization - deploy authorization proxy server
 func (r *ContainerStorageModuleReconciler) reconcileAuthorization(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient client.Client) error {
 	log := logger.GetLogger(ctx)
+
+	if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthCertManagerComponent) {
+		log.Infow("Reconcile authorization cert-manager")
+		if err := modules.CommonCertManager(ctx, isDeleting, op, cr, ctrlClient); err != nil {
+			return fmt.Errorf("unable to reconcile cert-manager for authorization: %v", err)
+		}
+	}
+
 	if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthProxyServerComponent) {
 		log.Infow("Reconcile authorization proxy-server")
 		if err := modules.AuthorizationServerDeployment(ctx, isDeleting, op, cr, ctrlClient); err != nil {
@@ -949,13 +957,6 @@ func (r *ContainerStorageModuleReconciler) reconcileAuthorization(ctx context.Co
 
 		if err := modules.InstallPolicies(ctx, isDeleting, op, cr, ctrlClient); err != nil {
 			return fmt.Errorf("unable to install policies: %v", err)
-		}
-	}
-
-	if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthCertManagerComponent) {
-		log.Infow("Reconcile authorization cert-manager")
-		if err := modules.CommonCertManager(ctx, isDeleting, op, cr, ctrlClient); err != nil {
-			return fmt.Errorf("unable to reconcile cert-manager for authorization: %v", err)
 		}
 	}
 

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -87,6 +87,7 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f // indirect
+	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/sync v0.4.0 // indirect


### PR DESCRIPTION
# Description
Cert-manager reconciliation in authorizationReconcile was happening after authorization proxy reconcile. This was looking for cert-manager to be present causing it to fail and exit and never invoke cert manager reconcile (which was actually install cert-manager CRDs if not already present and requested)
Solution : move the code that does cert-manager reconciliation prior to the auth proxy reconcile. 

Recent changes to e2e tests probably left a stale entry, causing docker builds to fail. That is also fixed in this PR. 

# GitHub Issues
List the GitHub issues impacted by this PR:
https://github.com/dell/csm/issues/1281

| GitHub Issue # |
|https://github.com/dell/csm/issues/1281 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Deploy Operator on a clean system and deploy authorization module. Verify cert-manager and all the other pods are deployed successfully. Note: If cert-manager is not deployed first, the proxy server, tenant , role service pods will fail. Redis and sentinel pod deployments wont be attempted even. Verified that cert-manager is deployed first and then all the pods (services and redis etc) are up and running after the installation. 
