### PR TITLE
changes to support brownfield onboarding to ANK8s

### DIFF
--- a/controllers/acc_controller.go
+++ b/controllers/acc_controller.go
@@ -470,15 +470,18 @@ func DeployApexConnectivityClient(ctx context.Context, isDeleting bool, operator
 		}
 	}
 
-	csmList := &csmv1.ContainerStorageModuleList{}
-	err = ctrlClient.List(ctx, csmList)
-	if err == nil && len(csmList.Items) > 0 {
-		log.Info("Found existing csm installations. Proceeding to create role/rolebindings")
-		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, BrownfieldManifest)
-		if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, cr, ctrlClient); err != nil {
-			log.Error(err, "error creating role/rolebindings")
-		}
+	if err = utils.CreateBrownfieldRbac(ctx, operatorConfig, cr, ctrlClient); err != nil {
+		log.Error(err, "error creating role/rolebindings")
 	}
+	// csmList := &csmv1.ContainerStorageModuleList{}
+	// err = ctrlClient.List(ctx, csmList)
+	// if err == nil && len(csmList.Items) > 0 {
+	// 	log.Info("Found existing csm installations. Proceeding to create role/rolebindings")
+	// 	brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, BrownfieldManifest)
+	// 	if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, cr, ctrlClient); err != nil {
+	// 		log.Error(err, "error creating role/rolebindings")
+	// 	}
+	// }
 
 	return nil
 }

--- a/controllers/acc_controller.go
+++ b/controllers/acc_controller.go
@@ -473,15 +473,6 @@ func DeployApexConnectivityClient(ctx context.Context, isDeleting bool, operator
 	if err = utils.CreateBrownfieldRbac(ctx, operatorConfig, cr, ctrlClient); err != nil {
 		log.Error(err, "error creating role/rolebindings")
 	}
-	// csmList := &csmv1.ContainerStorageModuleList{}
-	// err = ctrlClient.List(ctx, csmList)
-	// if err == nil && len(csmList.Items) > 0 {
-	// 	log.Info("Found existing csm installations. Proceeding to create role/rolebindings")
-	// 	brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, BrownfieldManifest)
-	// 	if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, cr, ctrlClient); err != nil {
-	// 		log.Error(err, "error creating role/rolebindings")
-	// 	}
-	// }
 
 	return nil
 }

--- a/controllers/acc_controller.go
+++ b/controllers/acc_controller.go
@@ -470,8 +470,6 @@ func DeployApexConnectivityClient(ctx context.Context, isDeleting bool, operator
 		}
 	}
 
-	//brownfield scenario
-	//If existing csm-installations are found, proceed to get those namespaces and create roles/rolebindings
 	csmList := &csmv1.ContainerStorageModuleList{}
 	err = ctrlClient.List(ctx, csmList)
 	if err == nil && len(csmList.Items) > 0 {

--- a/controllers/acc_controller.go
+++ b/controllers/acc_controller.go
@@ -438,6 +438,8 @@ func applyAccConfigVersionAnnotations(ctx context.Context, instance *csmv1.ApexC
 
 // DeployApexConnectivityClient - perform deployment
 func DeployApexConnectivityClient(ctx context.Context, isDeleting bool, operatorConfig utils.OperatorConfig, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client) error {
+	log := logger.GetLogger(ctx)
+
 	YamlString := ""
 	ModifiedYamlString := ""
 	deploymentPath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, AccManifest)
@@ -464,6 +466,20 @@ func DeployApexConnectivityClient(ctx context.Context, isDeleting bool, operator
 			}
 		}
 	}
+
+	//brownfield scenario
+	//If existing csm-installations are found, proceed to get those namespaces and create roles/rolebindings
+	csmList := &csmv1.ContainerStorageModuleList{}
+	err = ctrlClient.List(ctx, csmList)
+	if err == nil && len(csmList.Items) > 0 {
+		log.Info("Found existing csm installations. Proceeding to onboard them to Apex Navigator for Kubernetes")
+		BrownfieldCR := "brownfield-onboard.yaml"
+		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, BrownfieldCR)
+		if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, cr, ctrlClient); err != nil {
+			log.Error(err, "brownfield cluster onboarding failed")
+		}
+	}
+	log.Info("No existing csm installations found")
 
 	return nil
 }

--- a/controllers/acc_controller.go
+++ b/controllers/acc_controller.go
@@ -98,6 +98,9 @@ const (
 
 	// AccInitContainerImage - tag for init container image
 	AccInitContainerImage string = "<ACC_INIT_CONTAINER_IMAGE>"
+
+	// BrownfieldManifest - manifest for brownfield role/rolebinding creation
+	BrownfieldManifest string = "brownfield-onboard.yaml"
 )
 
 // ApexConnectivityClientReconciler reconciles a ApexConnectivityClient object
