### PR TITLE
make allowAutoRoundOffFilesystemSize param to true

### DIFF
--- a/operatorconfig/driverconfig/powerstore/v2.11.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.11.0/controller.yaml
@@ -251,7 +251,7 @@ spec:
             - name: GOPOWERSTORE_DEBUG
               value: true
             - name: CSI_AUTO_ROUND_OFF_FILESYSTEM_SIZE
-              value: false
+              value: true
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
           volumeMounts:

--- a/operatorconfig/driverconfig/powerstore/v2.11.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.11.0/csidriver.yaml
@@ -22,6 +22,7 @@ spec:
   storageCapacity: false
   podInfoOnMount: true
   fsGroupPolicy: ReadWriteOnceWithFSType
+  allowAutoRoundOffFilesystemSize: true
   volumeLifecycleModes:
     - Persistent
     - Ephemeral

--- a/operatorconfig/driverconfig/powerstore/v2.11.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.11.0/csidriver.yaml
@@ -22,7 +22,6 @@ spec:
   storageCapacity: false
   podInfoOnMount: true
   fsGroupPolicy: ReadWriteOnceWithFSType
-  allowAutoRoundOffFilesystemSize: true
   volumeLifecycleModes:
     - Persistent
     - Ephemeral


### PR DESCRIPTION
# Description
Making default value of allowAutoRoundOffFilesystemSize param for powerstore true. So that the non-supported min size volume provisioning won't fail.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1377 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Installed operator and provisioned a NFS volume of 1 MB . 
- 
![image](https://github.com/dell/csm-operator/assets/91597668/25080e06-509b-4961-8413-170aa17c0ac4)

