### PR TITLE
Added sentinel retry logic

### DIFF
--- a/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
@@ -754,27 +754,41 @@ spec:
                 nodes=$( echo "$nodes*$node" )
             done            
             loop=$(echo $nodes | sed -e "s/"*"/\n/g")
-            
-            for i in $loop
-            do
-                echo "Finding master at $i"
-                ROLE=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep role | cut -d ":" -f2)
-                if [ "$ROLE" = "master" ]; then
-                    MASTER=$i.authorization.svc.cluster.local
-                    echo "Master found at $MASTER..."
-                    break
-                else
-                  MASTER=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep master_host: | cut -d ":" -f2)
-                  if [ "$MASTER" = "" ]; then
-                      echo "Master not found..."
-                      echo "Sleeping 5 seconds for pods to come up..."
-                      sleep 5
-                      MASTER=
-                  else
+
+            foundMaster=$false
+
+            while [ $foundMaster == $false ] 
+            do  
+              for i in $loop
+              do
+                  echo "Finding master at $i"
+                  ROLE=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep role | cut -d ":" -f2)
+                  if [ "$ROLE" = "master" ]; then
+                      MASTER=$i.authorization.svc.cluster.local
                       echo "Master found at $MASTER..."
+                      foundMaster=$true
                       break
+                  else
+                    MASTER=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep master_host: | cut -d ":" -f2)
+                    if [ "$MASTER" = "" ]; then
+                        echo "Master not found..."
+                        echo "Sleeping 5 seconds for redis pods to come up..."
+                        sleep 5
+                        MASTER=
+                    else
+                        echo "Master found at $MASTER..."
+                        foundMaster=$true
+                        break
+                    fi
                   fi
-                fi
+              done
+
+              if [ $foundMaster == $true ]; then
+                break
+              else   
+                 echo "Master not found, sleep for 30s before attempting again"
+                 sleep 30
+              fi
             done
             
             echo "sentinel monitor mymaster $MASTER 6379 2" >> /tmp/master


### PR DESCRIPTION
# Description
Sentinel pod deployment occasionally cycles through all redis pods even before they come up and then fails. 
Adding retry logic in sentinel deployment (init container) to keep checking for redis pods with a delay of 30s if all redis pods have been checked and none of them are ready. 

This is not consistently reproducible and it depends on the particular environment when this manifests. The retry logic added should help. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| https://github.com/dell/csm/issues/1281|
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Deployed authorization using operator and verified sentinel pods all come up.
