### PR TITLE
Add note for fsGroupPolicy

### DIFF
--- a/pkg/resources/configmap/configmap.go
+++ b/pkg/resources/configmap/configmap.go
@@ -14,6 +14,7 @@ package configmap
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -33,16 +34,18 @@ func SyncConfigMap(ctx context.Context, configMap corev1.ConfigMap, client clien
 		log.Infow("Creating a new ConfigMap", "Name", configMap.Name)
 		err = client.Create(ctx, &configMap)
 		if err != nil {
-			return err
+			return fmt.Errorf("creating configmap: %v", err)
 		}
 	} else if err != nil {
 		log.Errorw("Unknown error.", "Error", err.Error())
 		return err
 	} else {
 		log.Infow("Updating ConfigMap", "Name:", configMap.Name)
+
+		configMap.ResourceVersion = found.ResourceVersion
 		err = client.Update(ctx, &configMap)
 		if err != nil {
-			return err
+			return fmt.Errorf("updating configmap: %v", err)
 		}
 	}
 

--- a/pkg/resources/csidriver/csidriver.go
+++ b/pkg/resources/csidriver/csidriver.go
@@ -14,6 +14,7 @@ package csidriver
 
 import (
 	"context"
+	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
 
@@ -32,16 +33,18 @@ func SyncCSIDriver(ctx context.Context, csi storagev1.CSIDriver, client client.C
 		log.Infow("Creating a new CSIDriver", "Name:", csi.Name)
 		err = client.Create(ctx, &csi)
 		if err != nil {
-			return err
+			return fmt.Errorf("creating csidriver object: %v", err)
 		}
 	} else if err != nil {
 		log.Errorw("Unknown error.", "Error", err.Error())
 		return err
 	} else {
-		log.Infow("CSIDriver Object exist. Updating", "Name:", csi.Name)
+		log.Infow("Updating existing CSIDriver Object", "Name:", csi.Name)
+
+		csi.ResourceVersion = found.ResourceVersion
 		err = client.Update(ctx, &csi)
 		if err != nil {
-			return err
+			return fmt.Errorf("updating csidriver object: %v", err)
 		}
 	}
 	return nil

--- a/pkg/resources/csidriver/csidriver.go
+++ b/pkg/resources/csidriver/csidriver.go
@@ -42,6 +42,7 @@ func SyncCSIDriver(ctx context.Context, csi storagev1.CSIDriver, client client.C
 		log.Infow("Updating existing CSIDriver Object", "Name:", csi.Name)
 
 		csi.ResourceVersion = found.ResourceVersion
+		// in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
 		err = client.Update(ctx, &csi)
 		if err != nil {
 			return fmt.Errorf("updating csidriver object: %v", err)

--- a/pkg/resources/csidriver/csidriver.go
+++ b/pkg/resources/csidriver/csidriver.go
@@ -38,7 +38,11 @@ func SyncCSIDriver(ctx context.Context, csi storagev1.CSIDriver, client client.C
 		log.Errorw("Unknown error.", "Error", err.Error())
 		return err
 	} else {
-		log.Infow("CSIDriver Object exist", "Name:", csi.Name)
+		log.Infow("CSIDriver Object exist. Updating", "Name:", csi.Name)
+		err = client.Update(ctx, &csi)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -154,6 +154,8 @@ const (
 	ClientNamespace = "<ClientNameSpace>"
 	// BrownfieldManifest - brownfield-onboard.yaml
 	BrownfieldManifest = "brownfield-onboard.yaml"
+	// DefaultFSGroupPolicy -
+	DefaultFSGroupPolicy = "ReadWriteOnceWithFSType"
 )
 
 // SplitYaml divides a big bytes of yaml files in individual yaml files.
@@ -356,6 +358,10 @@ func ModifyCommonCR(YamlString string, cr csmv1.ContainerStorageModule) string {
 		}
 	}
 	YamlString = strings.ReplaceAll(YamlString, KubeletConfigDir, path)
+
+	if cr.Spec.Driver.CSIDriverSpec.FSGroupPolicy != "" {
+		YamlString = strings.ReplaceAll(YamlString, DefaultFSGroupPolicy, string(cr.Spec.Driver.CSIDriverSpec.FSGroupPolicy))
+	}
 
 	return YamlString
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -154,8 +154,6 @@ const (
 	ClientNamespace = "<ClientNameSpace>"
 	// BrownfieldManifest - brownfield-onboard.yaml
 	BrownfieldManifest = "brownfield-onboard.yaml"
-	// DefaultFSGroupPolicy -
-	DefaultFSGroupPolicy = "ReadWriteOnceWithFSType"
 )
 
 // SplitYaml divides a big bytes of yaml files in individual yaml files.
@@ -358,11 +356,6 @@ func ModifyCommonCR(YamlString string, cr csmv1.ContainerStorageModule) string {
 		}
 	}
 	YamlString = strings.ReplaceAll(YamlString, KubeletConfigDir, path)
-
-	if cr.Spec.Driver.CSIDriverSpec.FSGroupPolicy != "" {
-		YamlString = strings.ReplaceAll(YamlString, DefaultFSGroupPolicy, string(cr.Spec.Driver.CSIDriverSpec.FSGroupPolicy))
-	}
-
 	return YamlString
 }
 

--- a/samples/storage_csm_powerflex_v2101.yaml
+++ b/samples/storage_csm_powerflex_v2101.yaml
@@ -7,6 +7,7 @@ spec:
   driver:
     csiDriverType: "powerflex"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -129,7 +130,7 @@ spec:
         # Default value: false
         - name: X_CSI_APPROVE_SDC_ENABLED
           value: "false"
-        
+
         # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin - volume usage
         # Allowed values:
         #   true: enable checking of health condition of CSI volumes
@@ -137,7 +138,7 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
-          
+
         # X_CSI_RENAME_SDC_ENABLED: Enable/Disable rename of SDC
         # Allowed values:
         #   true: enable renaming

--- a/samples/storage_csm_powerflex_v2110.yaml
+++ b/samples/storage_csm_powerflex_v2110.yaml
@@ -7,6 +7,7 @@ spec:
   driver:
     csiDriverType: "powerflex"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType

--- a/samples/storage_csm_powerflex_v292.yaml
+++ b/samples/storage_csm_powerflex_v292.yaml
@@ -7,6 +7,7 @@ spec:
   driver:
     csiDriverType: "powerflex"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -52,22 +53,22 @@ spec:
           value: "TEXT"
 
     sideCars:
-    # 'k8s' represents a string prepended to each volume created by the CSI driver
+      # 'k8s' represents a string prepended to each volume created by the CSI driver
       - name: provisioner
         args: ["--volume-name-prefix=k8s"]
 
-    # sdc-monitor is disabled by default, due to high CPU usage
+      # sdc-monitor is disabled by default, due to high CPU usage
       - name: sdc-monitor
         enabled: false
         image: dellemc/sdc:4.5
         envs:
-        - name: HOST_PID
-          value: "1"
-        - name: MDM
-          value: "10.xx.xx.xx,10.xx.xx.xx" #do not add mdm value here if it is present in secret
+          - name: HOST_PID
+            value: "1"
+          - name: MDM
+            value: "10.xx.xx.xx,10.xx.xx.xx" #do not add mdm value here if it is present in secret
 
-    # health monitor is disabled by default, refer to driver documentation before enabling it
-    # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED  to "true".
+      # health monitor is disabled by default, refer to driver documentation before enabling it
+      # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED  to "true".
       - name: csi-external-health-monitor-controller
         enabled: false
         args: ["--monitor-interval=60s"]
@@ -119,7 +120,6 @@ spec:
 
     node:
       envs:
-
         # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
         # Allowed values:
         #    true: enable SDC approval
@@ -127,7 +127,7 @@ spec:
         # Default value: false
         - name: X_CSI_APPROVE_SDC_ENABLED
           value: "false"
-        
+
         # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin - volume usage
         # Allowed values:
         #   true: enable checking of health condition of CSI volumes
@@ -135,7 +135,7 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
-          
+
         # X_CSI_RENAME_SDC_ENABLED: Enable/Disable rename of SDC
         # Allowed values:
         #   true: enable renaming
@@ -159,8 +159,6 @@ spec:
         - name: X_CSI_MAX_VOLUMES_PER_NODE
           value: "0"
 
-
-
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes
       # Allowed values: map of key-value pairs
@@ -183,7 +181,7 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled 
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
       # - key: "offline.vxflexos.storage.dell.com"
       #   operator: "Exists"
       #   effect: "NoSchedule"
@@ -209,7 +207,7 @@ spec:
         name: sdc
         envs:
           - name: MDM
-            value: "10.xx.xx.xx,10.xx.xx.xx"  #provide MDM value
+            value: "10.xx.xx.xx,10.xx.xx.xx" #provide MDM value
 
   modules:
     # Authorization: enable csm-authorization for RBAC
@@ -218,16 +216,16 @@ spec:
       enabled: false
       configVersion: v1.9.1
       components:
-      - name: karavi-authorization-proxy
-        image: dellemc/csm-authorization-sidecar:v1.9.1
-        envs:
-          # proxyHost: hostname of the csm-authorization server
-          - name: "PROXY_HOST"
-            value: "csm-authorization.com"
+        - name: karavi-authorization-proxy
+          image: dellemc/csm-authorization-sidecar:v1.9.1
+          envs:
+            # proxyHost: hostname of the csm-authorization server
+            - name: "PROXY_HOST"
+              value: "csm-authorization.com"
 
-          # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
-          - name: "SKIP_CERTIFICATE_VALIDATION"
-            value: "true"
+            # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
+            - name: "SKIP_CERTIFICATE_VALIDATION"
+              value: "true"
 
     # observability: allows to configure observability
     - name: observability
@@ -353,52 +351,52 @@ spec:
       enabled: false
       configVersion: v1.7.1
       components:
-      - name: dell-csi-replicator
-        # image: Image to use for dell-csi-replicator. This shouldn't be changed
-        # Allowed values: string
-        # Default value: None
-        image: dellemc/dell-csi-replicator:v1.7.1
-        envs:
-          # replicationPrefix: prefix to prepend to storage classes parameters
+        - name: dell-csi-replicator
+          # image: Image to use for dell-csi-replicator. This shouldn't be changed
           # Allowed values: string
-          # Default value: replication.storage.dell.com
-          - name: "X_CSI_REPLICATION_PREFIX"
-            value: "replication.storage.dell.com"
-          # replicationContextPrefix: prefix to use for naming of resources created by replication feature
-          # Allowed values: string
-          - name: "X_CSI_REPLICATION_CONTEXT_PREFIX"
-            value: "powerflex"
+          # Default value: None
+          image: dellemc/dell-csi-replicator:v1.7.1
+          envs:
+            # replicationPrefix: prefix to prepend to storage classes parameters
+            # Allowed values: string
+            # Default value: replication.storage.dell.com
+            - name: "X_CSI_REPLICATION_PREFIX"
+              value: "replication.storage.dell.com"
+            # replicationContextPrefix: prefix to use for naming of resources created by replication feature
+            # Allowed values: string
+            - name: "X_CSI_REPLICATION_CONTEXT_PREFIX"
+              value: "powerflex"
 
-      - name: dell-replication-controller-manager
-        # image: Defines controller image. This shouldn't be changed
-        # Allowed values: string
-        image: dellemc/dell-replication-controller:v1.7.1
-        envs:
-          # TARGET_CLUSTERS_IDS: comma separated list of cluster IDs of the targets clusters. DO NOT include the source(wherever CSM Operator is deployed) cluster ID
-          # Set the value to "self" in case of stretched/single cluster configuration
+        - name: dell-replication-controller-manager
+          # image: Defines controller image. This shouldn't be changed
           # Allowed values: string
-          - name: "TARGET_CLUSTERS_IDS"
-            value: "target-cluster-1"
-          # Replication log level
-          # Allowed values: "error", "warn"/"warning", "info", "debug"
-          # Default value: "debug"
-          - name: "REPLICATION_CTRL_LOG_LEVEL"
-            value: "debug"
+          image: dellemc/dell-replication-controller:v1.7.1
+          envs:
+            # TARGET_CLUSTERS_IDS: comma separated list of cluster IDs of the targets clusters. DO NOT include the source(wherever CSM Operator is deployed) cluster ID
+            # Set the value to "self" in case of stretched/single cluster configuration
+            # Allowed values: string
+            - name: "TARGET_CLUSTERS_IDS"
+              value: "target-cluster-1"
+            # Replication log level
+            # Allowed values: "error", "warn"/"warning", "info", "debug"
+            # Default value: "debug"
+            - name: "REPLICATION_CTRL_LOG_LEVEL"
+              value: "debug"
 
-          # replicas: Defines number of controller replicas
-          # Allowed values: int
-          # Default value: 1
-          - name: "REPLICATION_CTRL_REPLICAS"
-            value: "1"
-          # retryIntervalMin: Initial retry interval of failed reconcile request.
-          # It doubles with each failure, upto retry-interval-max
-          # Allowed values: time
-          - name: "RETRY_INTERVAL_MIN"
-            value: "1s"
-          # RETRY_INTERVAL_MAX: Maximum retry interval of failed reconcile request
-          # Allowed values: time
-          - name: "RETRY_INTERVAL_MAX"
-            value: "5m"
+            # replicas: Defines number of controller replicas
+            # Allowed values: int
+            # Default value: 1
+            - name: "REPLICATION_CTRL_REPLICAS"
+              value: "1"
+            # retryIntervalMin: Initial retry interval of failed reconcile request.
+            # It doubles with each failure, upto retry-interval-max
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MIN"
+              value: "1s"
+            # RETRY_INTERVAL_MAX: Maximum retry interval of failed reconcile request
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MAX"
+              value: "5m"
 
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature

--- a/samples/storage_csm_powermax_v2101.yaml
+++ b/samples/storage_csm_powermax_v2101.yaml
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powermax"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -227,7 +228,7 @@ spec:
         enabled: false
         args: [ "--monitor-interval=60s" ]
         image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.11.0
-      
+
       # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
       # Configure only when the storageCapacity is set as "true"
       # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m

--- a/samples/storage_csm_powermax_v2110.yaml
+++ b/samples/storage_csm_powermax_v2110.yaml
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powermax"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType

--- a/samples/storage_csm_powermax_v291.yaml
+++ b/samples/storage_csm_powermax_v291.yaml
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powermax"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -215,7 +216,7 @@ spec:
       - name: external-health-monitor
         enabled: false
         args: [ "--monitor-interval=60s" ]
-      
+
       # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
       # Configure only when the storageCapacity is set as "true"
       # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m

--- a/samples/storage_csm_powerscale_v2101.yaml
+++ b/samples/storage_csm_powerscale_v2101.yaml
@@ -7,6 +7,7 @@ spec:
   driver:
     csiDriverType: "isilon"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType

--- a/samples/storage_csm_powerscale_v2110.yaml
+++ b/samples/storage_csm_powerscale_v2110.yaml
@@ -7,6 +7,7 @@ spec:
   driver:
     csiDriverType: "isilon"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType

--- a/samples/storage_csm_powerscale_v291.yaml
+++ b/samples/storage_csm_powerscale_v291.yaml
@@ -7,6 +7,7 @@ spec:
   driver:
     csiDriverType: "isilon"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -115,7 +116,7 @@ spec:
         # Default value: "debug"
         - name: "CSI_LOG_LEVEL"
           value: "debug"
-        
+
         # CSI driver log format
         # Allowed values: "TEXT" or "JSON"
         # Default value: "TEXT"
@@ -252,7 +253,7 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled 
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
       #  - key: "offline.vxflexos.storage.dell.com"
       #    operator: "Exists"
       #    effect: "NoSchedule"

--- a/samples/storage_csm_powerstore_v2101.yaml
+++ b/samples/storage_csm_powerstore_v2101.yaml
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powerstore"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -115,9 +116,9 @@ spec:
           value: "false"
         # X_CSI_POWERSTORE_EXTERNAL_ACCESS: Allows to specify additional entries for hostAccess of NFS volumes. Both single IP address and subnet are valid entries.
         # Allowed Values: x.x.x.x/xx or x.x.x.x
-        # Default Value: 
+        # Default Value:
         - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
-          value: 
+          value:
 
       # nodeSelector: Define node selection constraints for controller pods.
       # For the pod to be eligible to run on a node, the node must have each
@@ -174,7 +175,7 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-  
+
   modules:
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature

--- a/samples/storage_csm_powerstore_v2110.yaml
+++ b/samples/storage_csm_powerstore_v2110.yaml
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powerstore"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -111,7 +112,7 @@ spec:
           value: "false"
         # X_CSI_POWERSTORE_EXTERNAL_ACCESS: Allows to specify additional entries for hostAccess of NFS volumes. Both single IP address and subnet are valid entries.
         # Allowed Values: x.x.x.x/xx or x.x.x.x
-        # Default Value: 
+        # Default Value:
         - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
           value:
       # nodeSelector: Define node selection constraints for controller pods.

--- a/samples/storage_csm_powerstore_v291.yaml
+++ b/samples/storage_csm_powerstore_v291.yaml
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powerstore"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -104,9 +105,9 @@ spec:
           value: "false"
         # X_CSI_POWERSTORE_EXTERNAL_ACCESS: Allows to specify additional entries for hostAccess of NFS volumes. Both single IP address and subnet are valid entries.
         # Allowed Values: x.x.x.x/xx or x.x.x.x
-        # Default Value: 
+        # Default Value:
         - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
-          value: 
+          value:
 
       # nodeSelector: Define node selection constraints for controller pods.
       # For the pod to be eligible to run on a node, the node must have each
@@ -163,7 +164,7 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-  
+
   modules:
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature

--- a/samples/storage_csm_unity_v2101.yaml
+++ b/samples/storage_csm_unity_v2101.yaml
@@ -7,6 +7,7 @@ spec:
   driver:
     csiDriverType: "unity"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType

--- a/samples/storage_csm_unity_v2110.yaml
+++ b/samples/storage_csm_unity_v2110.yaml
@@ -7,6 +7,7 @@ spec:
   driver:
     csiDriverType: "unity"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -70,15 +71,15 @@ spec:
         # ssl authentication. (unity-cert-0..unity-cert-n)
         # This field is only verified if X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION is set to false
         # Allowed values: n, where n > 0
-        # Default value: None          
+        # Default value: None
         - name: CERT_SECRET_COUNT
           value: "1"
         # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.
         # If it is set to false, then a secret unity-certs has to be created with an X.509 certificate of CA which signed the Unisphere certificate
         # Allowed values:
         #   true: skip Unisphere API server's certificate verification
-        #   false: verify Unisphere API server's certificates 
-        # Default value: true	
+        #   false: verify Unisphere API server's certificates
+        # Default value: true
         - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
           value: "true"
     sideCars:

--- a/samples/storage_csm_unity_v291.yaml
+++ b/samples/storage_csm_unity_v291.yaml
@@ -7,6 +7,7 @@ spec:
   driver:
     csiDriverType: "unity"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -28,10 +29,10 @@ spec:
       image: "dellemc/csi-unity:v2.9.1"
       imagePullPolicy: IfNotPresent
       envs:
-          # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
-          # Allowed values: boolean
-          # Default value: "false"
-          # Examples : "true" , "false"
+        # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
+        # Allowed values: boolean
+        # Default value: "false"
+        # Examples : "true" , "false"
         - name: X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS
           value: "false"
         - name: X_CSI_EPHEMERAL_STAGING_PATH
@@ -72,15 +73,15 @@ spec:
         # ssl authentication. (unity-cert-0..unity-cert-n)
         # This field is only verified if X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION is set to false
         # Allowed values: n, where n > 0
-        # Default value: None          
+        # Default value: None
         - name: CERT_SECRET_COUNT
           value: "1"
         # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.
         # If it is set to false, then a secret unity-certs has to be created with an X.509 certificate of CA which signed the Unisphere certificate
         # Allowed values:
         #   true: skip Unisphere API server's certificate verification
-        #   false: verify Unisphere API server's certificates 
-        # Default value: true	
+        #   false: verify Unisphere API server's certificates
+        # Default value: true
         - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
           value: "true"
 

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -622,12 +622,14 @@
 - scenario: "Install PowerFlex Driver with first set of alternate values"
   paths:
     - "testfiles/storage_csm_powerflex_alt_vals_1.yaml"
+    - "testfiles/powerflex-cert-secret-0.yaml"
   tags:
     - "powerflex"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-vxflexos] and template [testfiles/powerflex-templates/powerflex-storageclass-template.yaml] for [pflex]"
     - "Set up secret with template [testfiles/powerflex-templates/powerflex-secret-template.yaml] name [powerflex-config] in namespace [dell] for [pflex]"
