### PR TITLE
Added function to get the csm namespaces from the cluster.

### DIFF
--- a/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/brownfield-onboard.yaml
+++ b/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/brownfield-onboard.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: connectivity-client-docker-k8s
+  namespace: <ExistingNameSpace>
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["list","get", "create", "update", "delete","watch"]
+  - apiGroups: ["storage.dell.com"]
+    resources: ["containerstoragemodules"]
+    verbs: ["create", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "delete", "update"]
+  - apiGroups: ["mobility.storage.dell.com"]
+    resources: ["backups"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: connectivity-client-docker-k8s
+  namespace: <ExistingNameSpace>
+subjects:
+  - kind: ServiceAccount
+    name: connectivity-client-docker-k8s
+    namespace: <ClientNameSpace>
+roleRef:
+  kind: Role
+  name: connectivity-client-docker-k8s
+  apiGroup: rbac.authorization.k8s.io

--- a/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/brownfield-onboard.yaml
+++ b/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/brownfield-onboard.yaml
@@ -30,4 +30,3 @@ roleRef:
   kind: Role
   name: connectivity-client-docker-k8s
   apiGroup: rbac.authorization.k8s.io
-  

--- a/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/brownfield-onboard.yaml
+++ b/operatorconfig/clientconfig/apexconnectivityclient/v1.0.0/brownfield-onboard.yaml
@@ -30,3 +30,4 @@ roleRef:
   kind: Role
   name: connectivity-client-docker-k8s
   apiGroup: rbac.authorization.k8s.io
+  

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1180,14 +1180,13 @@ func getNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, e
 	// Set to store unique namespaces
 	namespaceMap := make(map[string]struct{})
 
-	list := &csmv1.ContainerStorageModuleList{}
+	csmList := &csmv1.ContainerStorageModuleList{}
 
-	if err := ctrlClient.List(ctx, list); err != nil {
+	if err := ctrlClient.List(ctx, csmList); err != nil {
 		return nil, fmt.Errorf("list csm resources: %w", err)
 	}
-	for _, csmResource := range list.Items {
+	for _, csmResource := range csmList.Items {
 		namespaceMap[csmResource.Namespace] = struct{}{}
-		fmt.Printf("namespace is %s\n", csmResource.Namespace)
 	}
 
 	// Convert set to slice

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1183,7 +1183,7 @@ func getNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, e
 	csmList := &csmv1.ContainerStorageModuleList{}
 
 	if err := ctrlClient.List(ctx, csmList); err != nil {
-		return nil, fmt.Errorf("list csm resources: %w", err)
+		return nil, fmt.Errorf("error listing csm resources: %w", err)
 	}
 	for _, csmResource := range csmList.Items {
 		namespaceMap[csmResource.Namespace] = struct{}{}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1175,3 +1175,26 @@ func getUpgradeInfo[T csmv1.CSMComponentType](ctx context.Context, operatorConfi
 	// Example return value: "v2.2.0"
 	return upgradePath.MinUpgradePath, nil
 }
+
+func GetNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, error) {
+	// Set to store unique namespaces
+	namespaceMap := make(map[string]struct{})
+
+	list := &csmv1.ContainerStorageModuleList{}
+
+	if err := ctrlClient.List(ctx, list); err != nil {
+		return nil, fmt.Errorf("list csm resources: %w", err)
+	}
+	for _, csmResource := range list.Items {
+		namespaceMap[csmResource.Namespace] = struct{}{}
+		fmt.Printf("namespace is %s\n", csmResource.Namespace)
+	}
+
+	// Convert set to slice
+	var namespaces []string
+	for namespace := range namespaceMap {
+		namespaces = append(namespaces, namespace)
+	}
+
+	return namespaces, nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1176,7 +1176,7 @@ func getUpgradeInfo[T csmv1.CSMComponentType](ctx context.Context, operatorConfi
 	return upgradePath.MinUpgradePath, nil
 }
 
-func GetNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, error) {
+func getNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, error) {
 	// Set to store unique namespaces
 	namespaceMap := make(map[string]struct{})
 


### PR DESCRIPTION
# Description
When the DN client is deployed through ApexConnectivityClient CR, the csm-operator looks for the existing CSM objects and the operator adds the required roles(similar to the one for dell-csm namespace) for the namespaces where the csm object resides.

This PR: Added a new function that identifies the namespaces having csm objects and returns it. Also added a new yaml manifest file that specifies the Role/Rolebinding rules.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Built the image with the changes and deployed operator and connectivity client. For testing, the function was called from DeployApexConnectivityClient() and  namespaces that had csm objects were identified
<img width="404" alt="Screenshot 2024-05-31 115210" src="https://github.com/dell/csm-operator/assets/110008193/5fd5fa55-40f4-442d-9d3a-e9c5dc6272cd">

<img width="689" alt="logs2authandvxflexos" src="https://github.com/dell/csm-operator/assets/110008193/15cd0971-3f9d-4d7e-bdad-4426b0e2fcad">