@@ -473,10 +476,9 @@ func DeployApexConnectivityClient(ctx context.Context, isDeleting bool, operator
 	err = ctrlClient.List(ctx, csmList)
 	if err == nil && len(csmList.Items) > 0 {
 		log.Info("Found existing csm installations. Proceeding to onboard them to Apex Navigator for Kubernetes")
-		BrownfieldCR := "brownfield-onboard.yaml"
-		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, BrownfieldCR)
+		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, BrownfieldManifest)
 		if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, cr, ctrlClient); err != nil {
-			log.Error(err, "brownfield cluster onboarding failed")
+			log.Error(err, "error creating role/rolebindings")
 		}
 	}
 	log.Info("No existing csm installations found")

--- a/controllers/acc_controller.go
+++ b/controllers/acc_controller.go
@@ -475,13 +475,12 @@ func DeployApexConnectivityClient(ctx context.Context, isDeleting bool, operator
 	csmList := &csmv1.ContainerStorageModuleList{}
 	err = ctrlClient.List(ctx, csmList)
 	if err == nil && len(csmList.Items) > 0 {
-		log.Info("Found existing csm installations. Proceeding to onboard them to Apex Navigator for Kubernetes")
+		log.Info("Found existing csm installations. Proceeding to create role/rolebindings")
 		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, BrownfieldManifest)
 		if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, cr, ctrlClient); err != nil {
 			log.Error(err, "error creating role/rolebindings")
 		}
 	}
-	log.Info("No existing csm installations found")
 
 	return nil
 }

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -155,6 +155,14 @@ func (suite *AccControllerTestSuite) SetupTest() {
 	suite.namespace = "test"
 }
 
+// test a happy path scenerio with deletion
+func (suite *AccControllerTestSuite) TestReconcileAcc() {
+	suite.makeFakeAcc(accName, suite.namespace, true)
+	suite.runFakeAccManager("", false)
+	suite.deleteAcc(accName)
+	suite.runFakeAccManager("", true)
+}
+
 func (suite *AccControllerTestSuite) TestAccConnectivityClient() {
 	csm := shared.MakeAcc(accName, suite.namespace, accConfigVersion)
 	csm.Spec.Client.CSMClientType = csmv1.DreadnoughtClient

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -728,65 +728,6 @@ func (suite *AccControllerTestSuite) debugAccFakeObjects() {
 	}
 }
 
-// func TestSyncDeployment(t *testing.T) {
-// 	ctx := context.Background()
-// 	k8sClient := fake.NewSimpleClientset()
-
-// 	// deploymentParam := &appsv1.Deployment{
-// 	// 	ObjectMeta: metav1.ObjectMeta{
-// 	// 		Name:      "test-deployment",
-// 	// 		Namespace: "default",
-// 	// 	},
-// 	// }
-
-// 	// applyConfig := deployv1.Deployment(deploymentParam.Name, deploymentParam.Namespace)
-// 	// labels := make(map[string]string, 1)
-// 	labels["*-8-csm"] = "/*-csm"
-// 	deployment := appsv1.DeploymentApplyConfiguration{
-//     ObjectMetaApplyConfiguration: &v1.ObjectMetaApplyConfiguration{Name: &[]string{"csm"}[0], Namespace: &[]string{"default"}[0]},
-//     Spec: &appsv1.DeploymentSpecApplyConfiguration{Template: &corev12.PodTemplateSpecApplyConfiguration{
-//        ObjectMetaApplyConfiguration: &v1.ObjectMetaApplyConfiguration{Labels: labels},
-//     }},
-// }
-
-// 	//applyConfig.Spec.Template.Labels["csm"] = "test-var"
-
-// 	// // Initialize the Labels map before setting a value
-// 	// if applyConfig.Spec.Template.Labels == nil {
-// 	// 	applyConfig.Spec.Template.Labels = make(map[string]string)
-// 	// }
-// 	// applyConfig.Spec.Template.Labels["csm"] = "test"
-// 	// applyConfig = deployv1.Deployment(deploymentParam.Name, deploymentParam.Namespace)
-// 	// applyConfig.WithSpec(deployv1.DeploymentSpec().WithTemplate(deployv1.PodTemplateSpecApplyConfiguration().WithLabels(map[string]string{"csm": "test-var"})))
-
-// 	err := deployment.SyncDeployment(ctx, *applyConfig, k8sClient, "test-var")
-// 	if err != nil {
-// 		t.Errorf("Unexpected error: %v", err)
-// 	}
-
-// 	// Simulate an error in Apply
-// 	k8sClient.PrependReactor("patch", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
-// 		return true, nil, fmt.Errorf("forced error")
-// 	})
-
-// 	err = deployment.SyncDeployment(ctx, *applyConfig, k8sClient, "test-var")
-// 	assert.NotNil(t, err)
-// }
-
-// func (suite *AccControllerTestSuite) TestCsmFinalizerErrorScenario() {
-// 	csm := shared.MakeAcc(accName, suite.namespace, accConfigVersion)
-// 	csm.ObjectMeta.Finalizers = []string{"foo"}
-// 	suite.fakeClient.Create(accCtx, &csm)
-// 	sec := shared.MakeSecret(accName+"-creds", suite.namespace, accConfigVersion)
-// 	suite.fakeClient.Create(accCtx, sec)
-// 	reconciler := suite.createAccReconciler()
-// 	updateAccError = true
-// 	_, err := reconciler.Reconcile(accCtx, accReq)
-// 	assert.Error(suite.T(), err)
-// 	updateAccError = false
-// 	suite.deleteAcc(accName)
-// }
-
 func TestSyncDeployment(t *testing.T) {
 	labels := make(map[string]string, 1)
 	labels["*-8-csm"] = "/*-csm"
@@ -797,8 +738,6 @@ func TestSyncDeployment(t *testing.T) {
 		}},
 	}
 	k8sClient := fake.NewSimpleClientset()