+    - "Apply custom resource [2]"
     - "Apply custom resource [1]"
     - "Validate custom resource [1]"
     - "Validate [powerflex] driver from CR [1] is installed"
@@ -635,6 +637,7 @@
     # cleanup
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
+    - "Delete custom resource [2]"
     - "Restore template [testfiles/powerflex-templates/powerflex-secret-template.yaml] for [pflex]"
     - "Restore template [testfiles/powerflex-templates/powerflex-storageclass-template.yaml] for [pflex]"
   customTest:

--- a/tests/shared/common.go
+++ b/tests/shared/common.go
@@ -41,6 +41,7 @@ const (
 	PmaxConfigVersion          string = "v2.11.0"
 	AuthServerConfigVersion    string = "v1.11.0"
 	AccConfigVersion           string = "v1.1.0"
+	AppMobConfigVersion        string = "v1.1.0"
 )
 
 // StorageKey is used to store a runtime object. It's used for both clientgo client and controller runtime client


### PR DESCRIPTION
# Description
PR to add immutable note for fsGroupPolicy.
Added app mobility unit tests to boost coverage on controllers.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1322|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested manually updating fsGroupPolicy in the CR on k8s 1.29. Field is immutable so Operator will return error.
- [x] Tested manually updating fsGroupPolicy in the CR on k8s 1.30 successfully. 
- [x] Tested manually updating configmap. Operator picks up on change.
