### PR TITLE
Remove OpenShift parameter from config and discover it on runtime

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -162,10 +162,6 @@ type Module struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="InitContainer"
 	InitContainer []ContainerTemplate `json:"initContainer,omitempty" yaml:"initContainer"`
-
-	// OpenShift is used to indicate if the Container Platform is OpenShift
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenShift"
-	OpenShift bool `json:"openshift,omitempty" yaml:"openshift,omitempty"`
 }
 
 // PodStatus - Represents PodStatus in a daemonset or deployment

--- a/config/crd/bases/storage.dell.com_apexconnectivityclients.yaml
+++ b/config/crd/bases/storage.dell.com_apexconnectivityclients.yaml
@@ -82,6 +82,10 @@ spec:
                         description: Certificate is a certificate used for a certificate/private-key
                           pair
                         type: string
+                      certificateAuthority:
+                        description: CertificateAuthority is a certificate authority
+                          used to validate a certificate
+                        type: string
                       commander:
                         description: Commander is the image tag for the Container
                         type: string
@@ -453,6 +457,10 @@ spec:
                           description: Certificate is a certificate used for a certificate/private-key
                             pair
                           type: string
+                        certificateAuthority:
+                          description: CertificateAuthority is a certificate authority
+                            used to validate a certificate
+                          type: string
                         commander:
                           description: Commander is the image tag for the Container
                           type: string
@@ -810,6 +818,10 @@ spec:
                         certificate:
                           description: Certificate is a certificate used for a certificate/private-key
                             pair
+                          type: string
+                        certificateAuthority:
+                          description: CertificateAuthority is a certificate authority
+                            used to validate a certificate
                           type: string
                         commander:
                           description: Commander is the image tag for the Container

--- a/config/crd/bases/storage.dell.com_containerstoragemodules.yaml
+++ b/config/crd/bases/storage.dell.com_containerstoragemodules.yaml
@@ -86,6 +86,10 @@ spec:
                         description: Certificate is a certificate used for a certificate/private-key
                           pair
                         type: string
+                      certificateAuthority:
+                        description: CertificateAuthority is a certificate authority
+                          used to validate a certificate
+                        type: string
                       commander:
                         description: Commander is the image tag for the Container
                         type: string
@@ -443,6 +447,10 @@ spec:
                       certificate:
                         description: Certificate is a certificate used for a certificate/private-key
                           pair
+                        type: string
+                      certificateAuthority:
+                        description: CertificateAuthority is a certificate authority
+                          used to validate a certificate
                         type: string
                       commander:
                         description: Commander is the image tag for the Container
@@ -823,6 +831,10 @@ spec:
                           description: Certificate is a certificate used for a certificate/private-key
                             pair
                           type: string
+                        certificateAuthority:
+                          description: CertificateAuthority is a certificate authority
+                            used to validate a certificate
+                          type: string
                         commander:
                           description: Commander is the image tag for the Container
                           type: string
@@ -1178,6 +1190,10 @@ spec:
                       certificate:
                         description: Certificate is a certificate used for a certificate/private-key
                           pair
+                        type: string
+                      certificateAuthority:
+                        description: CertificateAuthority is a certificate authority
+                          used to validate a certificate
                         type: string
                       commander:
                         description: Commander is the image tag for the Container
@@ -1538,6 +1554,10 @@ spec:
                         certificate:
                           description: Certificate is a certificate used for a certificate/private-key
                             pair
+                          type: string
+                        certificateAuthority:
+                          description: CertificateAuthority is a certificate authority
+                            used to validate a certificate
                           type: string
                         commander:
                           description: Commander is the image tag for the Container
@@ -1924,6 +1944,10 @@ spec:
                             description: Certificate is a certificate used for a certificate/private-key
                               pair
                             type: string
+                          certificateAuthority:
+                            description: CertificateAuthority is a certificate authority
+                              used to validate a certificate
+                            type: string
                           commander:
                             description: Commander is the image tag for the Container
                             type: string
@@ -2296,6 +2320,10 @@ spec:
                           certificate:
                             description: Certificate is a certificate used for a certificate/private-key
                               pair
+                            type: string
+                          certificateAuthority:
+                            description: CertificateAuthority is a certificate authority
+                              used to validate a certificate
                             type: string
                           commander:
                             description: Commander is the image tag for the Container

--- a/config/crd/bases/storage.dell.com_containerstoragemodules.yaml
+++ b/config/crd/bases/storage.dell.com_containerstoragemodules.yaml
@@ -2639,10 +2639,6 @@ spec:
                     name:
                       description: Name is name of ContainerStorageModule modules
                       type: string