-	//var dep appv2.DeploymentInterface= &Deployment{}
-
 	csmName := "csm"
 	var containers = make([]corev1.Container, 0)
 	containers = append(containers, corev1.Container{Name: "fake-container", Image: "fake-image"})
@@ -818,7 +757,7 @@ func TestSyncDeployment(t *testing.T) {
 	assert.NotNil(t, create)
 
 	// Simulate an error in Apply
-	k8sClient.PrependReactor("patch", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
+	k8sClient.PrependReactor("patch", "deployments", func(_ clienttesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("fake error")
 	})
 

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -738,8 +738,8 @@ func TestSyncDeployment(t *testing.T) {
 		}},
 	}
 	k8sClient := fake.NewSimpleClientset()
-	csmName := "csm"
-	var containers = make([]corev1.Container, 0)
+	csmName = "csm"
+	containers := make([]corev1.Container, 0)
 	containers = append(containers, corev1.Container{Name: "fake-container", Image: "fake-image"})
 	create, err := k8sClient.AppsV1().Deployments("default").Create(context.Background(), &appsv1.Deployment{
 		ObjectMeta: apiv1.ObjectMeta{
@@ -755,7 +755,6 @@ func TestSyncDeployment(t *testing.T) {
 	}, apiv1.CreateOptions{})
 	assert.NoError(t, err)
 	assert.NotNil(t, create)
-	//simulate an error in Apply
 	k8sClient.PrependReactor("patch", "deployments", func(_ clienttesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("fake error")
 	})

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -755,7 +755,7 @@ func TestSyncDeployment(t *testing.T) {
 	}, apiv1.CreateOptions{})
 	assert.NoError(t, err)
 	assert.NotNil(t, create)
-	// Simulate an error in Apply
+	//simulate an error in Apply
 	k8sClient.PrependReactor("patch", "deployments", func(_ clienttesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("fake error")
 	})

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -155,21 +155,6 @@ func (suite *AccControllerTestSuite) SetupTest() {
 	suite.namespace = "test"
 }
 
-// test a happy path scenerio with deletion
-func (suite *AccControllerTestSuite) TestReconcileAcc() {
-	suite.makeFakeAcc(accName, suite.namespace, true)
-	suite.runFakeAccManager("", false)
-	suite.deleteAcc(accName)
-	suite.runFakeAccManager("", true)
-}
-
-// test a happy path scenerio without deletion
-func (suite *AccControllerTestSuite) TestReconcileAccNoDelete() {
-	suite.makeFakeAcc(accName, suite.namespace, true)
-	suite.runFakeAccManager("", false)
-	suite.runFakeAccManager("", true)
-}
-
 func (suite *AccControllerTestSuite) TestAccConnectivityClient() {
 	csm := shared.MakeAcc(accName, suite.namespace, accConfigVersion)
 	csm.Spec.Client.CSMClientType = csmv1.DreadnoughtClient

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -723,17 +723,12 @@ func (suite *AccControllerTestSuite) debugAccFakeObjects() {
 
 func (suite *AccControllerTestSuite) TestDeployApexConnectivityClient() {
 	mockClient := suite.fakeClient
-	fmt.Printf("1")
-
 	csm := shared.MakeCSM("csm", suite.namespace, shared.PmaxConfigVersion)
 	csmList := &csmv1.ContainerStorageModuleList{
 		Items: []csmv1.ContainerStorageModule{csm},
 	}
-
 	acc := shared.MakeAcc(accName, suite.namespace, accConfigVersion)
-	fmt.Printf("2")
 	suite.fakeClient.List(accCtx, csmList)
-	fmt.Printf("3")
 	// mockClient.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil, csmList)
 	err := DeployApexConnectivityClient(accCtx, false, accOperatorConfig, acc, mockClient)
 	fmt.Printf("4")

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -163,6 +163,19 @@ func (suite *AccControllerTestSuite) TestReconcileAcc() {
 	suite.runFakeAccManager("", true)
 }
 
+// test a happy path scenerio without deletion
+func (suite *AccControllerTestSuite) TestReconcileAccNoDelete() {
+	suite.makeFakeAcc(accName, suite.namespace, true)
+	suite.runFakeAccManager("", false)
+	suite.runFakeAccManager("", true)
+}
+
+func (suite *AccControllerTestSuite) TestAccConnectivityClient() {
+	csm := shared.MakeAcc(accName, suite.namespace, accConfigVersion)
+	csm.Spec.Client.CSMClientType = csmv1.DreadnoughtClient
+	csm.Spec.Client.Common.Image = "image"
+}
+
 func (suite *AccControllerTestSuite) TestAccConnectivityClientConnectionTarget() {
 	csm := shared.MakeAcc(accName, suite.namespace, accConfigVersion)
 	csm.Spec.Client.CSMClientType = csmv1.DreadnoughtClient

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -711,27 +711,3 @@ func (suite *AccControllerTestSuite) debugAccFakeObjects() {
 		accUnittestLogger.Info("found fake object ", "object", fmt.Sprintf("%#v", o))
 	}
 }
-
-// type MockClient struct {
-// 	mock.Mock
-// }
-
-// func (m *MockClient) List(ctx context.Context, obj client.Object, list client.List) error {
-// 	args := m.Called(ctx, obj, list)
-// 	return args.Error(0) // Return nil error
-// }
-
-func (suite *AccControllerTestSuite) TestDeployApexConnectivityClient() {
-	mockClient := suite.fakeClient
-	csm := shared.MakeCSM("csm", suite.namespace, shared.PmaxConfigVersion)
-	csmList := &csmv1.ContainerStorageModuleList{
-		Items: []csmv1.ContainerStorageModule{csm},
-	}
-	acc := shared.MakeAcc(accName, suite.namespace, accConfigVersion)
-	suite.fakeClient.List(accCtx, csmList)
-	// mockClient.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil, csmList)
-	err := DeployApexConnectivityClient(accCtx, false, accOperatorConfig, acc, mockClient)
-	fmt.Printf("4")
-	assert.Nil(suite.T(), err)
-	assert.NotEmpty(suite.T(), csmList.Items)
-}

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -711,3 +711,32 @@ func (suite *AccControllerTestSuite) debugAccFakeObjects() {
 		accUnittestLogger.Info("found fake object ", "object", fmt.Sprintf("%#v", o))
 	}
 }
+
+// type MockClient struct {
+// 	mock.Mock
+// }
+
+// func (m *MockClient) List(ctx context.Context, obj client.Object, list client.List) error {
+// 	args := m.Called(ctx, obj, list)
+// 	return args.Error(0) // Return nil error
+// }
+
+func (suite *AccControllerTestSuite) TestDeployApexConnectivityClient() {
+	mockClient := suite.fakeClient
+	fmt.Printf("1")
+
+	csm := shared.MakeCSM("csm", suite.namespace, shared.PmaxConfigVersion)
+	csmList := &csmv1.ContainerStorageModuleList{
+		Items: []csmv1.ContainerStorageModule{csm},
+	}
+
+	acc := shared.MakeAcc(accName, suite.namespace, accConfigVersion)
+	fmt.Printf("2")
+	suite.fakeClient.List(accCtx, csmList)
+	fmt.Printf("3")
+	// mockClient.On("List", mock.Anything, mock.Anything, mock.Anything).Return(nil, csmList)
+	err := DeployApexConnectivityClient(accCtx, false, accOperatorConfig, acc, mockClient)
+	fmt.Printf("4")
+	assert.Nil(suite.T(), err)
+	assert.NotEmpty(suite.T(), csmList.Items)
+}

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -755,12 +755,10 @@ func TestSyncDeployment(t *testing.T) {
 	}, apiv1.CreateOptions{})
 	assert.NoError(t, err)
 	assert.NotNil(t, create)
-
 	// Simulate an error in Apply
 	k8sClient.PrependReactor("patch", "deployments", func(_ clienttesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("fake error")
 	})
-
 	err = deploymentpkg.SyncDeployment(context.Background(), deployment, k8sClient, csmName)
 	assert.Error(t, err)
 }

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -879,8 +879,7 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 		}
 
 	}
