### PR TITLE
Sentinel fix, remove hardcoded sentinel svc port, fix operator deploy…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ podman-build: gen-semver download-csm-common ## Build podman image with the mana
 
 docker-build: gen-semver download-csm-common ## Build docker image with the manager.
 	$(eval include csm-common.mk)
-	docker build . -t ${DEFAULT_IMG} --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE)
+	docker build . -t 10.247.98.98:5000/bharath-csm-operator:latest --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE)
 
 docker-push: docker-build ## Builds, tags and pushes docker image with the manager.
 	docker tag ${DEFAULT_IMG} ${IMG}

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ podman-build: gen-semver download-csm-common ## Build podman image with the mana
 
 docker-build: gen-semver download-csm-common ## Build docker image with the manager.
 	$(eval include csm-common.mk)
-	docker build . -t 10.247.98.98:5000/bharath-csm-operator:latest --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE)
+	docker build . -t ${DEFAULT_IMG} --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE)
 
 docker-push: docker-build ## Builds, tags and pushes docker image with the manager.
 	docker tag ${DEFAULT_IMG} ${IMG}

--- a/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
@@ -696,7 +696,7 @@ spec:
 
             foundMaster=false
 
-            while [ "$foundMaster" == "false" ] 
+            while [ "$foundMaster" -eq "false" ] 
             do  
               for i in $loop
               do
@@ -722,7 +722,7 @@ spec:
                   fi
               done
 
-              if [ "$foundMaster" == "true" ]; then
+              if [ "$foundMaster" -eq "true" ]; then
                 break
               else   
                  echo "Master not found, wait for 30s before attempting again"
@@ -787,7 +787,6 @@ spec:
   ports:
   - port: 5000
     targetPort: 5000
-    nodePort: 32003
     name: <AUTHORIZATION_REDIS_SENTINEL>-svc
   selector:
     app: <AUTHORIZATION_REDIS_SENTINEL>

--- a/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
@@ -696,7 +696,7 @@ spec:
 
             foundMaster=false
 
-            while [ "$foundMaster" -eq "false" ] 
+            while [ "$foundMaster" = "false" ] 
             do  
               for i in $loop
               do
@@ -722,7 +722,7 @@ spec:
                   fi
               done
 
-              if [ "$foundMaster" -eq "true" ]; then
+              if [ "$foundMaster" = "true" ]; then
                 break
               else   
                  echo "Master not found, wait for 30s before attempting again"

--- a/samples/authorization/csm_authorization_proxy_server_v200-alpha.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v200-alpha.yaml
@@ -12,14 +12,6 @@ spec:
       configVersion: v2.0.0-alpha
       forceRemoveModule: true
 
-      # For OpenShift Container Platform only
-      # enabled: Enable/Disable OpenShift Ingress Controller
-      # Allowed values:
-      #   true: enable use of OpenShift Ingress Controller
-      #   false: disable use of OpenShift Ingress Controller only if you have your own ingress controller. Set the appropriate annotations for the ingresses in the proxy-server section
-      # Default value: false
-      openshift: false
-
       components:
         # For Kubernetes Container Platform only
         # enabled: Enable/Disable NGINX Ingress Controller


### PR DESCRIPTION

# Description
1. Sentinel statefulset deployments failed on certain environments due to variance in the versions of shell. The == operator evaluated to = in some shells but not all of them. Fix is to use single = in comparisons.
2. Removed hardcoded sentinel port in service
3. Fixed operator deployment of authorization, does not require openshift parameter in CRD anymore. 
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| (https://github.com/dell/csm/issues/1281) |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Deployed Authorization via Operator on multiple OCP versions, verified success
- [x] Deployed Authorization via Operator on Kubernetes with RHEL workers, verified success.
