### PR TITLE
Enable CSI Powermax RevProxy to be installed as sidecar

### DIFF
--- a/config/samples/storage_v1_csm_powermax.yaml
+++ b/config/samples/storage_v1_csm_powermax.yaml
@@ -94,11 +94,6 @@ spec:
         # Default value: "" <empty>
         - name: X_CSI_TRANSPORT_PROTOCOL
           value: ""
-        # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Allowed values: "csipowermax-reverseproxy"
-        # default values: "csipowermax-reverseproxy"
-        - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-          value: "csipowermax-reverseproxy"
         # VMware/vSphere virtualization support
         # set X_CSI_VSPHERE_ENABLED to true, if you to enable VMware virtualized environment support via RDM
         # Allowed values:
@@ -258,6 +253,11 @@ spec:
               value: "2222"
             - name: X_CSI_CONFIG_MAP_NAME
               value: "powermax-reverseproxy-config"
+            # deployAsSidecar defines the way reversproxy is installed with the driver
+            # set it true, if csm-auth is enabled / you want it as a sidecar container
+            # set it false, if you want it as a deployment
+            - name: "DeployAsSidecar"
+              value: "true"
     # Authorization: enable csm-authorization for RBAC
     - name: authorization
       # enabled: Enable/Disable csm-authorization

--- a/operatorconfig/driverconfig/powermax/v2.10.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.10.0/controller.yaml
@@ -54,7 +54,7 @@ rules:
 # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -276,8 +276,6 @@ spec:
               value: "<X_CSI_IG_NODENAME_TEMPLATE>"
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
-            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "csipowermax-reverseproxy"
             - name: X_CSI_UNISPHERE_TIMEOUT
               value: 5m
             - name: X_CSI_POWERMAX_CONFIG_PATH
@@ -322,3 +320,5 @@ spec:
         - name: powermax-config-params
           configMap:
              name: <DriverDefaultReleaseName>-config-params
+        - name: cert-dir
+          emptyDir:

--- a/operatorconfig/driverconfig/powermax/v2.10.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.10.0/node.yaml
@@ -126,8 +126,8 @@ spec:
             - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
-            - name: X_CSI_ISCSI_CHROOT
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/operatorconfig/driverconfig/powermax/v2.10.1/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.10.1/controller.yaml
@@ -54,7 +54,7 @@ rules:
 # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -274,8 +274,6 @@ spec:
               value: "<X_CSI_IG_NODENAME_TEMPLATE>"
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
-            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "csipowermax-reverseproxy"
             - name: X_CSI_UNISPHERE_TIMEOUT
               value: 5m
             - name: X_CSI_POWERMAX_CONFIG_PATH
@@ -320,3 +318,5 @@ spec:
         - name: powermax-config-params
           configMap:
              name: <DriverDefaultReleaseName>-config-params
+        - name: cert-dir
+          emptyDir:

--- a/operatorconfig/driverconfig/powermax/v2.10.1/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.10.1/node.yaml
@@ -124,8 +124,8 @@ spec:
             - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
-            - name: X_CSI_ISCSI_CHROOT
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/operatorconfig/driverconfig/powermax/v2.11.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.11.0/controller.yaml
@@ -54,7 +54,7 @@ rules:
     # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -275,8 +275,6 @@ spec:
               value: "<X_CSI_IG_NODENAME_TEMPLATE>"
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
-            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "csipowermax-reverseproxy"
             - name: X_CSI_UNISPHERE_TIMEOUT
               value: 5m
             - name: X_CSI_POWERMAX_CONFIG_PATH
@@ -321,3 +319,5 @@ spec:
         - name: powermax-config-params
           configMap:
             name: <DriverDefaultReleaseName>-config-params
+        - name: cert-dir
+          emptyDir:

--- a/operatorconfig/driverconfig/powermax/v2.11.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.11.0/node.yaml
@@ -126,8 +126,8 @@ spec:
             - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