-                    openshift:
-                      description: OpenShift is used to indicate if the Container
-                        Platform is OpenShift
-                      type: boolean
                   type: object
                 type: array
             type: object

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -973,7 +973,7 @@ func (r *ContainerStorageModuleReconciler) reconcileAuthorization(ctx context.Co
 	if r.Config.IsOpenShift {
 		log.Infow("Using OpenShift default ingress controller")
 		if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthNginxIngressComponent) {
-			return fmt.Errorf("openshift enabled, skipping deployment of nginx ingress controller")
+			log.Warnw("openshift environment, skipping deployment of nginx ingress controller")
 		}
 	} else {
 		if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthNginxIngressComponent) {

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -970,18 +970,16 @@ func (r *ContainerStorageModuleReconciler) reconcileAuthorization(ctx context.Co
 		}
 	}
 
-	for _, m := range cr.Spec.Modules {
-		if m.OpenShift {
-			log.Infow("Using OpenShift default ingress controller")
-			if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthNginxIngressComponent) {
-				return fmt.Errorf("openshift enabled, skipping deployment of nginx ingress controller")
-			}
-		} else {
-			if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthNginxIngressComponent) {
-				log.Infow("Reconcile authorization NGINX Ingress Controller")
-				if err := modules.NginxIngressController(ctx, isDeleting, op, cr, ctrlClient); err != nil {
-					return fmt.Errorf("unable to reconcile nginx ingress controller for authorization: %v", err)
-				}
+	if r.Config.IsOpenShift {
+		log.Infow("Using OpenShift default ingress controller")
+		if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthNginxIngressComponent) {
+			return fmt.Errorf("openshift enabled, skipping deployment of nginx ingress controller")
+		}
+	} else {
+		if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthNginxIngressComponent) {
+			log.Infow("Reconcile authorization NGINX Ingress Controller")
+			if err := modules.NginxIngressController(ctx, isDeleting, op, cr, ctrlClient); err != nil {
+				return fmt.Errorf("unable to reconcile nginx ingress controller for authorization: %v", err)
 			}
 		}
 	}