-
-	//If dell connectivity client is deployed, create role/rolebindings in the csm namespaces
+	// If dell connectivity client is deployed, create role/rolebindings in the csm namespaces
 	if err = utils.CheckAccAndCreateRbac(ctx, operatorConfig, ctrlClient); err != nil {
 		return err
 	}

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -881,25 +881,29 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 	}
 
 	//If dell connectivity client is deployed, create role/rolebindings in the csm namespaces
-	list := &csmv1.ApexConnectivityClientList{}
-	if err := ctrlClient.List(ctx, list); err != nil {
-		log.Info("dell connectivity client not found")
-		return nil
-	} else if len(list.Items) <= 0 {
-		log.Info("dell connectivity client not found")
-		return nil
-	} else {
-		log.Info("dell connectivity client found")
-		cr := new(csmv1.ApexConnectivityClient)
-		BrownfieldCR := "brownfield-onboard.yaml"
-		configVersion1 := list.Items[0].Spec.Client.ConfigVersion
-		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, configVersion1, BrownfieldCR)
-
-		if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient); err != nil {
-			log.Error(err, "error creating role/rolebindings to newly discovered csm namespace")
-			return err
-		}
+	if err = utils.CheckAccAndCreateRbac(ctx, operatorConfig, ctrlClient); err != nil {
+		return err
 	}