-            - name: X_CSI_ISCSI_CHROOT
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/operatorconfig/driverconfig/powermax/v2.9.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.9.0/controller.yaml
@@ -54,7 +54,7 @@ rules:
 # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -276,8 +276,6 @@ spec:
               value: "<X_CSI_IG_NODENAME_TEMPLATE>"
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
-            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "csipowermax-reverseproxy"
             - name: X_CSI_UNISPHERE_TIMEOUT
               value: 5m
             - name: X_CSI_POWERMAX_CONFIG_PATH
@@ -322,3 +320,5 @@ spec:
         - name: powermax-config-params
           configMap:
              name: <DriverDefaultReleaseName>-config-params
+        - name: cert-dir
+          emptyDir:

--- a/operatorconfig/driverconfig/powermax/v2.9.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.9.0/node.yaml
@@ -124,8 +124,8 @@ spec:
             - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
-            - name: X_CSI_ISCSI_CHROOT
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/operatorconfig/driverconfig/powermax/v2.9.1/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.9.1/controller.yaml
@@ -54,7 +54,7 @@ rules:
 # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -274,8 +274,6 @@ spec:
               value: "<X_CSI_IG_NODENAME_TEMPLATE>"
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
-            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "csipowermax-reverseproxy"
             - name: X_CSI_UNISPHERE_TIMEOUT
               value: 5m
             - name: X_CSI_POWERMAX_CONFIG_PATH
@@ -320,3 +318,5 @@ spec:
         - name: powermax-config-params
           configMap:
              name: <DriverDefaultReleaseName>-config-params
+        - name: cert-dir
+          emptyDir:

--- a/operatorconfig/driverconfig/powermax/v2.9.1/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.9.1/node.yaml
@@ -124,8 +124,8 @@ spec:
             - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
