### PR TITLE
Remove node agent when performing AM upgrade 

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -1433,6 +1433,14 @@ func (r *ContainerStorageModuleReconciler) checkUpgrade(ctx context.Context, cr 
 		}
 		if cr.HasModule(csmv1.ApplicationMobility) {
 			newVersion := cr.GetModule(csmv1.ApplicationMobility).ConfigVersion
+			// if upgrading from v1.0.3 to v1.1.0, need to remove old node agent Daemonset due to name change
+			if oldVersion == "v1.0.3" && newVersion == "v1.1.0" {
+				log.Infow("Need to remove old node agent Daemonset")
+				if err := modules.RemoveOldDaemonset(operatorConfig, *cr, r.GetClient()); err != nil {
+					log.Warnf("Failed to remove old node agent Daemonset: %s", err)
+				}
+
+			}
 			return utils.IsValidUpgrade(ctx, oldVersion, newVersion, csmv1.ApplicationMobility, operatorConfig)
 		}
 		driverType := cr.Spec.Driver.CSIDriverType

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -1436,7 +1436,7 @@ func (r *ContainerStorageModuleReconciler) checkUpgrade(ctx context.Context, cr 
 			// if upgrading from v1.0.3 to v1.1.0, need to remove old node agent Daemonset due to name change
 			if oldVersion == "v1.0.3" && newVersion == "v1.1.0" {
 				log.Infow("Need to remove old node agent Daemonset")
-				if err := modules.RemoveOldDaemonset(operatorConfig, *cr, r.GetClient()); err != nil {
+				if err := modules.RemoveOldDaemonset(ctx, operatorConfig, *cr, r.GetClient()); err != nil {
 					log.Warnf("Failed to remove old node agent Daemonset: %s", err)
 				}
 

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -1433,6 +1433,7 @@ func (r *ContainerStorageModuleReconciler) checkUpgrade(ctx context.Context, cr 
 		}
 		if cr.HasModule(csmv1.ApplicationMobility) {
 			newVersion := cr.GetModule(csmv1.ApplicationMobility).ConfigVersion
+			modules.ApplicationMobilityOldVersion = oldVersion
 			return utils.IsValidUpgrade(ctx, oldVersion, newVersion, csmv1.ApplicationMobility, operatorConfig)
 		}
 		driverType := cr.Spec.Driver.CSIDriverType

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -1433,14 +1433,6 @@ func (r *ContainerStorageModuleReconciler) checkUpgrade(ctx context.Context, cr 
 		}
 		if cr.HasModule(csmv1.ApplicationMobility) {
 			newVersion := cr.GetModule(csmv1.ApplicationMobility).ConfigVersion
-			// if upgrading from v1.0.3 to v1.1.0, need to remove old node agent Daemonset due to name change
-			if oldVersion == "v1.0.3" && newVersion == "v1.1.0" {
-				log.Infow("Need to remove old node agent Daemonset")
-				if err := modules.RemoveOldDaemonset(ctx, operatorConfig, *cr, r.GetClient()); err != nil {
-					log.Warnf("Failed to remove old node agent Daemonset: %s", err)
-				}
-
-			}
 			return utils.IsValidUpgrade(ctx, oldVersion, newVersion, csmv1.ApplicationMobility, operatorConfig)
 		}
 		driverType := cr.Spec.Driver.CSIDriverType

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -113,6 +113,11 @@ const (
 	AppMobVeleroComponent = "velero"
 )
 
+var (
+	// ApplicationMobilityOldVersion - old version of application-mobility, will be filled in checkUpgrade
+	ApplicationMobilityOldVersion = ""
+)
+
 // getAppMobilityModule - get instance of app mobility module
 func getAppMobilityModule(cr csmv1.ContainerStorageModule) (csmv1.Module, error) {
 	for _, m := range cr.Spec.Modules {
@@ -584,10 +589,11 @@ func AppMobilityVelero(ctx context.Context, isDeleting bool, op utils.OperatorCo
 		}
 
 		newVersion := cr.GetModule(csmv1.ApplicationMobility).ConfigVersion
-		// if upgrading from v1.0.3 to v1.1.0, need to remove old node agent Daemonset due to name change
-		if newVersion == "v1.1.0" {
+
+		// if moving AM versions, need to remove old node agent Daemonset due to name change
+		if newVersion != ApplicationMobilityOldVersion {
 			log.Infow("Need to remove old node agent Daemonset")
-			if err := RemoveOldDaemonset(ctx, op, cr, ctrlClient); err != nil {
+			if err := RemoveOldDaemonset(ctx, op, ApplicationMobilityOldVersion, cr, ctrlClient); err != nil {
 				log.Warnf("Failed to remove old node agent Daemonset: %s", err)
 			}
 		}
@@ -882,11 +888,11 @@ func applyDeleteObjects(ctx context.Context, ctrlClient crclient.Client, yamlStr
 }
 
 // this method is only used to remove Daemonset if upgrading to AM v1.1.0
-func RemoveOldDaemonset(ctx context.Context, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
+func RemoveOldDaemonset(ctx context.Context, op utils.OperatorConfig, oldVersion string, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
 	log := logger.GetLogger(ctx)
 	//need to delete the old Daemonset, which is found in versions v1.0.3 or lower
 	log.Infof("removing application-mobility-node-agent daemonset from %s namespace", cr.Namespace)
-	oldNodeAgentPath := fmt.Sprintf("%s/moduleconfig/application-mobility/v1.0.3/%s", op.ConfigDirectory, NodeAgentCrdManifest)
+	oldNodeAgentPath := fmt.Sprintf("%s/moduleconfig/application-mobility/%s/%s", op.ConfigDirectory, oldVersion, NodeAgentCrdManifest)
 
 	buf, err := os.ReadFile(filepath.Clean(oldNodeAgentPath))
 	if err != nil {

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -591,7 +591,7 @@ func AppMobilityVelero(ctx context.Context, isDeleting bool, op utils.OperatorCo
 		newVersion := cr.GetModule(csmv1.ApplicationMobility).ConfigVersion
 
 		// if moving AM versions, need to remove old node agent Daemonset due to name change
-		if newVersion != ApplicationMobilityOldVersion {
+		if newVersion != ApplicationMobilityOldVersion && ApplicationMobilityOldVersion != "" {
 			log.Infow("Need to remove old node agent Daemonset")
 			if err := RemoveOldDaemonset(ctx, op, ApplicationMobilityOldVersion, cr, ctrlClient); err != nil {
 				log.Warnf("Failed to remove old node agent Daemonset: %s", err)

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -873,9 +873,12 @@ func applyDeleteObjects(ctx context.Context, ctrlClient crclient.Client, yamlStr
 }
 
 // this method is only used to remove Daemonset if upgrading to AM v1.1.0
-func RemoveOldDaemonset(op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
+func RemoveOldDaemonset(ctx context.Context, op utils.OperatorConfig, cr csmv1.ContainerStorageModule, ctrlClient crclient.Client) error {
+	log := logger.GetLogger(ctx)
 	//need to delete the old Daemonset, which is found in versions v1.0.3 or lower
+	log.Infof("removing application-mobility-node-agent daemonset from %s namespace", cr.Namespace)
 	oldNodeAgentPath := fmt.Sprintf("%s/moduleconfig/application-mobility/v1.0.3/%s", op.ConfigDirectory, NodeAgentCrdManifest)
+	oldNodeAgentPath = strings.ReplaceAll(oldNodeAgentPath, AppMobNamespace, cr.Namespace)
 	buf, err := os.ReadFile(filepath.Clean(oldNodeAgentPath))
 	if err != nil {
 		return fmt.Errorf("failed to find read old node-agent manifests at path: %s", oldNodeAgentPath)

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -583,6 +583,15 @@ func AppMobilityVelero(ctx context.Context, isDeleting bool, op utils.OperatorCo
 			return err
 		}
 
+		newVersion := cr.GetModule(csmv1.ApplicationMobility).ConfigVersion
+		// if upgrading from v1.0.3 to v1.1.0, need to remove old node agent Daemonset due to name change
+		if newVersion == "v1.1.0" {
+			log.Infow("Need to remove old node agent Daemonset")
+			if err := RemoveOldDaemonset(ctx, op, cr, ctrlClient); err != nil {
+				log.Warnf("Failed to remove old node agent Daemonset: %s", err)
+			}
+		}
+
 		er := applyDeleteObjects(ctx, ctrlClient, yamlString4, isDeleting)
 		if er != nil {
 			return er

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -878,10 +878,12 @@ func RemoveOldDaemonset(ctx context.Context, op utils.OperatorConfig, cr csmv1.C
 	//need to delete the old Daemonset, which is found in versions v1.0.3 or lower
 	log.Infof("removing application-mobility-node-agent daemonset from %s namespace", cr.Namespace)
 	oldNodeAgentPath := fmt.Sprintf("%s/moduleconfig/application-mobility/v1.0.3/%s", op.ConfigDirectory, NodeAgentCrdManifest)
-	oldNodeAgentPath = strings.ReplaceAll(oldNodeAgentPath, AppMobNamespace, cr.Namespace)
+
 	buf, err := os.ReadFile(filepath.Clean(oldNodeAgentPath))
 	if err != nil {
 		return fmt.Errorf("failed to find read old node-agent manifests at path: %s", oldNodeAgentPath)
 	}
-	return applyDeleteObjects(context.Background(), ctrlClient, string(buf), true)
+	yamlString := string(buf)
+	yamlString = strings.ReplaceAll(yamlString, AppMobNamespace, cr.Namespace)
+	return applyDeleteObjects(context.Background(), ctrlClient, yamlString, true)
 }

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -415,7 +415,7 @@ func UpdateStatus(ctx context.Context, instance *csmv1.ContainerStorageModule, r
 	running, merr := calculateState(ctx, instance, r, newStatus)
 
 	if !running {
-		return fmt.Errorf("CSM not running")
+		return fmt.Errorf("CSM not running\n")
 	}
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -415,7 +415,7 @@ func UpdateStatus(ctx context.Context, instance *csmv1.ContainerStorageModule, r
 	running, merr := calculateState(ctx, instance, r, newStatus)
 
 	if !running {
-		return errors.New("CSM not running")
+		return fmt.Errorf("CSM not running")
 	}
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -717,7 +717,7 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 	}
 
 	for _, pod := range podList.Items {
-		log.Infof("Checking Daemonset pod: %s", pod.Name)
+		log.Infof("Checking Daemonset pod: %s and status: %s", pod.Name, pod.Status.Phase)
 		if pod.Status.Phase == corev1.PodRunning {
 			readyPods++
 		} else {
@@ -730,6 +730,14 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 	} else {
 		daemonRunning = true
 	}
+
+	log.Infof("veleroEnabled: %t", veleroEnabled)
+	log.Infof("certEnabled: %t", certEnabled)
+	log.Infof("certManagerRunning: %t", certManagerRunning)
+	log.Infof("certManagerCainInjectorRunning: %t", certManagerCainInjectorRunning)
+	log.Infof("certManagerWebhookRunning: %t", certManagerWebhookRunning)
+	log.Infof("appMobRunning: %t", appMobRunning)
+	log.Infof("veleroRunning: %t", veleroRunning)
 
 	if certEnabled && veleroEnabled {
 		return appMobRunning && certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && veleroRunning && daemonRunning, nil

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -735,14 +735,6 @@ func appMobStatusCheck(ctx context.Context, instance *csmv1.ContainerStorageModu
 		daemonRunning = true
 	}
 
-	log.Infof("veleroEnabled: %t", veleroEnabled)
-	log.Infof("certEnabled: %t", certEnabled)
-	log.Infof("certManagerRunning: %t", certManagerRunning)
-	log.Infof("certManagerCainInjectorRunning: %t", certManagerCainInjectorRunning)
-	log.Infof("certManagerWebhookRunning: %t", certManagerWebhookRunning)
-	log.Infof("appMobRunning: %t", appMobRunning)
-	log.Infof("veleroRunning: %t", veleroRunning)
-
 	if certEnabled && veleroEnabled {
 		return appMobRunning && certManagerRunning && certManagerCainInjectorRunning && certManagerWebhookRunning && veleroRunning && daemonRunning, nil
 	}

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -412,7 +412,11 @@ func UpdateStatus(ctx context.Context, instance *csmv1.ContainerStorageModule, r
 	log.Infow("Update State", "Controller",
 		newStatus.ControllerStatus, "Node", newStatus.NodeStatus)
 
-	_, merr := calculateState(ctx, instance, r, newStatus)
+	running, merr := calculateState(ctx, instance, r, newStatus)
+
+	if !running {
+		return errors.New("CSM not running")
+	}
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		log := logger.GetLogger(ctx)


### PR DESCRIPTION
# Description
This PR adds a step to remove node-agent, as the node agent deployed will not be updated by CSM upgrade, and the 2 conflicting daemonsets cause clones to fail 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Ran upgrade and clone job to verify clone works after preforming AM upgrade 