+
+	// list := &csmv1.ApexConnectivityClientList{}
+	// if err := ctrlClient.List(ctx, list); err != nil {
+	// 	log.Info("dell connectivity client not found")
+	// 	return nil
+	// } else if len(list.Items) <= 0 {
+	// 	log.Info("dell connectivity client not found")
+	// 	return nil
+	// } else {
+	// 	log.Info("dell connectivity client found")
+	// 	cr := new(csmv1.ApexConnectivityClient)
+	// 	BrownfieldCR := "brownfield-onboard.yaml"
+	// 	configVersion1 := list.Items[0].Spec.Client.ConfigVersion
+	// 	brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, configVersion1, BrownfieldCR)
+
+	// 	if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient); err != nil {
+	// 		log.Error(err, "error creating role/rolebindings to newly discovered csm namespace")
+	// 		return err
+	// 	}
+	// }
 	return nil
 }
 

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -885,25 +885,6 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 		return err
 	}
 
-	// list := &csmv1.ApexConnectivityClientList{}
-	// if err := ctrlClient.List(ctx, list); err != nil {
-	// 	log.Info("dell connectivity client not found")
-	// 	return nil
-	// } else if len(list.Items) <= 0 {
-	// 	log.Info("dell connectivity client not found")
-	// 	return nil
-	// } else {
-	// 	log.Info("dell connectivity client found")
-	// 	cr := new(csmv1.ApexConnectivityClient)
-	// 	BrownfieldCR := "brownfield-onboard.yaml"
-	// 	configVersion1 := list.Items[0].Spec.Client.ConfigVersion
-	// 	brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, configVersion1, BrownfieldCR)
-
-	// 	if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient); err != nil {
-	// 		log.Error(err, "error creating role/rolebindings to newly discovered csm namespace")
-	// 		return err
-	// 	}
-	// }
 	return nil
 }
 

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -879,6 +879,27 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 		}
 
 	}