-            - name: X_CSI_ISCSI_CHROOT
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.10.0/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.10.0/container.yaml
@@ -1,0 +1,21 @@
+name: reverseproxy
+image: dellemc/csipowermax-reverseproxy:v2.10.0
+imagePullPolicy: IfNotPresent
+env:
+  - name: X_CSI_REVPROXY_CONFIG_DIR
+    value: /etc/config/configmap
+  - name: X_CSI_REVPROXY_CONFIG_FILE_NAME
+    value: config.yaml
+  - name: X_CSI_REVRPOXY_IN_CLUSTER
+    value: "true"
+  - name: X_CSI_REVPROXY_TLS_CERT_DIR
+    value: /app/tls
+  - name: X_CSI_REVPROXY_WATCH_NAMESPACE
+    value: <DriverDefaultReleaseNamespace>
+volumeMounts:
+  - name: configmap-volume
+    mountPath: /etc/config/configmap
+  - name: tls-secret
+    mountPath: /app/tls
+  - name: cert-dir
+    mountPath: /app/certs

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.10.0/service.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.10.0/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  ports:
+    - port: <X_CSI_REVPROXY_PORT>
+      protocol: TCP
+      targetPort: 2222
+  selector:
+    app: <DriverDefaultReleaseName>-controller
+  type: ClusterIP

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.8.0/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.8.0/container.yaml
@@ -1,0 +1,21 @@
+name: reverseproxy
+image: dellemc/csipowermax-reverseproxy:v2.8.0
+imagePullPolicy: IfNotPresent
+env:
+  - name: X_CSI_REVPROXY_CONFIG_DIR
+    value: /etc/config/configmap
+  - name: X_CSI_REVPROXY_CONFIG_FILE_NAME
+    value: config.yaml
+  - name: X_CSI_REVRPOXY_IN_CLUSTER
+    value: "true"
+  - name: X_CSI_REVPROXY_TLS_CERT_DIR
+    value: /app/tls
+  - name: X_CSI_REVPROXY_WATCH_NAMESPACE
+    value: <DriverDefaultReleaseNamespace>
+volumeMounts:
+  - name: configmap-volume
+    mountPath: /etc/config/configmap
+  - name: tls-secret
+    mountPath: /app/tls
+  - name: cert-dir
+    mountPath: /app/certs

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.8.0/service.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.8.0/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  ports:
+    - port: <X_CSI_REVPROXY_PORT>
+      protocol: TCP
+      targetPort: 2222
+  selector:
+    app: <DriverDefaultReleaseName>-controller
+  type: ClusterIP

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.8.1/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.8.1/container.yaml
@@ -1,0 +1,21 @@
+name: reverseproxy
+image: dellemc/csipowermax-reverseproxy:v2.8.1
+imagePullPolicy: IfNotPresent
+env:
+  - name: X_CSI_REVPROXY_CONFIG_DIR
+    value: /etc/config/configmap
+  - name: X_CSI_REVPROXY_CONFIG_FILE_NAME
+    value: config.yaml
+  - name: X_CSI_REVRPOXY_IN_CLUSTER
+    value: "true"
+  - name: X_CSI_REVPROXY_TLS_CERT_DIR
+    value: /app/tls
+  - name: X_CSI_REVPROXY_WATCH_NAMESPACE
+    value: <DriverDefaultReleaseNamespace>
+volumeMounts:
+  - name: configmap-volume
+    mountPath: /etc/config/configmap
+  - name: tls-secret
+    mountPath: /app/tls
+  - name: cert-dir
+    mountPath: /app/certs

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.8.1/service.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.8.1/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  ports:
+    - port: <X_CSI_REVPROXY_PORT>
+      protocol: TCP
+      targetPort: 2222
+  selector:
+    app: <DriverDefaultReleaseName>-controller
+  type: ClusterIP

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.9.0/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.9.0/container.yaml
@@ -1,0 +1,21 @@
+name: reverseproxy
+image: dellemc/csipowermax-reverseproxy:v2.9.0
+imagePullPolicy: IfNotPresent
+env:
+  - name: X_CSI_REVPROXY_CONFIG_DIR
+    value: /etc/config/configmap
+  - name: X_CSI_REVPROXY_CONFIG_FILE_NAME
+    value: config.yaml
+  - name: X_CSI_REVRPOXY_IN_CLUSTER
+    value: "true"
+  - name: X_CSI_REVPROXY_TLS_CERT_DIR
+    value: /app/tls
+  - name: X_CSI_REVPROXY_WATCH_NAMESPACE
+    value: <DriverDefaultReleaseNamespace>
+volumeMounts:
+  - name: configmap-volume
+    mountPath: /etc/config/configmap
+  - name: tls-secret
+    mountPath: /app/tls
+  - name: cert-dir
+    mountPath: /app/certs

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.9.0/service.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.9.0/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  ports:
+    - port: <X_CSI_REVPROXY_PORT>
+      protocol: TCP
+      targetPort: 2222
+  selector:
+    app: <DriverDefaultReleaseName>-controller
+  type: ClusterIP

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.9.1/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.9.1/container.yaml
@@ -1,0 +1,21 @@
+name: reverseproxy
+image: dellemc/csipowermax-reverseproxy:v2.9.1
+imagePullPolicy: IfNotPresent
+env:
+  - name: X_CSI_REVPROXY_CONFIG_DIR
+    value: /etc/config/configmap
+  - name: X_CSI_REVPROXY_CONFIG_FILE_NAME
+    value: config.yaml
+  - name: X_CSI_REVRPOXY_IN_CLUSTER
+    value: "true"
+  - name: X_CSI_REVPROXY_TLS_CERT_DIR
+    value: /app/tls
+  - name: X_CSI_REVPROXY_WATCH_NAMESPACE
+    value: <DriverDefaultReleaseNamespace>
+volumeMounts:
+  - name: configmap-volume
+    mountPath: /etc/config/configmap
+  - name: tls-secret
+    mountPath: /app/tls
+  - name: cert-dir
+    mountPath: /app/certs

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.9.1/service.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.9.1/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  ports:
+    - port: <X_CSI_REVPROXY_PORT>
+      protocol: TCP
+      targetPort: 2222
+  selector:
+    app: <DriverDefaultReleaseName>-controller
+  type: ClusterIP

--- a/pkg/modules/testdata/cr_powermax_reverseproxy.yaml
+++ b/pkg/modules/testdata/cr_powermax_reverseproxy.yaml
@@ -46,6 +46,8 @@ spec:
               value: "2222"
             - name: X_CSI_CONFIG_MAP_NAME
               value: "powermax-reverseproxy-config"
