### PR TITLE
CSI PowerMax: Corrects CHROOT param in older version

### DIFF
--- a/operatorconfig/driverconfig/powermax/v2.10.1/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.10.1/node.yaml
@@ -125,7 +125,7 @@ spec:
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
               value: "csipowermax-reverseproxy"
-            - name: X_CSI_NODE_CHROOT
+            - name: X_CSI_ISCSI_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -287,6 +287,14 @@ func ReverseProxyInjectDeployment(dp v1.DeploymentApplyConfiguration, cr csmv1.C
 		return nil, err
 	}
 	container := *containerPtr
+	// update the image
+	for _, side := range revProxyModule.Components {
+		if side.Name == ReverseProxyServerComponent {
+			if side.Image != "" {
+				*container.Image = string(side.Image)
+			}
+		}
+	}
 	dp.Spec.Template.Spec.Containers = append(dp.Spec.Template.Spec.Containers, container)
 	// inject revProxy ENVs in driver environment
 	revProxyPort := getRevProxyPort(*revProxyModule)

--- a/tests/config/driverconfig/powermax/v2.10.0/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.10.0/node.yaml
@@ -125,7 +125,7 @@ spec:
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
               value: "csipowermax-reverseproxy"
-            - name: X_CSI_NODE_CHROOT
+            - name: X_CSI_ISCSI_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/tests/config/driverconfig/powermax/v2.10.1/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.10.1/node.yaml
@@ -125,7 +125,7 @@ spec:
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
               value: "csipowermax-reverseproxy"
-            - name: X_CSI_NODE_CHROOT
+            - name: X_CSI_ISCSI_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"

--- a/tests/config/driverconfig/powermax/v2.9.1/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.9.1/node.yaml
@@ -125,7 +125,7 @@ spec:
               value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
               value: "csipowermax-reverseproxy"
-            - name: X_CSI_NODE_CHROOT
+            - name: X_CSI_ISCSI_CHROOT
               value: noderoot
             - name: X_CSI_GRPC_MAX_THREADS
               value: "50"


### PR DESCRIPTION
# Description
This PR:
- Corrects the CHROOT env param in 2.10.1
- Corrects the unit tests file to point to correct param
- Minor update in reverseproxy to reflect CR image when installed as sidecar.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1221|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit Test
- [x] Cluster Test