+
+	//If dell connectivity client is deployed, create role/rolebindings in the csm namespaces
+	list := &csmv1.ApexConnectivityClientList{}
+	if err := ctrlClient.List(ctx, list); err != nil {
+		log.Info("dell connectivity client not found")
+		return nil
+	} else if len(list.Items) <= 0 {
+		log.Info("dell connectivity client not found")
+		return nil
+	} else {
+		log.Info("dell connectivity client found")
+		cr := new(csmv1.ApexConnectivityClient)
+		BrownfieldCR := "brownfield-onboard.yaml"
+		configVersion1 := list.Items[0].Spec.Client.ConfigVersion
+		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, configVersion1, BrownfieldCR)
+
+		if err = utils.BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient); err != nil {
+			log.Error(err, "error creating role/rolebindings to newly discovered csm namespace")
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1211,17 +1211,17 @@ func getUpgradeInfo[T csmv1.CSMComponentType](ctx context.Context, operatorConfi
 
 // BrownfieldOnboard will onboard the brownfield cluster
 func BrownfieldOnboard(ctx context.Context, path string, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client) error {
-	log := logger.GetLogger(ctx)
+	logInstance := logger.GetLogger(ctx)
 
 	namespace, err := GetNamespaces(ctx, ctrlClient)
 	if err != nil {
-		log.Error(err, "Failed to get namespaces")
+		logInstance.Error(err, "Failed to get namespaces")
 		return err
 	}
 
 	buf, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
-		log.Error(err, "Failed to read manifest file")
+		logInstance.Error(err, "Failed to read manifest file")
 		return err
 	}
 
@@ -1297,22 +1297,22 @@ func CreateObjects(ctx context.Context, yamlFile string, ctrlClient crclient.Cli
 
 // CheckAccAndCreateRbac checks if the dell connectivity client exists and creates the role and rolebindings
 func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, ctrlClient crclient.Client) error {
-	log := logger.GetLogger(ctx)
+	logInstance := logger.GetLogger(ctx)
 	list := &csmv1.ApexConnectivityClientList{}
 	if err := ctrlClient.List(ctx, list); err != nil {
-		log.Info("dell connectivity client not found")
-		return nil
+		logInstance.Info("dell connectivity client not found")
 	} else if len(list.Items) <= 0 {
-		log.Info("dell connectivity client not found")
-		return nil
+		logInstance.Info("dell connectivity client not found")
+
 	} else {
-		log.Info("dell connectivity client found")
+		logInstance.Info("dell connectivity client found")
 		cr := new(csmv1.ApexConnectivityClient)
 		configVersion1 := list.Items[0].Spec.Client.ConfigVersion
-		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, configVersion1, BrownfieldManifest)
+		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory,
+			csmv1.DreadnoughtClient, configVersion1, BrownfieldManifest)
 
 		if err = BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient); err != nil {
-			log.Error(err, "error creating role/rolebindings")
+			logInstance.Error(err, "error creating role/rolebindings")
 			return err
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1316,6 +1316,7 @@ func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, c
 	return nil
 }
 
+// CreateBrownfieldRbac creates the role and rolebindings
 func CreateBrownfieldRbac(ctx context.Context, operatorConfig OperatorConfig, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client) error {
 	logInstance := logger.GetLogger(ctx)
 	csmList := &csmv1.ContainerStorageModuleList{}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -140,9 +140,10 @@ const (
 	PodmonNodeComponent = "podmon-node"
 	// ApplicationMobilityNamespace - application-mobility
 	ApplicationMobilityNamespace = "application-mobility"
-	// BrownfieldNamespace
+	// ExistingNamespace - existing namespace
 	ExistingNamespace = "<ExistingNameSpace>"
-	ClientNamespace   = "<ClientNameSpace>"
+	// ClientNamespace - client namespace
+	ClientNamespace = "<ClientNameSpace>"
 	// BrownfieldManifest - manifest for brownfield role/rolebinding creation
 	BrownfieldManifest string = "brownfield-onboard.yaml"
 )

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1315,3 +1315,18 @@ func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, c
 	}
 	return nil
 }