+            - name: "DeployAsSidecar"
+              value: "false"
     - name: authorization
       # enable: Enable/Disable csm-authorization
       enabled: false

--- a/samples/storage_csm_powermax_v2100.yaml
+++ b/samples/storage_csm_powermax_v2100.yaml
@@ -96,11 +96,6 @@ spec:
         # Default value: "" <empty>
         - name: X_CSI_TRANSPORT_PROTOCOL
           value: ""
-        # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Allowed values: "csipowermax-reverseproxy"
-        # default values: "csipowermax-reverseproxy"
-        - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-          value: "csipowermax-reverseproxy"
         # VMware/vSphere virtualization support
         # set X_CSI_VSPHERE_ENABLED to true, if you to enable VMware virtualized environment support via RDM
         # Allowed values:
@@ -273,7 +268,11 @@ spec:
             value: "2222"
           - name: X_CSI_CONFIG_MAP_NAME
             value: "powermax-reverseproxy-config"
-
+          # deployAsSidecar defines the way reversproxy is installed with the driver
+          # set it true, if csm-auth is enabled / you want it as a sidecar container
+          # set it false, if you want it as a deployment
+          - name: "DeployAsSidecar"
+            value: "true"
     # Authorization: enable csm-authorization for RBAC
     - name: authorization
       # enabled: Enable/Disable csm-authorization

--- a/samples/storage_csm_powermax_v2101.yaml
+++ b/samples/storage_csm_powermax_v2101.yaml
@@ -96,11 +96,6 @@ spec:
         # Default value: "" <empty>
         - name: X_CSI_TRANSPORT_PROTOCOL
           value: ""
-        # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Allowed values: "csipowermax-reverseproxy"
-        # default values: "csipowermax-reverseproxy"
-        - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-          value: "csipowermax-reverseproxy"
         # VMware/vSphere virtualization support
         # set X_CSI_VSPHERE_ENABLED to true, if you to enable VMware virtualized environment support via RDM
         # Allowed values:
@@ -263,7 +258,11 @@ spec:
             value: "2222"
           - name: X_CSI_CONFIG_MAP_NAME
             value: "powermax-reverseproxy-config"
-
+          # deployAsSidecar defines the way reversproxy is installed with the driver
+          # set it true, if csm-auth is enabled / you want it as a sidecar container
+          # set it false, if you want it as a deployment
+          - name: "DeployAsSidecar"
+            value: "true"
     # Authorization: enable csm-authorization for RBAC
     - name: authorization
       # enabled: Enable/Disable csm-authorization

--- a/samples/storage_csm_powermax_v2110.yaml
+++ b/samples/storage_csm_powermax_v2110.yaml
@@ -94,11 +94,6 @@ spec:
         # Default value: "" <empty>
         - name: X_CSI_TRANSPORT_PROTOCOL
           value: ""
-        # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Allowed values: "csipowermax-reverseproxy"
-        # default values: "csipowermax-reverseproxy"
-        - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-          value: "csipowermax-reverseproxy"
         # VMware/vSphere virtualization support
         # set X_CSI_VSPHERE_ENABLED to true, if you to enable VMware virtualized environment support via RDM
         # Allowed values:
@@ -125,6 +120,16 @@ spec:
         # Default value: "" <empty>
         - name: "X_CSI_VCENTER_HOST"
           value: ""
+        # CSI driver log level
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "debug"
+        - name: "CSI_LOG_LEVEL"
+          value: "debug"
+        # CSI driver log format
+        # Allowed values: "TEXT" or "JSON"
+        # Default value: "TEXT"
+        - name: "CSI_LOG_FORMAT"
+          value: "TEXT"
     controller:
       envs:
         # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition
@@ -258,6 +263,11 @@ spec:
               value: "2222"
             - name: X_CSI_CONFIG_MAP_NAME
               value: "powermax-reverseproxy-config"