@@ -989,7 +987,7 @@ func (r *ContainerStorageModuleReconciler) reconcileAuthorization(ctx context.Co
 	// Authorization Ingress rules
 	if utils.IsModuleComponentEnabled(ctx, cr, csmv1.AuthorizationServer, modules.AuthProxyServerComponent) {
 		log.Infow("Reconcile authorization Ingresses")
-		if err := modules.AuthorizationIngress(ctx, isDeleting, cr, r, ctrlClient); err != nil {
+		if err := modules.AuthorizationIngress(ctx, isDeleting, r.Config.IsOpenShift, cr, r, ctrlClient); err != nil {
 			return fmt.Errorf("unable to reconcile authorization ingress rules: %v", err)
 		}
 	}

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -187,23 +187,23 @@ func (suite *CSMControllerTestSuite) TestReconcile() {
 
 func (suite *CSMControllerTestSuite) TestAuthorizationServerReconcile() {
 	suite.makeFakeAuthServerCSM(csmName, suite.namespace, getAuthProxyServer())
-	suite.runFakeAuthCSMManager("timed out waiting for the condition", false)
+	suite.runFakeAuthCSMManager("timed out waiting for the condition", false, false)
 	suite.deleteCSM(csmName)
-	suite.runFakeAuthCSMManager("", true)
+	suite.runFakeAuthCSMManager("", true, false)
 }
 
 func (suite *CSMControllerTestSuite) TestAuthorizationServerReconcileOCP() {
 	suite.makeFakeAuthServerCSMOCP(csmName, suite.namespace, getAuthProxyServerOCP())
-	suite.runFakeAuthCSMManager("", false)
+	suite.runFakeAuthCSMManager("", false, true)
 	suite.deleteCSM(csmName)
-	suite.runFakeAuthCSMManager("", true)
+	suite.runFakeAuthCSMManager("", true, true)
 }
 
 func (suite *CSMControllerTestSuite) TestAppMobReconcile() {
 	suite.makeFakeAppMobCSM(csmName, suite.namespace, getAppMob())
-	suite.runFakeAuthCSMManager("", false)
+	suite.runFakeAuthCSMManager("", false, false)
 	suite.deleteCSM(csmName)
-	suite.runFakeAuthCSMManager("", true)
+	suite.runFakeAuthCSMManager("", true, false)
 }
 
 func (suite *CSMControllerTestSuite) TestResiliencyReconcile() {
@@ -937,8 +937,11 @@ func (suite *CSMControllerTestSuite) runFakeCSMManager(expectedErr string, recon
 	}
 }
 
-func (suite *CSMControllerTestSuite) runFakeAuthCSMManager(expectedErr string, reconcileDelete bool) {
+func (suite *CSMControllerTestSuite) runFakeAuthCSMManager(expectedErr string, reconcileDelete, isOpenShift bool) {
 	reconciler := suite.createReconciler()
+	if isOpenShift {
+		reconciler.Config.IsOpenShift = true
+	}
 
 	// invoke controller Reconcile to test. Typically k8s would call this when resource is changed
 	res, err := reconciler.Reconcile(ctx, req)
@@ -1281,7 +1284,6 @@ func getAuthProxyServer() []csmv1.Module {
 			Enabled:           true,
 			ConfigVersion:     "v2.0.0-alpha",
 			ForceRemoveModule: true,
-			OpenShift:         false,
 			Components: []csmv1.ContainerTemplate{
 				{
 					Name:     "proxy-server",
@@ -1319,7 +1321,6 @@ func getAuthProxyServerOCP() []csmv1.Module {
 			Enabled:           true,
 			ConfigVersion:     "v2.0.0-alpha",
 			ForceRemoveModule: true,
-			OpenShift:         true,
 			Components: []csmv1.ContainerTemplate{
 				{
 					Name:     "proxy-server",

--- a/deploy/crds/storage.dell.com.crds.all.yaml
+++ b/deploy/crds/storage.dell.com.crds.all.yaml
@@ -3394,9 +3394,6 @@ spec:
                     name:
                       description: Name is name of ContainerStorageModule modules
                       type: string
-                    openshift:
-                      description: OpenShift is used to indicate if the Container Platform is OpenShift
-                      type: boolean
                   type: object
                 type: array
             type: object

--- a/pkg/modules/authorization_test.go
+++ b/pkg/modules/authorization_test.go
@@ -838,7 +838,7 @@ func TestAuthorizationIngress(t *testing.T) {
 				Client:    sourceClient,
 				K8sClient: fake.NewSimpleClientset(),
 			}
-			err := AuthorizationIngress(context.TODO(), isDeleting, cr, &fakeReconcile, sourceClient)
+			err := AuthorizationIngress(context.TODO(), isDeleting, true, cr, &fakeReconcile, sourceClient)
 			if success {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/modules/testdata/cr_auth_proxy.yaml
+++ b/pkg/modules/testdata/cr_auth_proxy.yaml
@@ -115,3 +115,4 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10
     LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m

--- a/pkg/modules/testdata/cr_auth_proxy_certs.yaml
+++ b/pkg/modules/testdata/cr_auth_proxy_certs.yaml
@@ -93,3 +93,4 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10
     LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m

--- a/pkg/modules/testdata/cr_auth_proxy_certs_missing_key.yaml
+++ b/pkg/modules/testdata/cr_auth_proxy_certs_missing_key.yaml
@@ -93,3 +93,4 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10
     LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m

--- a/pkg/modules/testdata/cr_auth_proxy_no_redis.yaml
+++ b/pkg/modules/testdata/cr_auth_proxy_no_redis.yaml
@@ -103,3 +103,4 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10
     LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m

--- a/samples/authorization/csm_authorization_proxy_server_v200-alpha.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v200-alpha.yaml
@@ -117,3 +117,4 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10
     LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m

--- a/tests/e2e/testfiles/authorization-templates/csm_authorization_proxy_server.yaml
+++ b/tests/e2e/testfiles/authorization-templates/csm_authorization_proxy_server.yaml
@@ -103,3 +103,4 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10
     LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m

--- a/tests/e2e/testfiles/authorization-templates/csm_authorization_proxy_server_alt_ns.yaml
+++ b/tests/e2e/testfiles/authorization-templates/csm_authorization_proxy_server_alt_ns.yaml
@@ -93,3 +93,4 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10
     LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m

--- a/tests/e2e/testfiles/authorization-templates/csm_authorization_proxy_server_default_redis.yaml
+++ b/tests/e2e/testfiles/authorization-templates/csm_authorization_proxy_server_default_redis.yaml
@@ -93,3 +93,4 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10
     LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m

--- a/tests/e2e/testfiles/authorization-templates/csm_authorization_proxy_server_ocp.yaml
+++ b/tests/e2e/testfiles/authorization-templates/csm_authorization_proxy_server_ocp.yaml
@@ -93,3 +93,4 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: 10
     LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m


### PR DESCRIPTION
# Description
1. Discover OpenShift setup instead of providing whether it is OpenShift or not in deployment configuration.
2. Add Storage poll interval in deployment yaml for ease of configuration!

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1281 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Verify ingress is route the request
- [x] Verify polling interval is taken from configuration parameter during deployment
- [x] make controller-unit-test driver-unit-test module-unit-test

```
2024-06-05T15:48:48.488-0400    INFO    utils/utils.go:748      Creating a new Object   {"Name:": "csipowermax-reverseproxy", "Kind:": "Deployment"}
--- PASS: TestReverseProxyServer (0.07s)
    --- PASS: TestReverseProxyServer/fail_-_authorization_module_not_found (0.00s)
    --- PASS: TestReverseProxyServer/success_-_deleting (0.02s)
    --- PASS: TestReverseProxyServer/success_-_creating (0.05s)
PASS
coverage: 90.2% of statements
ok      github.com/dell/csm-operator/pkg/modules        8.503s  coverage: 90.2% of statements
```