+
+func CreateBrownfieldRbac(ctx context.Context, operatorConfig OperatorConfig, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client) error {
+	logInstance := logger.GetLogger(ctx)
+	csmList := &csmv1.ContainerStorageModuleList{}
+	err := ctrlClient.List(ctx, csmList)
+	if err == nil && len(csmList.Items) > 0 {
+		logInstance.Info("Found existing csm installations. Proceeding to create role/rolebindings")
+		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, BrownfieldManifest)
+		if err = BrownfieldOnboard(ctx, brownfieldManifestFilePath, cr, ctrlClient); err != nil {
+			logInstance.Error(err, "error creating role/rolebindings")
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1213,21 +1213,21 @@ func getUpgradeInfo[T csmv1.CSMComponentType](ctx context.Context, operatorConfi
 func BrownfieldOnboard(ctx context.Context, path string, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client) error {
 	logInstance := logger.GetLogger(ctx)
 
-	namespace, err := GetNamespaces(ctx, ctrlClient)
+	namespaces, err := GetNamespaces(ctx, ctrlClient)
 	if err != nil {
 		logInstance.Error(err, "Failed to get namespaces")
 		return err
 	}
 
-	buf, err := os.ReadFile(filepath.Clean(path))
+	manifestFile, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		logInstance.Error(err, "Failed to read manifest file")
 		return err
 	}
 
-	yamlFile := string(buf)
+	yamlFile := string(manifestFile)
 
-	for _, ns := range namespace {
+	for _, ns := range namespaces {
 
 		yamlFile := strings.ReplaceAll(yamlFile, ExistingNamespace, ns)
 		yamlFile = strings.ReplaceAll(yamlFile, ClientNamespace, cr.Namespace)
@@ -1305,9 +1305,9 @@ func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, c
 	} else {
 		logInstance.Info("dell connectivity client found")
 		cr := new(csmv1.ApexConnectivityClient)
-		configVersion1 := list.Items[0].Spec.Client.ConfigVersion
+		accConfigVersion := list.Items[0].Spec.Client.ConfigVersion
 		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory,
-			csmv1.DreadnoughtClient, configVersion1, BrownfieldManifest)
+			csmv1.DreadnoughtClient, accConfigVersion, BrownfieldManifest)
 		if err = BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient); err != nil {
 			logInstance.Error(err, "error creating role/rolebindings")
 			return err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1297,15 +1297,15 @@ func CreateObjects(ctx context.Context, yamlFile string, ctrlClient crclient.Cli
 // CheckAccAndCreateRbac checks if the dell connectivity client exists and creates the role and rolebindings
 func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, ctrlClient crclient.Client) error {
 	logInstance := logger.GetLogger(ctx)
-	list := &csmv1.ApexConnectivityClientList{}
-	if err := ctrlClient.List(ctx, list); err != nil {
+	accList := &csmv1.ApexConnectivityClientList{}
+	if err := ctrlClient.List(ctx, accList); err != nil {
 		logInstance.Info("dell connectivity client not found")
-	} else if len(list.Items) <= 0 {
+	} else if len(accList.Items) <= 0 {
 		logInstance.Info("dell connectivity client not found")
 	} else {
 		logInstance.Info("dell connectivity client found")
 		cr := new(csmv1.ApexConnectivityClient)
-		accConfigVersion := list.Items[0].Spec.Client.ConfigVersion
+		accConfigVersion := accList.Items[0].Spec.Client.ConfigVersion
 		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory,
 			csmv1.DreadnoughtClient, accConfigVersion, BrownfieldManifest)
 		if err = BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient); err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1269,7 +1269,6 @@ func CreateObjects(ctx context.Context, yamlFile string, ctrlClient crclient.Cli
 	if err != nil {
 		return err
 	}
-
 	for _, obj := range deployObjects {
 		log.FromContext(ctx).Info("namespace of parsed object is", "object", obj.GetNamespace())
 
@@ -1303,14 +1302,12 @@ func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, c
 		logInstance.Info("dell connectivity client not found")
 	} else if len(list.Items) <= 0 {
 		logInstance.Info("dell connectivity client not found")
-
 	} else {
 		logInstance.Info("dell connectivity client found")
 		cr := new(csmv1.ApexConnectivityClient)
 		configVersion1 := list.Items[0].Spec.Client.ConfigVersion
 		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory,
 			csmv1.DreadnoughtClient, configVersion1, BrownfieldManifest)
-
 		if err = BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient); err != nil {
 			logInstance.Error(err, "error creating role/rolebindings")
 			return err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -144,8 +144,8 @@ const (
 	ExistingNamespace = "<ExistingNameSpace>"
 	// ClientNamespace - client namespace
 	ClientNamespace = "<ClientNameSpace>"
-	// BrownfieldManifest - manifest for brownfield role/rolebinding creation
-	BrownfieldManifest string = "brownfield-onboard.yaml"
+	// BrownfieldManifest - brownfield-onboard.yaml
+	BrownfieldManifest = "brownfield-onboard.yaml"
 )
 
 // SplitYaml divides a big bytes of yaml files in individual yaml files.
@@ -1209,6 +1209,7 @@ func getUpgradeInfo[T csmv1.CSMComponentType](ctx context.Context, operatorConfi
 	return upgradePath.MinUpgradePath, nil
 }
 
+// BrownfieldOnboard will onboard the brownfield cluster
 func BrownfieldOnboard(ctx context.Context, path string, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client) error {
 	log := logger.GetLogger(ctx)
 
@@ -1239,6 +1240,7 @@ func BrownfieldOnboard(ctx context.Context, path string, cr csmv1.ApexConnectivi
 	return nil
 }
 
+// GetNamespaces returns the list of namespaces in the cluster
 func GetNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, error) {
 	// Set to store unique namespaces
 	namespaceMap := make(map[string]struct{})
@@ -1261,6 +1263,7 @@ func GetNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, e
 	return namespaces, nil
 }
 
+// CreateObjects creates the objects in the cluster
 func CreateObjects(ctx context.Context, yamlFile string, ctrlClient crclient.Client) error {
 	deployObjects, err := GetModuleComponentObj([]byte(yamlFile))
 	if err != nil {
@@ -1292,6 +1295,7 @@ func CreateObjects(ctx context.Context, yamlFile string, ctrlClient crclient.Cli
 	return nil
 }
 
+// CheckAccAndCreateRbac checks if the dell connectivity client exists and creates the role and rolebindings
 func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, ctrlClient crclient.Client) error {
 	log := logger.GetLogger(ctx)
 	list := &csmv1.ApexConnectivityClientList{}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,6 +42,7 @@ import (
 	t1 "k8s.io/apimachinery/pkg/types"
 	confv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	acorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
@@ -139,6 +140,9 @@ const (
 	PodmonNodeComponent = "podmon-node"
 	// ApplicationMobilityNamespace - application-mobility
 	ApplicationMobilityNamespace = "application-mobility"
+	// BrownfieldNamespace
+	ExistingNamespace = "<ExistingNameSpace>"
+	ClientNamespace   = "<ClientNameSpace>"
 )
 
 // SplitYaml divides a big bytes of yaml files in individual yaml files.
@@ -1202,7 +1206,37 @@ func getUpgradeInfo[T csmv1.CSMComponentType](ctx context.Context, operatorConfi
 	return upgradePath.MinUpgradePath, nil
 }
 
-func getNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, error) {
+func BrownfieldOnboard(ctx context.Context, path string, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client) error {
+	log := logger.GetLogger(ctx)
+
+	namespace, err := GetNamespaces(ctx, ctrlClient)
+	if err != nil {
+		log.Error(err, "Failed to get namespaces")
+		return err
+	}
+
+	buf, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		log.Error(err, "Failed to read manifest file")
+		return err
+	}
+
+	yamlFile := string(buf)
+
+	for _, ns := range namespace {
+
+		yamlFile := strings.ReplaceAll(yamlFile, ExistingNamespace, ns)
+		yamlFile = strings.ReplaceAll(yamlFile, ClientNamespace, cr.Namespace)
+
+		err := CreateObjects(ctx, yamlFile, ctrlClient)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func GetNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, error) {
 	// Set to store unique namespaces
 	namespaceMap := make(map[string]struct{})
 
@@ -1222,4 +1256,35 @@ func getNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, e
 	}
 
 	return namespaces, nil
+}
+
+func CreateObjects(ctx context.Context, yamlFile string, ctrlClient crclient.Client) error {
+	deployObjects, err := GetModuleComponentObj([]byte(yamlFile))
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range deployObjects {
+		log.FromContext(ctx).Info("namespace of parsed object is", "object", obj.GetNamespace())
+
+		found := obj.DeepCopyObject().(crclient.Object)
+		err := ctrlClient.Get(ctx, crclient.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}, found)
+		if err != nil && k8serror.IsNotFound(err) {
+			log.FromContext(ctx).Info("Creating a new object", "object", obj.GetObjectKind().GroupVersionKind().String())
+			err := ctrlClient.Create(ctx, obj)
+			if err != nil {
+				return err
+			}
+		} else if err != nil {
+			log.FromContext(ctx).Info("Unknown error trying to retrieve the object.", "Error", err.Error())
+			return err
+		} else {
+			log.FromContext(ctx).Info("Updating Object", "object", obj.GetObjectKind().GroupVersionKind().String())
+			err = ctrlClient.Update(ctx, obj)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
# Description
When the DN client is deployed through ApexConnectivityClient CR, the csm-operator looks for the existing CSM objects as part of client reconciliation and the operator adds the required roles(similar to the one for dell-csm namespace) for the namespaces where the csm object resides.
When the cluster is already on-boarded to ANK8s and csm is directly deployed on the cluster, as part of csm-reconciliation, the roles are created to the new namespace where csm id deployed

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Scenario 1: CSM-Operator version < 1.4(1.2&1.3) was deployed in the cluster and followed by powerflex driver. The operator image was upgraded to the test image and the apex connectivity client was deployed. The namespaces where the csm is installed are identified and the role/rolebindings are created as part of connectivity client deployment
- [x] Scenario 2: Operator and connectivity client is installed already and csm is deployed in a new ns. The role/rolebindings are created for the new namespace
- [x] Scenario 3: Operator is installed but connectivity client is absent. Csm is deployed however no role/rolebindings will be created.
- [x] Scenario 4: Operator was deployed in the cluster and followed by csi driver and the connectivity client . The connectivity client was then re-installed after deleting the role/rolebindings earlier created in the cluster. The namespaces where the csm is installed are identified and the role/rolebindings are created as part of connectivity client deployment

<img width="348" alt="rolesandrb" src="https://github.com/dell/csm-operator/assets/110008193/a792a165-c236-4c7d-a908-019aec02af3f">
<img width="863" alt="new" src="https://github.com/dell/csm-operator/assets/110008193/78d868cc-2787-44b1-99a8-9b13302ba5a5">