+            # deployAsSidecar defines the way reversproxy is installed with the driver
+            # set it true, if csm-auth is enabled / you want it as a sidecar container
+            # set it false, if you want it as a deployment
+            - name: "DeployAsSidecar"
+              value: "true"
     # Authorization: enable csm-authorization for RBAC
     - name: authorization
       # enabled: Enable/Disable csm-authorization

--- a/samples/storage_csm_powermax_v290.yaml
+++ b/samples/storage_csm_powermax_v290.yaml
@@ -96,11 +96,6 @@ spec:
         # Default value: "" <empty>
         - name: X_CSI_TRANSPORT_PROTOCOL
           value: ""
-        # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Allowed values: "csipowermax-reverseproxy"
-        # default values: "csipowermax-reverseproxy"
-        - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-          value: "csipowermax-reverseproxy"
         # VMware/vSphere virtualization support
         # set X_CSI_VSPHERE_ENABLED to true, if you to enable VMware virtualized environment support via RDM
         # Allowed values:
@@ -251,7 +246,11 @@ spec:
             value: "2222"
           - name: X_CSI_CONFIG_MAP_NAME
             value: "powermax-reverseproxy-config"
-
+          # deployAsSidecar defines the way reversproxy is installed with the driver
+          # set it true, if csm-auth is enabled / you want it as a sidecar container
+          # set it false, if you want it as a deployment
+          - name: "DeployAsSidecar"
+            value: "true"
     # Authorization: enable csm-authorization for RBAC
     - name: authorization
       # enabled: Enable/Disable csm-authorization

--- a/samples/storage_csm_powermax_v291.yaml
+++ b/samples/storage_csm_powermax_v291.yaml
@@ -96,11 +96,6 @@ spec:
         # Default value: "" <empty>
         - name: X_CSI_TRANSPORT_PROTOCOL
           value: ""
-        # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Allowed values: "csipowermax-reverseproxy"
-        # default values: "csipowermax-reverseproxy"
-        - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-          value: "csipowermax-reverseproxy"
         # VMware/vSphere virtualization support
         # set X_CSI_VSPHERE_ENABLED to true, if you to enable VMware virtualized environment support via RDM
         # Allowed values:
@@ -251,7 +246,11 @@ spec:
             value: "2222"
           - name: X_CSI_CONFIG_MAP_NAME
             value: "powermax-reverseproxy-config"
-
+          # deployAsSidecar defines the way reversproxy is installed with the driver
+          # set it true, if csm-auth is enabled / you want it as a sidecar container
+          # set it false, if you want it as a deployment
+          - name: "DeployAsSidecar"
+            value: "true"
     # Authorization: enable csm-authorization for RBAC
     - name: authorization
       # enabled: Enable/Disable csm-authorization

--- a/tests/config/driverconfig/powermax/v2.10.0/controller.yaml
+++ b/tests/config/driverconfig/powermax/v2.10.0/controller.yaml
@@ -54,7 +54,7 @@ rules:
 # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -274,8 +274,6 @@ spec:
               value: "<X_CSI_IG_NODENAME_TEMPLATE>"
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
-            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
             - name: X_CSI_REPLICATION_CONTEXT_PREFIX
               value: powermax/
             - name: X_CSI_REPLICATION_PREFIX
@@ -324,3 +322,5 @@ spec:
         - name: powermax-config-params
           configMap:
              name: <DriverDefaultReleaseName>-config-params
+        - name: cert-dir
+          emptyDir:

--- a/tests/config/driverconfig/powermax/v2.10.0/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.10.0/node.yaml
@@ -124,8 +124,8 @@ spec:
             - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
-            - name: X_CSI_ISCSI_CHROOT
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/tests/config/driverconfig/powermax/v2.10.1/controller.yaml
+++ b/tests/config/driverconfig/powermax/v2.10.1/controller.yaml
@@ -54,7 +54,7 @@ rules:
 # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -324,3 +324,5 @@ spec:
         - name: powermax-config-params
           configMap:
              name: <DriverDefaultReleaseName>-config-params
+        - name: cert-dir
+          emptyDir:

