### PR TITLE
Add n-2 downgrade support

### DIFF
--- a/operatorconfig/driverconfig/powerflex/v2.11.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.11.0/upgrade-path.yaml
@@ -1,3 +1,3 @@
 
- minUpgradePath: v2.10.0
+ minUpgradePath: v2.9.0
 

--- a/operatorconfig/driverconfig/powerscale/v2.10.1/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.10.1/upgrade-path.yaml
@@ -1,1 +1,1 @@
-minUpgradePath: v2.10.0
+minUpgradePath: v2.8.0

--- a/operatorconfig/driverconfig/powerscale/v2.11.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.11.0/upgrade-path.yaml
@@ -1,3 +1,3 @@
 
- minUpgradePath: v2.10.0
+ minUpgradePath: v2.9.0
 

--- a/operatorconfig/driverconfig/powerstore/v2.10.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.10.0/upgrade-path.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 #
-minUpgradePath: v2.9.1
+minUpgradePath: v2.8.0

--- a/operatorconfig/driverconfig/powerstore/v2.10.1/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.10.1/upgrade-path.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 #
-minUpgradePath: v2.10.0
+minUpgradePath: v2.8.0

--- a/operatorconfig/driverconfig/powerstore/v2.11.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.11.0/upgrade-path.yaml
@@ -1,3 +1,3 @@
 
- minUpgradePath: v2.10.0
+ minUpgradePath: v2.9.0
 

--- a/operatorconfig/driverconfig/powerstore/v2.9.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.9.0/upgrade-path.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 #
-minUpgradePath: v2.8.0
+minUpgradePath: v2.7.0

--- a/operatorconfig/driverconfig/powerstore/v2.9.1/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.9.1/upgrade-path.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 #
-minUpgradePath: v2.8.0
+minUpgradePath: v2.7.0


### PR DESCRIPTION
# Description
A few files were missing n-2 upgrade/downgrade support for drivers.
Added them so that powerflex, powerstore and powerscale supports n-2 version of upgrade/downgrade


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
