### PR TITLE
CSI-Unity: Update usage of env X_CSI_ALLOWED_NETWORKS

### DIFF
--- a/config/samples/storage_v1_csm_unity.yaml
+++ b/config/samples/storage_v1_csm_unity.yaml
@@ -140,11 +140,11 @@ spec:
           value: "false"
         # X_CSI_ALLOWED_NETWORKS: Custom networks for Unity export
         # Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
-        # Allowed values: list of one or more networks
-        # Default value: None
-        # Provide them in the following format: "net1 net2"
+        # Allowed values: list of one or more networks (comma separated)
+        # Default value: ""
+        # Provide them in the following format: "net1, net2"
         # CIDR format should be used
-        # eg: "192.168.1.0/24 192.168.100.0/22"
+        # eg: "192.168.1.0/24, 192.168.100.0/22"
         - name: X_CSI_ALLOWED_NETWORKS
           value: ""
       # nodeSelector: Define node selection constraints for node pods.

--- a/operatorconfig/driverconfig/unity/v2.11.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/node.yaml
@@ -111,6 +111,8 @@ spec:
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
             - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
               value: "true"
+            - name: X_CSI_ALLOWED_NETWORKS
+              value: "<X_CSI_ALLOWED_NETWORKS>"
           volumeMounts:
             - name: driver-path
               mountPath: /var/lib/kubelet/plugins/unity.emc.dell.com

--- a/samples/storage_csm_unity_v2110.yaml
+++ b/samples/storage_csm_unity_v2110.yaml
@@ -142,11 +142,11 @@ spec:
           value: "false"
         # X_CSI_ALLOWED_NETWORKS: Custom networks for Unity export
         # Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
-        # Allowed values: list of one or more networks
-        # Default value: None
-        # Provide them in the following format: "net1 net2"
+        # Allowed values: list of one or more networks (comma separated)
+        # Default value: ""
+        # Provide them in the following format: "net1, net2"
         # CIDR format should be used
-        # eg: "192.168.1.0/24 192.168.100.0/22"
+        # eg: "192.168.1.0/24, 192.168.100.0/22"
         - name: X_CSI_ALLOWED_NETWORKS
           value: ""
       # nodeSelector: Define node selection constraints for node pods.


### PR DESCRIPTION
# Description
This PR update the usage of the env X_CSI_ALLOWED_NETWORKS in Unity driver sample to include comma separated values.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1335 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
- [x] Tested with empty value in X_CSI_ALLOWED_NETWORKS
![image](https://github.com/dell/csm-operator/assets/109594002/ab2f163c-eb76-49d0-8142-833506233644)

- [x] Tested with CIDR addresses in X_CSI_ALLOWED_NETWORKS
![image](https://github.com/dell/csm-operator/assets/109594002/643700d7-aa30-4dc3-8c74-305aed693bef)