--- a/tests/config/driverconfig/powermax/v2.10.1/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.10.1/node.yaml
@@ -124,8 +124,8 @@ spec:
             - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
-            - name: X_CSI_ISCSI_CHROOT
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/tests/config/driverconfig/powermax/v2.11.0/controller.yaml
+++ b/tests/config/driverconfig/powermax/v2.11.0/controller.yaml
@@ -54,7 +54,7 @@ rules:
 # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -274,8 +274,6 @@ spec:
               value: "<X_CSI_IG_NODENAME_TEMPLATE>"
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
-            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
             - name: X_CSI_REPLICATION_CONTEXT_PREFIX
               value: powermax/
             - name: X_CSI_REPLICATION_PREFIX
@@ -324,3 +322,5 @@ spec:
         - name: powermax-config-params
           configMap:
              name: <DriverDefaultReleaseName>-config-params
+        - name: cert-dir
+          emptyDir:

--- a/tests/config/driverconfig/powermax/v2.11.0/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.11.0/node.yaml
@@ -124,8 +124,8 @@ spec:
             - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
-            - name: X_CSI_ISCSI_CHROOT
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/tests/config/driverconfig/powermax/v2.9.1/controller.yaml
+++ b/tests/config/driverconfig/powermax/v2.9.1/controller.yaml
@@ -54,7 +54,7 @@ rules:
 # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -274,8 +274,6 @@ spec:
               value: "<X_CSI_IG_NODENAME_TEMPLATE>"
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
-            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
             - name: X_CSI_REPLICATION_CONTEXT_PREFIX
               value: powermax/
             - name: X_CSI_REPLICATION_PREFIX
@@ -324,3 +322,5 @@ spec:
         - name: powermax-config-params
           configMap:
              name: <DriverDefaultReleaseName>-config-params
+        - name: cert-dir
+          emptyDir:

--- a/tests/config/driverconfig/powermax/v2.9.1/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.9.1/node.yaml
@@ -124,8 +124,8 @@ spec:
             - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "powermax-reverseproxy"
