### PR TITLE
Removing the role and rolebindings from the brownfield deployment

### DIFF
--- a/controllers/acc_controller.go
+++ b/controllers/acc_controller.go
@@ -470,7 +470,7 @@ func DeployApexConnectivityClient(ctx context.Context, isDeleting bool, operator
 		}
 	}
 
-	if err = utils.CreateBrownfieldRbac(ctx, operatorConfig, cr, ctrlClient); err != nil {
+	if err = utils.CreateBrownfieldRbac(ctx, operatorConfig, cr, ctrlClient, isDeleting); err != nil {
 		log.Error(err, "error creating role/rolebindings")
 	}
 

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -275,8 +275,6 @@ func (r *ContainerStorageModuleReconciler) Reconcile(ctx context.Context, req ct
 		// remove role/rolebinding from the csm object namespace
 		err := r.SyncRbac(ctx, *csm, *operatorConfig, r.Client)
 		if err != nil {
-			r.EventRecorder.Event(csm, corev1.EventTypeWarning, csmv1.EventDeleted, fmt.Sprintf("Failed to sync rbac: %s", err))
-			log.Errorw("sync rbac", "error", err.Error())
 			return ctrl.Result{}, fmt.Errorf("error when syncing rbac: %v", err)
 		}
 
@@ -296,7 +294,6 @@ func (r *ContainerStorageModuleReconciler) Reconcile(ctx context.Context, req ct
 				// remove all resources deployed from CR by operator
 				if err := r.removeModule(ctx, *csm, *operatorConfig, r.Client); err != nil {
 					r.EventRecorder.Event(csm, corev1.EventTypeWarning, csmv1.EventDeleted, fmt.Sprintf("Failed to remove module: %s", err))
-					log.Errorw("remove module", "error", err.Error())
 					return ctrl.Result{}, fmt.Errorf("error when deleting module: %v", err)
 				}
 			}

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -272,7 +272,7 @@ func (r *ContainerStorageModuleReconciler) Reconcile(ctx context.Context, req ct
 	if csm.IsBeingDeleted() {
 		log.Infow("Delete request", "csm", req.Namespace, "Name", req.Name)
 
-		//remove role/rolebinding from the csm object namespace
+		// remove role/rolebinding from the csm object namespace
 		err := r.SyncRbac(ctx, *csm, *operatorConfig, r.Client)
 		if err != nil {
 			r.EventRecorder.Event(csm, corev1.EventTypeWarning, csmv1.EventDeleted, fmt.Sprintf("Failed to sync rbac: %s", err))
@@ -896,12 +896,13 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 }
 
 // SyncRbac - Sync the current installation - this can lead to a create or update
-func (r *ContainerStorageModuleReconciler) SyncRbac(ctx context.Context, cr csmv1.ContainerStorageModule, operatorConfig utils.OperatorConfig, ctrlClient client.Client) error {
+func (r *ContainerStorageModuleReconciler) SyncRbac(ctx context.Context, _ csmv1.ContainerStorageModule, operatorConfig utils.OperatorConfig, ctrlClient client.Client) error {
 	if err := utils.CheckAccAndCreateOrDeleteRbac(ctx, operatorConfig, ctrlClient, true); err != nil {
 		return err
 	}
 	return nil
 }
+
 // reconcileObservability - Delete/Create/Update observability components
 // isDeleting - true: Delete; false: Create/Update
 func (r *ContainerStorageModuleReconciler) reconcileObservability(ctx context.Context, isDeleting bool, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, components []string, ctrlClient client.Client, k8sClient kubernetes.Interface) error {

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1210,7 +1210,7 @@ func getUpgradeInfo[T csmv1.CSMComponentType](ctx context.Context, operatorConfi
 }
 
 // BrownfieldOnboard will onboard the brownfield cluster
-func BrownfieldOnboard(ctx context.Context, path string, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client) error {
+func BrownfieldOnboard(ctx context.Context, path string, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client, isDeleting bool) error {
 	logInstance := logger.GetLogger(ctx)
 
 	namespaces, err := GetNamespaces(ctx, ctrlClient)
@@ -1232,9 +1232,22 @@ func BrownfieldOnboard(ctx context.Context, path string, cr csmv1.ApexConnectivi
 		yamlFile := strings.ReplaceAll(yamlFile, ExistingNamespace, ns)
 		yamlFile = strings.ReplaceAll(yamlFile, ClientNamespace, cr.Namespace)
 
-		err := CreateObjects(ctx, yamlFile, ctrlClient)
+		deployObjects, err := GetModuleComponentObj([]byte(yamlFile))
 		if err != nil {
 			return err
+		}
+		for _, ctrlObj := range deployObjects {
+			if isDeleting {
+				err := DeleteObject(ctx, ctrlObj, ctrlClient)
+				if err != nil {
+					return err
+				}
+			} else {
+				err := ApplyObject(ctx, ctrlObj, ctrlClient)
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil
@@ -1263,39 +1276,8 @@ func GetNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, e
 	return namespaces, nil
 }
 
-// CreateObjects creates the objects in the cluster
-func CreateObjects(ctx context.Context, yamlFile string, ctrlClient crclient.Client) error {
-	deployObjects, err := GetModuleComponentObj([]byte(yamlFile))
-	if err != nil {
-		return err
-	}
-	for _, obj := range deployObjects {
-		log.FromContext(ctx).Info("namespace of parsed object is", "object", obj.GetNamespace())
-
-		found := obj.DeepCopyObject().(crclient.Object)
-		err := ctrlClient.Get(ctx, crclient.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}, found)
-		if err != nil && k8serror.IsNotFound(err) {
-			log.FromContext(ctx).Info("Creating a new object", "object", obj.GetObjectKind().GroupVersionKind().String())
-			err := ctrlClient.Create(ctx, obj)
-			if err != nil {
-				return err
-			}
-		} else if err != nil {
-			log.FromContext(ctx).Info("Unknown error trying to retrieve the object.", "Error", err.Error())
-			return err
-		} else {
-			log.FromContext(ctx).Info("Updating Object", "object", obj.GetObjectKind().GroupVersionKind().String())
-			err = ctrlClient.Update(ctx, obj)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // CheckAccAndCreateRbac checks if the dell connectivity client exists and creates the role and rolebindings
-func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, ctrlClient crclient.Client) error {
+func CheckAccAndCreateOrDeleteRbac(ctx context.Context, operatorConfig OperatorConfig, ctrlClient crclient.Client, isDeleting bool) error {
 	logInstance := logger.GetLogger(ctx)
 	accList := &csmv1.ApexConnectivityClientList{}
 	if err := ctrlClient.List(ctx, accList); err != nil {
@@ -1308,7 +1290,7 @@ func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, c
 		accConfigVersion := accList.Items[0].Spec.Client.ConfigVersion
 		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory,
 			csmv1.DreadnoughtClient, accConfigVersion, BrownfieldManifest)
-		if err = BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient); err != nil {
+		if err = BrownfieldOnboard(ctx, brownfieldManifestFilePath, *cr, ctrlClient, isDeleting); err != nil {
 			logInstance.Error(err, "error creating role/rolebindings")
 			return err
 		}
@@ -1317,14 +1299,14 @@ func CheckAccAndCreateRbac(ctx context.Context, operatorConfig OperatorConfig, c
 }
 
 // CreateBrownfieldRbac creates the role and rolebindings
-func CreateBrownfieldRbac(ctx context.Context, operatorConfig OperatorConfig, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client) error {
+func CreateBrownfieldRbac(ctx context.Context, operatorConfig OperatorConfig, cr csmv1.ApexConnectivityClient, ctrlClient crclient.Client, isDeleting bool) error {
 	logInstance := logger.GetLogger(ctx)
 	csmList := &csmv1.ContainerStorageModuleList{}
 	err := ctrlClient.List(ctx, csmList)
 	if err == nil && len(csmList.Items) > 0 {
 		logInstance.Info("Found existing csm installations. Proceeding to create role/rolebindings")
 		brownfieldManifestFilePath := fmt.Sprintf("%s/clientconfig/%s/%s/%s", operatorConfig.ConfigDirectory, csmv1.DreadnoughtClient, cr.Spec.Client.ConfigVersion, BrownfieldManifest)
-		if err = BrownfieldOnboard(ctx, brownfieldManifestFilePath, cr, ctrlClient); err != nil {
+		if err = BrownfieldOnboard(ctx, brownfieldManifestFilePath, cr, ctrlClient, isDeleting); err != nil {
 			logInstance.Error(err, "error creating role/rolebindings")
 			return err
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,7 +42,6 @@ import (
 	t1 "k8s.io/apimachinery/pkg/types"
 	confv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	acorev1 "k8s.io/client-go/applyconfigurations/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
@@ -1276,7 +1275,7 @@ func GetNamespaces(ctx context.Context, ctrlClient crclient.Client) ([]string, e
 	return namespaces, nil
 }
 
-// CheckAccAndCreateRbac checks if the dell connectivity client exists and creates the role and rolebindings
+// CheckAccAndCreateOrDeleteRbac checks if the dell connectivity client exists and creates/deletes the role and rolebindings
 func CheckAccAndCreateOrDeleteRbac(ctx context.Context, operatorConfig OperatorConfig, ctrlClient crclient.Client, isDeleting bool) error {
 	logInstance := logger.GetLogger(ctx)
 	accList := &csmv1.ApexConnectivityClientList{}


### PR DESCRIPTION
# Description
Removing the role and role bindings which were added as part of apex-connectivity-client from the CSM-objects, when the delete CSM object is triggered.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X]  Scenario 1: CSM-Operator version < 1.4(1.2&1.3) was deployed in the cluster and followed by powerflex driver. The operator image was upgraded to the test image and the apex connectivity client was deployed. The namespaces where the csm is installed are identified and the role/rolebindings are created as part of connectivity client deployment. When the Delete CSM object was invoked, roles/rolebindings were removed from the CSM object namespace.