-            - name: X_CSI_ISCSI_CHROOT
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -112,7 +112,6 @@ var _ = BeforeSuite(func() {
 	step.StepRunnerInit(stepRunner, ctrlClient, clientSet)
 
 	beautify = "    "
-
 })
 
 var _ = Describe("[run-e2e-test] E2E Testing", func() {

--- a/tests/e2e/scenarios.txt
+++ b/tests/e2e/scenarios.txt
@@ -67,7 +67,9 @@
  53. Install App Mobility with powerflex driver- default
  54. Install PowerMax Driver(Standalone)
 	cert-csi
- 55. Install PowerMax Driver(With Observability)
+ 55. Install PowerMax Driver(Sidecar)
+    cert-csi
+ 56. Install PowerMax Driver(With Observability)
 	cert-csi
- 56. Install PowerMax Driver(Standalone), Enable/Disable Observability
+ 57. Install PowerMax Driver(Standalone), Enable/Disable Observability
 

--- a/tests/e2e/steps/step_common.go
+++ b/tests/e2e/steps/step_common.go
@@ -233,7 +233,8 @@ func getDriverDeployment(cr csmv1.ContainerStorageModule, ctrlClient client.Clie
 	dp := &appsv1.Deployment{}
 	if err := ctrlClient.Get(context.TODO(), client.ObjectKey{
 		Namespace: cr.Namespace,
-		Name:      fmt.Sprintf("%s-controller", cr.Name)}, dp); err != nil {
+		Name:      fmt.Sprintf("%s-controller", cr.Name),
+	}, dp); err != nil {
 		return nil, err
 	}
 
@@ -244,7 +245,8 @@ func getDriverDaemonset(cr csmv1.ContainerStorageModule, ctrlClient client.Clien
 	ds := &appsv1.DaemonSet{}
 	if err := ctrlClient.Get(context.TODO(), client.ObjectKey{
 		Namespace: cr.Namespace,
-		Name:      fmt.Sprintf("%s-node", cr.Name)}, ds); err != nil {
+		Name:      fmt.Sprintf("%s-node", cr.Name),
+	}, ds); err != nil {
 		return nil, err
 	}
 
@@ -257,7 +259,8 @@ func getObservabilityDeployment(namespace string, driverType csmv1.DriverType, c
 
 	if err := ctrlClient.Get(context.TODO(), client.ObjectKey{
 		Namespace: namespace,
-		Name:      dpName}, dp); err != nil {
+		Name:      dpName,
+	}, dp); err != nil {
 		return nil, err
 	}
 

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1506,6 +1506,25 @@ List of E2E Tests Scenarios
     run:
       - cert-csi test vio --sc powermax --chainNumber 2 --chainLength 2
 
+- scenario: "Install PowerMax Driver(Sidecar)"
+  paths:
+    - "testfiles/storage_csm_powermax_sidecar.yaml"
+  tags:
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Run custom test"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+  customTest:
+    name: Cert CSI
+    run:
+      - cert-csi test vio --sc powermax --chainNumber 2 --chainLength 2
+
 - scenario: "Install PowerMax Driver(With Observability)"
   paths:
     - "testfiles/storage_csm_powermax_observability.yaml"

--- a/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
@@ -94,11 +94,6 @@ spec:
         # Default value: "" <empty>
         - name: X_CSI_TRANSPORT_PROTOCOL
           value: ""
-        # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Allowed values: "csipowermax-reverseproxy"
-        # default values: "csipowermax-reverseproxy"
-        - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-          value: "csipowermax-reverseproxy"
         # VMware/vSphere virtualization support
         # set X_CSI_VSPHERE_ENABLED to true, if you to enable VMware virtualized environment support via RDM
         # Allowed values:

--- a/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
@@ -189,47 +189,5 @@ spec:
               value: "2222"
             - name: X_CSI_CONFIG_MAP_NAME
               value: "powermax-reverseproxy-config"
-    - name: resiliency
-      # enabled: Enable/Disable Resiliency feature
-      # Allowed values:
-      #   true: enable Resiliency feature(deploy podmon sidecar)
-      #   false: disable Resiliency feature(do not deploy podmon sidecar)
-      # Default value: false
-      enabled: false
-      configVersion: v1.10.0
-      components:
-        - name: podmon-controller
-          image: dellemc/podmon:v1.9.0
-          imagePullPolicy: IfNotPresent
-          args:
-            - "--labelvalue=csi-powermax"
-            - "--arrayConnectivityPollRate=60"
-            - "--skipArrayConnectionValidation=false"
-            - "--driverPodLabelValue=dell-storage"
-            - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityConnectionLossThreshold=3"
-            # Below 4 args should not be modified.
-            - "--csisock=unix:/var/run/csi/csi.sock"
-            - "--mode=controller"
-            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
-            - "--driverPath=csi-powermax.dellemc.com"
-        - name: podmon-node
-          image: dellemc/podmon:v1.9.0
-          imagePullPolicy: IfNotPresent
-          envs:
-            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
-            # Allowed values: Any valid and free port (string)
-            # Default value: 8083
-            - name: "X_CSI_PODMON_API_PORT"
-              value: "8083"
-          args:
-            - "--labelvalue=csi-powermax"
-            - "--arrayConnectivityPollRate=60"
-            - "--leaderelection=false"
-            - "--driverPodLabelValue=dell-storage"
-            - "--ignoreVolumelessPods=false"
-            # Below 4 args should not be modified.
-            - "--csisock=unix:/var/lib/kubelet/plugins/powermax.emc.dell.com/csi_sock"
-            - "--mode=node"
-            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
-            - "--driverPath=csi-powermax.dellemc.com"
+            - name: "DeployAsSidecar"
+              value: "true"


### PR DESCRIPTION
# Description
- Enables Revproxy installation as Sidecar.
- Adds an ENV to controller revproxy installation.
- Updates ENV variable name of ISCSI_CHROOT to NODE_CHROOT
- Adds Unit Tests

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1220|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Cluster Test
- [x] Unit Test
-  ![image](https://github.com/dell/csm-operator/assets/92086230/9c9267f6-ccf7-4c19-a4fa-917db7d93c26)

