### PR TITLE
Added OCP samples to reflect redhat registry and sha ids used for certification

### DIFF
--- a/samples/ocp/1.6.0/connectivity_client_v110.yaml
+++ b/samples/ocp/1.6.0/connectivity_client_v110.yaml
@@ -1,0 +1,26 @@
+apiVersion: storage.dell.com/v1
+kind: ApexConnectivityClient
+metadata:
+  name: dell-connectivity-client
+  namespace: dell-connectivity-client
+spec:
+  client:
+    csmClientType: "apexConnectivityClient"
+    configVersion: v1.1.0
+    connectionTarget: connect-into.dell.com
+    forceRemoveClient: true
+    common:
+      name: connectivity-client-docker-k8s
+      image: registry.connect.redhat.com/dell-emc/connectivity-client-docker-k8s@sha256:204be30a60ee2864cf8e9a8a49f13efbee14222c78f27307288f59b5eb188158
+      imagePullPolicy: IfNotPresent
+    initContainers:
+      - name: connectivity-client-init
+        image: registry.connect.redhat.com/dell-emc/connectivity-client-docker-k8s@sha256:204be30a60ee2864cf8e9a8a49f13efbee14222c78f27307288f59b5eb188158
+        imagePullPolicy: IfNotPresent
+    sideCars:
+      - name: kubernetes-proxy
+        image: docker.io/bitnami/kubectl@sha256:e9d32369b107d0ceeee228c4dc19eff372c26009f29a2fc8f22327508f608542
+        imagePullPolicy: IfNotPresent
+      - name: cert-persister
+        image: docker.io/dellemc/connectivity-cert-persister-k8s@sha256:aaa935f3ba99a91bf5f00c53de5cd69e23716645ea9690f050c4ed80834661fc
+        imagePullPolicy: IfNotPresent

--- a/samples/ocp/1.6.0/storage_csm_powerflex_v2110.yaml
+++ b/samples/ocp/1.6.0/storage_csm_powerflex_v2110.yaml
@@ -1,0 +1,406 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: vxflexos
+  namespace: vxflexos
+spec:
+  driver:
+    csiDriverType: "powerflex"
+    csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
+      # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+      # Allowed values: ReadWriteOnceWithFSType, File , None
+      # Default value: ReadWriteOnceWithFSType
+      fSGroupPolicy: "File"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
+    configVersion: v2.11.0
+    replicas: 1
+    dnsPolicy: ClusterFirstWithHostNet
+    forceUpdate: false
+    forceRemoveDriver: true
+    common:
+      image: "registry.connect.redhat.com/dell-emc/csi-vxflexos@sha256:a4e96d11be8920f01b273748a8cf8cfc60515403640f77f101a13f7d79056e23"
+      imagePullPolicy: IfNotPresent
+      envs:
+        - name: X_CSI_VXFLEXOS_ENABLELISTVOLUMESNAPSHOT
+          value: "false"
+        - name: X_CSI_VXFLEXOS_ENABLESNAPSHOTCGDELETE
+          value: "false"
+        - name: X_CSI_DEBUG
+          value: "true"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
+        - name: KUBELET_CONFIG_DIR
+          value: "/var/lib/kubelet"
+        - name: "CERT_SECRET_COUNT"
+          value: "0"
+        - name: X_CSI_QUOTA_ENABLED
+          value: "false"
+    sideCars:
+      # 'k8s' represents a string prepended to each volume created by the CSI driver
+      - name: provisioner
+        image: registry.k8s.io/sig-storage/csi-provisioner@sha256:405a14e1aa702f7ea133cea459e8395fe40a6125c088c55569e696d48e1bd385
+        args: ["--volume-name-prefix=k8s"]
+      - name: attacher
+        image: registry.k8s.io/sig-storage/csi-attacher@sha256:b4d611100ece2f9bc980d1cb19c2285b8868da261e3b1ee8f45448ab5512ab94
+      - name: registrar
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f25af73ee708ff9c82595ae99493cdef9295bd96953366cddf36305f82555dac
+      - name: resizer
+        image: registry.k8s.io/sig-storage/csi-resizer@sha256:a541e6cc2d8b011bb21b1d4ffec6b090e85270cce6276ee302d86153eec0af43
+      - name: snapshotter
+        image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:2e04046334baf9be425bb0fa1d04c2d1720d770825eedbdbcdb10d430da4ad8c
+      - name: csi-metadata-retriever
+        image: registry.connect.redhat.com/dell-emc/csi-metadata-retriever@sha256:abf97fc03ff59147ef0cd9ec3e58fcd5ef499aa9c13da53a8b99731884cb87d9
+        # sdc-monitor is disabled by default, due to high CPU usage
+      - name: sdc-monitor
+        enabled: false
+        image: docker.io/dellemc/sdc@sha256:37b3a459c51ff66cfd439638129942b46054d1dbf2685b7b4444aa605cc7f4b8
+        envs:
+          - name: HOST_PID
+            value: "1"
+          - name: MDM
+            value: "10.xx.xx.xx,10.xx.xx.xx" #do not add mdm value here if it is present in secret
+            # health monitor is disabled by default, refer to driver documentation before enabling it
+            # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED  to "true".
+      - name: csi-external-health-monitor-controller
+        enabled: false
+        args: ["--monitor-interval=60s"]
+        image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller@sha256:7ecd3509367bcc2db5d599cdff9f3afb6f13e7b664a10785dec2459c7ee50a9c
+    # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+    # Configure when the storageCapacity is set as "true"
+    # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+    #- name: provisioner
+    #  args: ["--capacity-poll-interval=5m"]
+
+    controller:
+      envs:
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin - volume condition.
+        # Install the 'external-health-monitor' sidecar accordingly.
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_POWERFLEX_EXTERNAL_ACCESS: Allows to specify additional entries for hostAccess of NFS volumes. Both single IP address and subnet are valid entries.
+        # Allowed Values: x.x.x.x/xx or x.x.x.x
+        # Default Value: None
+        - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+          value:
+      #"controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
+      # Leave as blank to use all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # "controller.tolerations" defines tolerations that would be applied to controller deployment
+      # Leave as blank to install controller on worker nodes
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+    node:
+      envs:
+        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin - volume usage
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_RENAME_SDC_ENABLED: Enable/Disable rename of SDC
+        # Allowed values:
+        #   true: enable renaming
+        #   false: disable renaming
+        # Default value: false
+        - name: X_CSI_RENAME_SDC_ENABLED
+          value: "false"
+        # X_CSI_RENAME_SDC_PREFIX: defines a string for prefix of the SDC name.
+        # "prefix" + "worker_node_hostname" should not exceed 31 chars.
+        # Default value: none
+        # Examples: "rhel-sdc", "sdc-test"
+        - name: X_CSI_RENAME_SDC_PREFIX
+          value: ""
+        # X_CSI_MAX_VOLUMES_PER_NODE: Defines the maximum PowerFlex volumes that can be created per node
+        # Allowed values: Any value greater than or equal to 0
+        # If value is zero Container Orchestrator shall decide how many volumes of this type can be published by the controller to the node.
+        # This limit is applicable to all the nodes in the cluster for which node label 'maxVxflexosVolumesPerNode' is not set.
+        # Default value: "0"
+        - name: X_CSI_MAX_VOLUMES_PER_NODE
+          value: "0"
+      # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
+      # Leave as blank to use all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # "node.tolerations" defines tolerations that would be applied to node daemonset
+      # Leave as blank to install node driver only on worker nodes
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+    initContainers:
+      - image: docker.io/dellemc/sdc@sha256:37b3a459c51ff66cfd439638129942b46054d1dbf2685b7b4444aa605cc7f4b8
+        imagePullPolicy: IfNotPresent
+        name: sdc
+        envs:
+          - name: MDM
+            value: "10.xx.xx.xx,10.xx.xx.xx" #provide MDM value
+  modules:
+    # Authorization: enable csm-authorization for RBAC
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: false
+      # For PowerFlex Tech-Preview v2.0.0-alpha use v1.11.0 as configVersion.
+      # Do not change the configVersion to v2.0.0-alpha
+      configVersion: v1.11.0
+      components:
+        - name: karavi-authorization-proxy
+          # Use image: dellemc/csm-authorization-sidecar:v2.0.0-alpha for PowerFlex Tech-Preview v2.0.0-alpha
+          image: registry.connect.redhat.com/dell-emc/csm-authorization-sidecar@sha256:5d3f43f2c1bb0704ddf4b9d8f9218cc2d77cabcd73ec9e7076f4865809d2fc5d
+          envs:
+            # proxyHost: hostname of the csm-authorization server
+            - name: "PROXY_HOST"
+              value: "csm-authorization.com"
+            # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
+            - name: "SKIP_CERTIFICATE_VALIDATION"
+              value: "true"
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: false
+      configVersion: v1.9.0
+      components:
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: false
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: registry.connect.redhat.com/dell-emc/csm-topology@sha256:25eb850d37bdd78fa62f39c17d8208a4f21539ff7396dc7b672bf6945bba388d
+          # certificate: base64-encoded certificate for cert/private-key pair -- add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: false
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: docker.io/otel/opentelemetry-collector@sha256:cecb0904bcc2a90c823c2c044e7034934ab6c98b5ec52c337c0f6c6e57cd3cf1
+          # certificate: base64-encoded certificate for cert/private-key pair -- add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.20"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.20"
+        # enabled: Enable/Disable cert-manager
+        # Allowed values:
+        #   true: enable deployment of cert-manager
+        #   false: disable deployment of cert-manager only if it's already deployed
+        # Default value: false
+        - name: cert-manager
+          enabled: false
+        - name: metrics-powerflex
+          # enabled: Enable/Disable PowerFlex metrics
+          enabled: false
+          # image: Defines PowerFlex metrics image. This shouldn't be changed
+          image: registry.connect.redhat.com/dell-emc/csm-metrics-powerflex@sha256:03d145edb80b8633168af7c7236bde6887cd9f28b6c765fce427f245599feef6
+          envs:
+            # POWERFLEX_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerFlex
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERFLEX_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERFLEX_SDC_METRICS_ENABLED: enable/disable collection of sdc metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERFLEX_SDC_METRICS_ENABLED"
+              value: "true"
+            # POWERFLEX_VOLUME_METRICS_ENABLED: enable/disable collection of volume metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERFLEX_VOLUME_METRICS_ENABLED"
+              value: "true"
+            # POWERFLEX_STORAGE_POOL_METRICS_ENABLED: enable/disable collection of storage pool metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERFLEX_STORAGE_POOL_METRICS_ENABLED"
+              value: "true"
+            # POWERFLEX_SDC_IO_POLL_FREQUENCY: set polling frequency to get sdc metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERFLEX_SDC_IO_POLL_FREQUENCY"
+              value: "10"
+            # POWERFLEX_VOLUME_IO_POLL_FREQUENCY: set polling frequency to get volume metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERFLEX_VOLUME_IO_POLL_FREQUENCY"
+              value: "10"
+            # POWERFLEX_STORAGE_POOL_POLL_FREQUENCY: set polling frequency to get Quota capacity metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERFLEX_STORAGE_POOL_POLL_FREQUENCY"
+              value: "10"
+            # PowerFlex metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERFLEX_LOG_LEVEL"
+              value: "INFO"
+            # PowerFlex Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERFLEX_LOG_FORMAT"
+              value: "TEXT"
+            # Otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"
+    # Replication: allows to configure replication
+    # Replication CRDs must be installed before installing driver
+    - name: replication
+      # enabled: Enable/Disable replication feature
+      # Allowed values:
+      #   true: enable replication feature(install dell-csi-replicator sidecar)
+      #   false: disable replication feature(do not install dell-csi-replicator sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.9.0
+      components:
+        - name: dell-csi-replicator
+          # image: Image to use for dell-csi-replicator. This shouldn't be changed
+          # Allowed values: string
+          # Default value: None
+          image: registry.connect.redhat.com/dell-emc/dell-csi-replicator@sha256:d378bd9538dd73fca6f6837df6f01570f16e4d30aa6704588ecda4e39ce12668
+          envs:
+            # replicationPrefix: prefix to prepend to storage classes parameters
+            # Allowed values: string
+            # Default value: replication.storage.dell.com
+            - name: "X_CSI_REPLICATION_PREFIX"
+              value: "replication.storage.dell.com"
+            # replicationContextPrefix: prefix to use for naming of resources created by replication feature
+            # Allowed values: string
+            - name: "X_CSI_REPLICATION_CONTEXT_PREFIX"
+              value: "powerflex"
+        - name: dell-replication-controller-manager
+          # image: Defines controller image. This shouldn't be changed
+          # Allowed values: string
+          image: registry.connect.redhat.com/dell-emc/dell-replication-controller@sha256:d06408eb29f2da630bf46452f25cec022758d414ea7122618d7f1374e224b443
+          envs:
+            # TARGET_CLUSTERS_IDS: comma separated list of cluster IDs of the targets clusters. DO NOT include the source(wherever CSM Operator is deployed) cluster ID
+            # Set the value to "self" in case of stretched/single cluster configuration
+            # Allowed values: string
+            - name: "TARGET_CLUSTERS_IDS"
+              value: "target-cluster-1"
+            # Replication log level
+            # Allowed values: "error", "warn"/"warning", "info", "debug"
+            # Default value: "debug"
+            - name: "REPLICATION_CTRL_LOG_LEVEL"
+              value: "debug"
+            # replicas: Defines number of controller replicas
+            # Allowed values: int
+            # Default value: 1
+            - name: "REPLICATION_CTRL_REPLICAS"
+              value: "1"
+            # retryIntervalMin: Initial retry interval of failed reconcile request.
+            # It doubles with each failure, upto retry-interval-max
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MIN"
+              value: "1s"
+            # RETRY_INTERVAL_MAX: Maximum retry interval of failed reconcile request
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MAX"
+              value: "5m"
+    - name: resiliency
+      # enabled: Enable/Disable Resiliency feature
+      # Allowed values:
+      #   true: enable Resiliency feature(deploy podmon sidecar)
+      #   false: disable Resiliency feature(do not deploy podmon sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.10.0
+      components:
+        - name: podmon-controller
+          image: docker.io/dellemc/podmon@sha256:818d32881238b4f91fef65f5f800bcef180b612bd33c3ca9965571bc7b43cf26
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--labelvalue=csi-vxflexos"
+            - "--skipArrayConnectionValidation=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            - "--arrayConnectivityConnectionLossThreshold=3"
+            # Below 3 args should not be modified.
+            - "--csisock=unix:/var/run/csi/csi.sock"
+            - "--mode=controller"
+            - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
+        - name: podmon-node
+          image: docker.io/dellemc/podmon@sha256:818d32881238b4f91fef65f5f800bcef180b612bd33c3ca9965571bc7b43cf26
+          imagePullPolicy: IfNotPresent
+          envs:
+            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
+            # Allowed values: Any valid and free port (string)
+            # Default value: 8083
+            - name: "X_CSI_PODMON_API_PORT"
+              value: "8083"
+          args:
+            - "--labelvalue=csi-vxflexos"
+            - "--leaderelection=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityPollRate=5"
+            # Below 3 args should not be modified.
+            - "--csisock=unix:/var/lib/kubelet/plugins/vxflexos.emc.dell.com/csi_sock"
+            - "--mode=node"
+            - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"

--- a/samples/ocp/1.6.0/storage_csm_powermax_v2110.yaml
+++ b/samples/ocp/1.6.0/storage_csm_powermax_v2110.yaml
@@ -1,0 +1,490 @@
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: powermax
+  namespace: powermax
+spec:
+  # Add fields here
+  driver:
+    csiDriverType: "powermax"
+    csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
+      # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+      # Allowed values: ReadWriteOnceWithFSType, File , None
+      # Default value: ReadWriteOnceWithFSType
+      fSGroupPolicy: "ReadWriteOnceWithFSType"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
+    configVersion: v2.11.0
+    # replica: Define the number of PowerMax controller nodes
+    # to deploy to the Kubernetes release
+    # Allowed values: n, where n > 0
+    # Default value: None
+    replicas: 2
+    # Default credential secret for Powermax, if not set it to ""
+    authSecret: powermax-creds
+    dnsPolicy: ClusterFirstWithHostNet
+    forceUpdate: false
+    forceRemoveDriver: true
+    common:
+      image: registry.connect.redhat.com/dell-emc/csi-powermax@sha256:313ab1390a66f4fc9b47bde65bb135685adc5ec30108798c6254f8a34232f10e
+      # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
+      # Allowed values:
+      #  Always: Always pull the image.
+      #  IfNotPresent: Only pull the image if it does not already exist on the node.
+      #  Never: Never pull the image.
+      # Default value: None
+      imagePullPolicy: IfNotPresent
+      envs:
+        # X_CSI_MANAGED_ARRAYS: Serial ID of the arrays that will be used for provisioning
+        # Default value: None
+        # Examples: "000000000001", "000000000002"
+        - name: X_CSI_MANAGED_ARRAYS
+          value: "000000000000,000000000001"
+        # X_CSI_POWERMAX_ENDPOINT: Address of the Unisphere server that is managing the PowerMax arrays
+        # In case of multi-array, provide an endpoint of locally attached array
+        # Default value: None
+        # Example: https://0.0.0.1:8443
+        - name: X_CSI_POWERMAX_ENDPOINT
+          value: "https://0.0.0.0:8443/"
+        # X_CSI_K8S_CLUSTER_PREFIX: Define a prefix that is appended onto
+        # all resources created in the Array
+        # This should be unique per K8s/CSI deployment
+        # maximum length of this value is 3 characters
+        # Default value: None
+        # Examples: "XYZ", "EMC"
+        - name: X_CSI_K8S_CLUSTER_PREFIX
+          value: "XYZ"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
+        - name: KUBELET_CONFIG_DIR
+          value: /var/lib/kubelet
+        # X_CSI_POWERMAX_PORTGROUPS: Define the set of existing port groups that the driver will use.
+        # It is a comma separated list of portgroup names.
+        # Required only in case of iSCSI port groups
+        # Allowed values: iSCSI Port Group names
+        # Default value: None
+        # Examples: "pg1", "pg1, pg2"
+        - name: X_CSI_POWERMAX_PORTGROUPS
+          value: ""
+        # "X_CSI_TRANSPORT_PROTOCOL" can be "FC" or "FIBRE" for fibrechannel,
+        # "ISCSI" for iSCSI,
+        # "NVMETCP" for NVMeTCP or "" for autoselection.
+        # Allowed values:
+        #   "FC"    - Fiber Channel protocol
+        #   "FIBER" - Fiber Channel protocol
+        #   "ISCSI" - iSCSI protocol
+        #   "NVMETCP" = NVMeTCP protocol
+        #   ""      - Automatic selection of transport protocol
+        # Default value: "" <empty>
+        - name: X_CSI_TRANSPORT_PROTOCOL
+          value: ""
+        # VMware/vSphere virtualization support
+        # set X_CSI_VSPHERE_ENABLED to true, if you to enable VMware virtualized environment support via RDM
+        # Allowed values:
+        #   "true" - vSphere volumes are enabled
+        #   "false" - vSphere volumes are disabled
+        # Default value: "false"
+        - name: "X_CSI_VSPHERE_ENABLED"
+          value: "false"
+        # X_CSI_VSPHERE_PORTGROUP: An existing portGroup that driver will use for vSphere
+        # recommended format: csi-x-VC-PG, x can be anything of user choice
+        # Allowed value: valid existing port group on the array
+        # Default value: "" <empty>
+        - name: "X_CSI_VSPHERE_PORTGROUP"
+          value: ""
+        # X_CSI_VSPHERE_HOSTNAME: An existing host(initiator group)/ host group(cascaded initiator group) that driver will use for vSphere
+        # this host should contain initiators from all the ESXs/ESXi host where the cluster is deployed
+        # recommended format: csi-x-VC-HN, x can be anything of user choice
+        # Allowed value: valid existing host/host group on the array
+        # Default value: "" <empty>
+        - name: "X_CSI_VSPHERE_HOSTNAME"
+          value: ""
+        # X_CSI_VCENTER_HOST: URL/endpoint of the vCenter where all the ESX are present
+        # Allowed value: valid vCenter host endpoint
+        # Default value: "" <empty>
+        - name: "X_CSI_VCENTER_HOST"
+          value: ""
+        # CSI driver log level
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "debug"
+        - name: "CSI_LOG_LEVEL"
+          value: "debug"
+        # CSI driver log format
+        # Allowed values: "TEXT" or "JSON"
+        # Default value: "TEXT"
+        - name: "CSI_LOG_FORMAT"
+          value: "TEXT"
+    controller:
+      envs:
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+      # nodeSelector: Define node selection constraints for controller pods.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations that would be applied to controller deployment
+      # Leave as blank to install controller on worker nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  - key: "node-role.kubernetes.io/control-plane"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+    node:
+      envs:
+        # X_CSI_POWERMAX_ISCSI_ENABLE_CHAP: Determine if the driver is going to configure
+        # ISCSI node databases on the nodes with the CHAP credentials
+        # If enabled, the CHAP secret must be provided in the credentials secret
+        # and set to the key "chapsecret"
+        # Allowed values:
+        #   "true"  - CHAP is enabled
+        #   "false" - CHAP is disabled
+        # Default value: "false"
+        - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
+          value: "false"
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_TOPOLOGY_CONTROL_ENABLED provides a way to filter topology keys on a node based on array and transport protocol
+        # if enabled, user can create custom topology keys by editing node-topology-config configmap.
+        # Allowed values:
+        #   true: enable the filtration based on config map
+        #   false: disable the filtration based on config map
+        # Default value: false
+        - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+          value: "false"
+        # X_CSI_MAX_VOLUMES_PER_NODE: Defines the maximum PowerMax volumes that the controller can schedule on the node
+        # Allowed values: Any value greater than or equal to 0
+        # Default value: "0"
+        - name: X_CSI_MAX_VOLUMES_PER_NODE
+          value: "0"
+      # nodeSelector: Define node selection constraints for node pods.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations that would be applied to node daemonset
+      # Add/Remove tolerations as per requirement
+      # Leave as blank if you wish to not apply any tolerations
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      tolerations:
+        - key: "node.kubernetes.io/memory-pressure"
+          operator: "Exists"
+          effect: "NoExecute"
+        - key: "node.kubernetes.io/disk-pressure"
+          operator: "Exists"
+          effect: "NoExecute"
+        - key: "node.kubernetes.io/network-unavailable"
+          operator: "Exists"
+          effect: "NoExecute"
+    sideCars:
+      # 'pmax' represents a string prepended to each volume created by the CSI driver
+      - name: provisioner
+        image: registry.k8s.io/sig-storage/csi-provisioner@sha256:405a14e1aa702f7ea133cea459e8395fe40a6125c088c55569e696d48e1bd385
+        args: ["--volume-name-prefix=pmax"]
+      - name: attacher
+        image: registry.k8s.io/sig-storage/csi-attacher@sha256:b4d611100ece2f9bc980d1cb19c2285b8868da261e3b1ee8f45448ab5512ab94
+      - name: registrar
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f25af73ee708ff9c82595ae99493cdef9295bd96953366cddf36305f82555dac
+      - name: resizer
+        image: registry.k8s.io/sig-storage/csi-resizer@sha256:a541e6cc2d8b011bb21b1d4ffec6b090e85270cce6276ee302d86153eec0af43
+      - name: snapshotter
+        image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:2e04046334baf9be425bb0fa1d04c2d1720d770825eedbdbcdb10d430da4ad8c
+      - name: csi-metadata-retriever
+        image: registry.connect.redhat.com/dell-emc/csi-metadata-retriever@sha256:abf97fc03ff59147ef0cd9ec3e58fcd5ef499aa9c13da53a8b99731884cb87d9
+      # health monitor is disabled by default, refer to driver documentation before enabling it
+      - name: external-health-monitor
+        enabled: false
+        args: ["--monitor-interval=60s"]
+        image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller@sha256:7ecd3509367bcc2db5d599cdff9f3afb6f13e7b664a10785dec2459c7ee50a9c
+        # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+        # Configure only when the storageCapacity is set as "true"
+        # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+        #- name: provisioner
+        #  args: ["--capacity-poll-interval=5m"]
+  modules:
+    # CSI Powermax Reverseproxy is a mandatory module for Powermax
+    - name: csireverseproxy
+      # enabled: Always set to true
+      enabled: true
+      forceRemoveModule: true
+      configVersion: v2.10.0
+      components:
+        - name: csipowermax-reverseproxy
+          # image: Define the container images used for the reverse proxy
+          # Default value: None
+          image: docker.io/dellemc/csipowermax-reverseproxy@sha256:63efb70544d41887130fd97c94516a3740754c1799fe5fcd1671a9319ac9c192
+          envs:
+            # "tlsSecret" defines the TLS secret that is created with certificate
+            # and its associated key
+            # Default value: None
+            # Example: "tls-secret"
+            - name: X_CSI_REVPROXY_TLS_SECRET
+              value: "csirevproxy-tls-secret"
+            - name: X_CSI_REVPROXY_PORT
+              value: "2222"
+            - name: X_CSI_CONFIG_MAP_NAME
+              value: "powermax-reverseproxy-config"
+            # deployAsSidecar defines the way reversproxy is installed with the driver
+            # set it true, if csm-auth is enabled / you want it as a sidecar container
+            # set it false, if you want it as a deployment
+            - name: "DeployAsSidecar"
+              value: "true"
+    # Authorization: enable csm-authorization for RBAC
+    - name: authorization
+      # enabled: Enable/Disable csm-authorization
+      enabled: false
+      configVersion: v1.11.0
+      components:
+        - name: karavi-authorization-proxy
+          image: registry.connect.redhat.com/dell-emc/csm-authorization-sidecar@sha256:5d3f43f2c1bb0704ddf4b9d8f9218cc2d77cabcd73ec9e7076f4865809d2fc5d
+          envs:
+            # proxyHost: hostname of the csm-authorization server
+            - name: "PROXY_HOST"
+              value: "csm-authorization.com"
+            # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
+            - name: "SKIP_CERTIFICATE_VALIDATION"
+              value: "true"
+    # Replication: allows configuring replication module
+    # Replication CRDs must be installed before installing driver
+    - name: replication
+      # enabled: Enable/Disable replication feature
+      # Allowed values:
+      #   true: enable replication feature(install dell-csi-replicator sidecar)
+      #   false: disable replication feature(do not install dell-csi-replicator sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.9.0
+      components:
+        - name: dell-csi-replicator
+          # image: Image to use for dell-csi-replicator. This shouldn't be changed
+          # Allowed values: string
+          # Default value: None
+          image: registry.connect.redhat.com/dell-emc/dell-csi-replicator@sha256:d378bd9538dd73fca6f6837df6f01570f16e4d30aa6704588ecda4e39ce12668
+          envs:
+            # replicationPrefix: prefix to prepend to storage classes parameters
+            # Allowed values: string
+            # Default value: replication.storage.dell.com
+            - name: "X_CSI_REPLICATION_PREFIX"
+              value: "replication.storage.dell.com"
+            # replicationContextPrefix: prefix to use for naming of resources created by replication feature
+            # Allowed values: string
+            # Default value: powermax
+            - name: "X_CSI_REPLICATION_CONTEXT_PREFIX"
+              value: "powermax"
+        - name: dell-replication-controller-manager
+          # image: Defines controller image. This shouldn't be changed
+          # Allowed values: string
+          image: registry.connect.redhat.com/dell-emc/dell-replication-controller@sha256:d06408eb29f2da630bf46452f25cec022758d414ea7122618d7f1374e224b443
+          envs:
+            # TARGET_CLUSTERS_IDS: comma separated list of cluster IDs of the targets clusters. DO NOT include the source(wherever CSM Operator is deployed) cluster ID
+            # Set the value to "self" in case of stretched/single cluster configuration
+            # Allowed values: string
+            - name: "TARGET_CLUSTERS_IDS"
+              value: "target-cluster-1"
+            # Replication log level
+            # Allowed values: "error", "warn"/"warning", "info", "debug"
+            # Default value: "debug"
+            - name: "REPLICATION_CTRL_LOG_LEVEL"
+              value: "debug"
+            # replicas: Defines number of controller replicas
+            # Allowed values: int
+            # Default value: 1
+            - name: "REPLICATION_CTRL_REPLICAS"
+              value: "1"
+            # retryIntervalMin: Initial retry interval of failed reconcile request.
+            # It doubles with each failure, upto retry-interval-max
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MIN"
+              value: "1s"
+            # RETRY_INTERVAL_MAX: Maximum retry interval of failed reconcile request
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MAX"
+              value: "5m"
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: false
+      configVersion: v1.9.0
+      components:
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: false
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: registry.connect.redhat.com/dell-emc/csm-topology@sha256:25eb850d37bdd78fa62f39c17d8208a4f21539ff7396dc7b672bf6945bba388d
+          # certificate: base64-encoded certificate for cert/private-key pair -- add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: false
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: docker.io/otel/opentelemetry-collector@sha256:cecb0904bcc2a90c823c2c044e7034934ab6c98b5ec52c337c0f6c6e57cd3cf1
+          # certificate: base64-encoded certificate for cert/private-key pair -- add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.20"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.20"
+        - name: cert-manager
+          # enabled: Enable/Disable cert-manager
+          # Allowed values:
+          #   true: enable deployment of cert-manager
+          #   false: disable deployment of cert-manager only if it's already deployed
+          # Default value: false
+          enabled: false
+        - name: metrics-powermax
+          # enabled: Enable/Disable PowerMax metrics
+          enabled: false
+          # image: Defines PowerMax metrics image. This shouldn't be changed
+          image: registry.connect.redhat.com/dell-emc/csm-metrics-powerflex@sha256:03d145edb80b8633168af7c7236bde6887cd9f28b6c765fce427f245599feef6
+          envs:
+            # POWERMAX_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerMax
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERMAX_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERMAX_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERMAX_PERFORMANCE_METRICS_ENABLED: enable/disable collection of volume performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERMAX_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERMAX_CAPACITY_POLL_FREQUENCY: set polling frequency to get capacity metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_CAPACITY_POLL_FREQUENCY"
+              value: "10"
+            # POWERMAX_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get volume performance data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_PERFORMANCE_POLL_FREQUENCY"
+              value: "10"
+            # PowerMax metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERMAX_LOG_LEVEL"
+              value: "INFO"
+            # PowerMax Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERMAX_LOG_FORMAT"
+              value: "TEXT"
+            # otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"
+            # configMap name which has all array/endpoint related info
+            - name: "X_CSI_CONFIG_MAP_NAME"
+              value: "powermax-reverseproxy-config"
+    - name: resiliency
+      # enabled: Enable/Disable Resiliency feature
+      # Allowed values:
+      #   true: enable Resiliency feature(deploy podmon sidecar)
+      #   false: disable Resiliency feature(do not deploy podmon sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.10.0
+      components:
+        - name: podmon-controller
+          image: docker.io/dellemc/podmon@sha256:818d32881238b4f91fef65f5f800bcef180b612bd33c3ca9965571bc7b43cf26
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--labelvalue=csi-powermax"
+            - "--arrayConnectivityPollRate=60"
+            - "--skipArrayConnectionValidation=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityConnectionLossThreshold=3"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/run/csi/csi.sock"
+            - "--mode=controller"
+            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
+            - "--driverPath=csi-powermax.dellemc.com"
+        - name: podmon-node
+          image: docker.io/dellemc/podmon@sha256:818d32881238b4f91fef65f5f800bcef180b612bd33c3ca9965571bc7b43cf26
+          imagePullPolicy: IfNotPresent
+          envs:
+            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
+            # Allowed values: Any valid and free port (string)
+            # Default value: 8083
+            - name: "X_CSI_PODMON_API_PORT"
+              value: "8083"
+          args:
+            - "--labelvalue=csi-powermax"
+            - "--arrayConnectivityPollRate=60"
+            - "--leaderelection=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/lib/kubelet/plugins/powermax.emc.dell.com/csi_sock"
+            - "--mode=node"
+            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
+            - "--driverPath=csi-powermax.dellemc.com"

--- a/samples/ocp/1.6.0/storage_csm_powerscale_v2110.yaml
+++ b/samples/ocp/1.6.0/storage_csm_powerscale_v2110.yaml
@@ -1,0 +1,485 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: isilon
+  namespace: isilon
+spec:
+  driver:
+    csiDriverType: "isilon"
+    csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
+      # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+      # Allowed values: ReadWriteOnceWithFSType, File , None
+      # Default value: ReadWriteOnceWithFSType
+      fSGroupPolicy: "ReadWriteOnceWithFSType"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
+    configVersion: v2.11.0
+    authSecret: isilon-creds
+    replicas: 2
+    dnsPolicy: ClusterFirstWithHostNet
+    # Uninstall CSI Driver and/or modules when CR is deleted
+    forceRemoveDriver: true
+    common:
+      image: "registry.connect.redhat.com/dell-emc/csi-isilon@sha256:a8644e1872b971254efc0e2826b740017f6e88d93ef6ae3d8937f119dd0f155e"
+      imagePullPolicy: IfNotPresent
+      envs:
+        # X_CSI_VERBOSE: Indicates what content of the OneFS REST API message should be logged in debug level logs
+        # Allowed Values:
+        #   0: log full content of the HTTP request and response
+        #   1: log without the HTTP response body
+        #   2: log only 1st line of the HTTP request and response
+        # Default value: 0
+        - name: X_CSI_VERBOSE
+          value: "1"
+        # X_CSI_ISI_PORT: Specify the HTTPs port number of the PowerScale OneFS API server
+        # This value acts as a default value for endpointPort, if not specified for a cluster config in secret
+        # Allowed value: valid port number
+        # Default value: 8080
+        - name: X_CSI_ISI_PORT
+          value: "8080"
+        # X_CSI_ISI_PATH: The base path for the volumes to be created on PowerScale cluster.
+        # This value acts as a default value for isiPath, if not specified for a cluster config in secret
+        # Ensure that this path exists on PowerScale cluster.
+        # Allowed values: unix absolute path
+        # Default value: /ifs
+        # Examples: /ifs/data/csi, /ifs/engineering
+        - name: X_CSI_ISI_PATH
+          value: "/ifs/data/csi"
+        # X_CSI_ISI_NO_PROBE_ON_START: Indicates whether the controller/node should probe all the PowerScale clusters during driver initialization
+        # Allowed values:
+        #   true : do not probe all PowerScale clusters during driver initialization
+        #   false: probe all PowerScale clusters during driver initialization
+        # Default value: false
+        - name: X_CSI_ISI_NO_PROBE_ON_START
+          value: "false"
+        # X_CSI_ISI_AUTOPROBE: automatically probe the PowerScale cluster if not done already during CSI calls.
+        # Allowed values:
+        #   true : enable auto probe.
+        #   false: disable auto probe.
+        # Default value: false
+        - name: X_CSI_ISI_AUTOPROBE
+          value: "true"
+        # X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION: Specify whether the PowerScale OneFS API server's certificate chain and host name should be verified.
+        # Formerly this attribute was named as "X_CSI_ISI_INSECURE"
+        # This value acts as a default value for skipCertificateValidation, if not specified for a cluster config in secret
+        # Allowed values:
+        #   true: skip OneFS API server's certificate verification
+        #   false: verify OneFS API server's certificates
+        # Default value: true
+        - name: X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION
+          value: "true"
+        # X_CSI_ISI_AUTH_TYPE: Specify the authentication method to be used.
+        # Allowed values:
+        #   0: basic authentication
+        #   1: session-based authentication
+        # Default value: 0
+        - name: X_CSI_ISI_AUTH_TYPE
+          value: "0"
+        # X_CSI_CUSTOM_TOPOLOGY_ENABLED: Specify if custom topology label <provisionerName>.dellemc.com/<powerscalefqdnorip>:<provisionerName>
+        # has to be used for making connection to backend PowerScale Array.
+        # If X_CSI_CUSTOM_TOPOLOGY_ENABLED is set to true, then do not specify allowedTopologies in storage class.
+        # Allowed values:
+        #   true : enable custom topology
+        #   false: disable custom topology
+        # Default value: false
+        - name: X_CSI_CUSTOM_TOPOLOGY_ENABLED
+          value: "false"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
+        - name: KUBELET_CONFIG_DIR
+          value: "/var/lib/kubelet"
+        # certSecretCount: Represents number of certificate secrets, which user is going to create for
+        # ssl authentication. (isilon-cert-0..isilon-cert-n)
+        # Allowed values: n, where n > 0
+        # Default value: None
+        - name: "CERT_SECRET_COUNT"
+          value: "1"
+        # CSI driver log level
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "debug"
+        - name: "CSI_LOG_LEVEL"
+          value: "debug"
+    controller:
+      envs:
+        # X_CSI_ISI_QUOTA_ENABLED: Indicates whether the provisioner should attempt to set (later unset) quota
+        # on a newly provisioned volume.
+        # This requires SmartQuotas to be enabled on PowerScale cluster.
+        # Allowed values:
+        #   true: set quota for volume
+        #   false: do not set quota for volume
+        - name: X_CSI_ISI_QUOTA_ENABLED
+          value: "true"
+        # X_CSI_ISI_ACCESS_ZONE: The name of the access zone a volume can be created in.
+        # If storageclass is missing with AccessZone parameter, then value of X_CSI_ISI_ACCESS_ZONE is used for the same.
+        # Default value: System
+        # Examples: System, zone1
+        - name: X_CSI_ISI_ACCESS_ZONE
+          value: "System"
+        # X_CSI_ISI_VOLUME_PATH_PERMISSIONS: The permissions for isi volume directory path
+        # This value acts as a default value for isiVolumePathPermissions, if not specified for a cluster config in secret
+        # Allowed values: valid octal mode number
+        # Default value: "0777"
+        # Examples: "0777", "777", "0755"
+        - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
+          value: "0777"
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
+        # Install the 'external-health-monitor' sidecar accordingly.
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS: Ignore unresolvable hosts on the OneFS.
+        # When set to true, OneFS allows new host to add to existing export list though any of the existing hosts from the
+        # same exports are unresolvable/doesn't exist anymore.
+        # Allowed values:
+        #   true: ignore existing unresolvable hosts and append new host to the existing export
+        #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
+        # Default value: false
+        - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+          value: "false"
+        # X_CSI_MAX_PATH_LIMIT: this parameter is used for setting the maximum Path length for the given volume.
+        # Default value: 192
+        # Examples: 192, 256
+        - name: X_CSI_MAX_PATH_LIMIT
+          value: "192"
+      # nodeSelector: Define node selection constraints for pods of controller deployment.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the controller deployment, if required.
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+    node:
+      envs:
+        # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
+        # If value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node.
+        # This limit is applicable to all the nodes in the cluster for which node label 'max-isilon-volumes-per-node' is not set.
+        # Allowed values: n, where n >= 0
+        # Default value: 0
+        - name: X_CSI_MAX_VOLUMES_PER_NODE
+          value: "0"
+        # X_CSI_ALLOWED_NETWORKS: Custom networks for PowerScale export
+        # Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
+        # Allowed values: list of one or more networks
+        # Default value: None
+        # Provide them in the following format: "[net1, net2]"
+        # CIDR format should be used
+        # eg: "[192.168.1.0/24, 192.168.100.0/22]"
+        - name: X_CSI_ALLOWED_NETWORKS
+          value: ""
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
+        # Install the 'external-health-monitor' sidecar accordingly.
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_MAX_PATH_LIMIT: this parameter is used for setting the maximum Path length for the given volume.
+        # Default value: 192
+        # Examples: 192, 256
+        - name: X_CSI_MAX_PATH_LIMIT
+          value: "192"
+      # nodeSelector: Define node selection constraints for pods of node daemonset
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the node daemonset, if required.
+      # Default value: None
+      tolerations:
+      # - key: "node.kubernetes.io/memory-pressure"
+      #   operator: "Exists"
+      #   effect: "NoExecute"
+      # - key: "node.kubernetes.io/disk-pressure"
+      #   operator: "Exists"
+      #   effect: "NoExecute"
+      # - key: "node.kubernetes.io/network-unavailable"
+      #   operator: "Exists"
+      #   effect: "NoExecute"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+    sideCars:
+      - name: provisioner
+        image: registry.k8s.io/sig-storage/csi-provisioner@sha256:405a14e1aa702f7ea133cea459e8395fe40a6125c088c55569e696d48e1bd385
+        args: ["--volume-name-prefix=csipscale"]
+      - name: attacher
+        image: registry.k8s.io/sig-storage/csi-attacher@sha256:b4d611100ece2f9bc980d1cb19c2285b8868da261e3b1ee8f45448ab5512ab94
+      - name: registrar
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f25af73ee708ff9c82595ae99493cdef9295bd96953366cddf36305f82555dac
+      - name: resizer
+        image: registry.k8s.io/sig-storage/csi-resizer@sha256:a541e6cc2d8b011bb21b1d4ffec6b090e85270cce6276ee302d86153eec0af43
+      - name: snapshotter
+        image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:2e04046334baf9be425bb0fa1d04c2d1720d770825eedbdbcdb10d430da4ad8c
+      - name: csi-metadata-retriever
+        image: registry.connect.redhat.com/dell-emc/csi-metadata-retriever@sha256:abf97fc03ff59147ef0cd9ec3e58fcd5ef499aa9c13da53a8b99731884cb87d9
+      # health monitor is disabled by default, refer to driver documentation before enabling it
+      - name: external-health-monitor
+        enabled: false
+        args: ["--monitor-interval=60s"]
+        image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller@sha256:7ecd3509367bcc2db5d599cdff9f3afb6f13e7b664a10785dec2459c7ee50a9c
+        # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+        # Configure when the storageCapacity is set as "true"
+        # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+        #- name: provisioner
+        #  args: ["--capacity-poll-interval=5m"]
+  modules:
+    # Authorization: enable csm-authorization for RBAC
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: false
+      configVersion: v1.11.0
+      components:
+        - name: karavi-authorization-proxy
+          image: registry.connect.redhat.com/dell-emc/csm-authorization-sidecar@sha256:5d3f43f2c1bb0704ddf4b9d8f9218cc2d77cabcd73ec9e7076f4865809d2fc5d
+          envs:
+            # proxyHost: hostname of the csm-authorization server
+            - name: "PROXY_HOST"
+              value: "csm-authorization.com"
+            # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
+            - name: "SKIP_CERTIFICATE_VALIDATION"
+              value: "true"
+    # replication: allows to configure replication
+    # Replication CRDs must be installed before installing driver
+    - name: replication
+      # enabled: Enable/Disable replication feature
+      # Allowed values:
+      #   true: enable replication feature(install dell-csi-replicator sidecar)
+      #   false: disable replication feature(do not install dell-csi-replicator sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.9.0
+      components:
+        - name: dell-csi-replicator
+          # image: Image to use for dell-csi-replicator. This shouldn't be changed
+          # Allowed values: string
+          # Default value: None
+          image: registry.connect.redhat.com/dell-emc/dell-csi-replicator@sha256:d378bd9538dd73fca6f6837df6f01570f16e4d30aa6704588ecda4e39ce12668
+          envs:
+            # replicationPrefix: prefix to prepend to storage classes parameters
+            # Allowed values: string
+            # Default value: replication.storage.dell.com
+            - name: "X_CSI_REPLICATION_PREFIX"
+              value: "replication.storage.dell.com"
+            # replicationContextPrefix: prefix to use for naming of resources created by replication feature
+            # Allowed values: string
+            # Default value: powerstore
+            - name: "X_CSI_REPLICATION_CONTEXT_PREFIX"
+              value: "powerscale"
+        - name: dell-replication-controller-manager
+          # image: Defines controller image. This shouldn't be changed
+          # Allowed values: string
+          image: registry.connect.redhat.com/dell-emc/dell-replication-controller@sha256:d06408eb29f2da630bf46452f25cec022758d414ea7122618d7f1374e224b443
+          envs:
+            # TARGET_CLUSTERS_IDS: comma separated list of cluster IDs of the targets clusters. DO NOT include the source(wherever CSM Operator is deployed) cluster ID
+            # Set the value to "self" in case of stretched/single cluster configuration
+            # Allowed values: string
+            - name: "TARGET_CLUSTERS_IDS"
+              value: "target-cluster-1"
+            # Replication log level
+            # Allowed values: "error", "warn"/"warning", "info", "debug"
+            # Default value: "debug"
+            - name: "REPLICATION_CTRL_LOG_LEVEL"
+              value: "debug"
+            # replicas: Defines number of controller replicas
+            # Allowed values: int
+            # Default value: 1
+            - name: "REPLICATION_CTRL_REPLICAS"
+              value: "1"
+            # retryIntervalMin: Initial retry interval of failed reconcile request.
+            # It doubles with each failure, upto retry-interval-max
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MIN"
+              value: "1s"
+            # RETRY_INTERVAL_MAX: Maximum retry interval of failed reconcile request
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MAX"
+              value: "5m"
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: false
+      configVersion: v1.9.0
+      components:
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: false
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: registry.connect.redhat.com/dell-emc/csm-topology@sha256:25eb850d37bdd78fa62f39c17d8208a4f21539ff7396dc7b672bf6945bba388d
+          # certificate: base64-encoded certificate for cert/private-key pair -- add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: false
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: docker.io/otel/opentelemetry-collector@sha256:cecb0904bcc2a90c823c2c044e7034934ab6c98b5ec52c337c0f6c6e57cd3cf1
+          # certificate: base64-encoded certificate for cert/private-key pair -- add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.20"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.20"
+        - name: cert-manager
+          # enabled: Enable/Disable cert-manager
+          # Allowed values:
+          #   true: enable deployment of cert-manager
+          #   false: disable deployment of cert-manager only if it's already deployed
+          # Default value: false
+          enabled: false
+        - name: metrics-powerscale
+          # enabled: Enable/Disable PowerScale metrics
+          enabled: false
+          # image: Defines PowerScale metrics image. This shouldn't be changed
+          # Allowed values: string
+          image: registry.connect.redhat.com/dell-emc/csm-metrics-powerscale@sha256:46900ab481d9dda6bd66a335d8e37f2dcfd63d5d5fe6076b2f4de8613fc5a68e
+          envs:
+            # POWERSCALE_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerScale
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERSCALE_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERSCALE_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_PERFORMANCE_METRICS_ENABLED: enable/disable collection of performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERSCALE_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY: set polling frequency to get cluster capacity metrics data
+            # Allowed values: int
+            # Default value: 30
+            - name: "POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get cluster performance metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY"
+              value: "20"
+            # POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY: set polling frequency to get Quota capacity metrics data
+            # Allowed values: int
+            # Default value: 20
+            - name: "POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY"
+              value: "30"
+            # ISICLIENT_INSECURE: set true/false to skip/verify OneFS API server's certificates
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_INSECURE"
+              value: "true"
+            # ISICLIENT_AUTH_TYPE: set 0/1 to enables session-based/basic Authentication
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "ISICLIENT_AUTH_TYPE"
+              value: "1"
+            # ISICLIENT_VERBOSE: set 0/1/2 decide High/Medium/Low content of the OneFS REST API message should be logged in debug level logs
+            # Allowed values: 0,1,2
+            # Default value: 0
+            - name: "ISICLIENT_VERBOSE"
+              value: "0"
+            # PowerScale metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERSCALE_LOG_LEVEL"
+              value: "INFO"
+            # PowerScale Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERSCALE_LOG_FORMAT"
+              value: "TEXT"
+            # Otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"
+    - name: resiliency
+      # enabled: Enable/Disable Resiliency feature
+      # Allowed values:
+      #   true: enable Resiliency feature(deploy podmon sidecar)
+      #   false: disable Resiliency feature(do not deploy podmon sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.10.0
+      components:
+        - name: podmon-controller
+          image: docker.io/dellemc/podmon@sha256:818d32881238b4f91fef65f5f800bcef180b612bd33c3ca9965571bc7b43cf26
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--labelvalue=csi-isilon"
+            - "--arrayConnectivityPollRate=60"
+            - "--skipArrayConnectionValidation=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityConnectionLossThreshold=3"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/run/csi/csi.sock"
+            - "--mode=controller"
+            - "--driverPath=csi-isilon.dellemc.com"
+            - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
+        - name: podmon-node
+          image: docker.io/dellemc/podmon@sha256:818d32881238b4f91fef65f5f800bcef180b612bd33c3ca9965571bc7b43cf26
+          imagePullPolicy: IfNotPresent
+          envs:
+            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
+            # Allowed values: Any valid and free port (string)
+            # Default value: 8083
+            - name: "X_CSI_PODMON_API_PORT"
+              value: "8083"
+          args:
+            - "--labelvalue=csi-isilon"
+            - "--arrayConnectivityPollRate=60"
+            - "--leaderelection=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"
+            - "--mode=node"
+            - "--driverPath=csi-isilon.dellemc.com"
+            - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"

--- a/samples/ocp/1.6.0/storage_csm_powerstore_v2110.yaml
+++ b/samples/ocp/1.6.0/storage_csm_powerstore_v2110.yaml
@@ -1,0 +1,216 @@
+#
+#
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: powerstore
+  namespace: powerstore
+spec:
+  driver:
+    csiDriverType: "powerstore"
+    csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
+      # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+      # Allowed values: ReadWriteOnceWithFSType, File , None
+      # Default value: ReadWriteOnceWithFSType
+      fSGroupPolicy: "ReadWriteOnceWithFSType"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
+    configVersion: v2.11.0
+    # authSecret: This is the secret used to validate the default PowerStore secret used for installation
+    # Allowed values: <metadataName specified in the Manifest>-config
+    # For example: If the metadataName is set to powerstore, authSecret value should be set to powerstore-config
+    authSecret: powerstore-config
+    # Controller count
+    replicas: 2
+    dnsPolicy: ClusterFirstWithHostNet
+    forceUpdate: false
+    forceRemoveDriver: true
+    common:
+      image: "registry.connect.redhat.com/dell-emc/csi-powerstore@sha256:11d498da9977b57608b308e6ce36427aaa95aac7ce95bc59e95b036c7d38b043"
+      imagePullPolicy: IfNotPresent
+      envs:
+        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+          value: "csi-node"
+        - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
+          value: "/etc/fc-ports-filter"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
+        - name: KUBELET_CONFIG_DIR
+          value: /var/lib/kubelet
+        - name: CSI_LOG_LEVEL
+          value: debug
+    sideCars:
+      # 'csivol' represents a string prepended to each volume created by the CSI driver
+      - name: provisioner
+        image: registry.k8s.io/sig-storage/csi-provisioner@sha256:405a14e1aa702f7ea133cea459e8395fe40a6125c088c55569e696d48e1bd385
+        args: ["--volume-name-prefix=csivol"]
+      - name: attacher
+        image: registry.k8s.io/sig-storage/csi-attacher@sha256:b4d611100ece2f9bc980d1cb19c2285b8868da261e3b1ee8f45448ab5512ab94
+      - name: registrar
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f25af73ee708ff9c82595ae99493cdef9295bd96953366cddf36305f82555dac
+      - name: resizer
+        image: registry.k8s.io/sig-storage/csi-resizer@sha256:a541e6cc2d8b011bb21b1d4ffec6b090e85270cce6276ee302d86153eec0af43
+      - name: snapshotter
+        image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:2e04046334baf9be425bb0fa1d04c2d1720d770825eedbdbcdb10d430da4ad8c
+      - name: csi-metadata-retriever
+        image: registry.connect.redhat.com/dell-emc/csi-metadata-retriever@sha256:abf97fc03ff59147ef0cd9ec3e58fcd5ef499aa9c13da53a8b99731884cb87d9
+      # health monitor is disabled by default, refer to driver documentation before enabling it
+      - name: external-health-monitor
+        enabled: false
+        args: ["--monitor-interval=60s"]
+        image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller@sha256:7ecd3509367bcc2db5d599cdff9f3afb6f13e7b664a10785dec2459c7ee50a9c
+    # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+    # Configure only when the storageCapacity is set as "true"
+    # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+    #- name: provisioner
+    #  args: ["--capacity-poll-interval=5m"]
+
+    controller:
+      envs:
+        # X_CSI_NFS_ACLS: enables setting permissions on NFS mount directory
+        # This value will be the default value if a storage class and array config in secret
+        # do not contain the NFS ACL (nfsAcls) parameter specified
+        # Permissions can be specified in two formats:
+        #   1) Unix mode (NFSv3)
+        #   2) NFSv4 ACLs (NFSv4)
+        #      NFSv4 ACLs are supported on NFSv4 share only.
+        # Allowed values:
+        #   1) Unix mode: valid octal mode number
+        #      Examples: "0777", "777", "0755"
+        #   2) NFSv4 acls: valid NFSv4 acls, seperated by comma
+        #      Examples: "A::OWNER@:RWX,A::GROUP@:RWX", "A::OWNER@:rxtncy"
+        # Optional: true
+        # Default value: "0777"
+        # nfsAcls: "0777"
+        - name: X_CSI_NFS_ACLS
+          value: "0777"
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin - volume condition.
+        # Install the 'external-health-monitor' sidecar accordingly.
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_POWERSTORE_EXTERNAL_ACCESS: Allows to specify additional entries for hostAccess of NFS volumes. Both single IP address and subnet are valid entries.
+        # Allowed Values: x.x.x.x/xx or x.x.x.x
+        # Default Value:
+        - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
+          value:
+      # nodeSelector: Define node selection constraints for controller pods.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the controllers, if required.
+      # Leave as blank to install controller on worker nodes
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+    node:
+      envs:
+        # Set to "true" to enable ISCSI CHAP Authentication
+        # CHAP password will be autogenerated by driver
+        - name: "X_CSI_POWERSTORE_ENABLE_CHAP"
+          value: "false"
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin - volume usage
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE: Defines the maximum PowerStore volumes that can be created per node
+        # Allowed values: Any value greater than or equal to 0
+        # Default value: "0"
+        - name: X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE
+          value: "0"
+      # nodeSelector: Define node selection constraints for node pods.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the controllers, if required.
+      # Leave as blank to install controller on worker nodes
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+  modules:
+    - name: resiliency
+      # enabled: Enable/Disable Resiliency feature
+      # Allowed values:
+      #   true: enable Resiliency feature(deploy podmon sidecar)
+      #   false: disable Resiliency feature(do not deploy podmon sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.10.0
+      components:
+        - name: podmon-controller
+          image: docker.io/dellemc/podmon@sha256:818d32881238b4f91fef65f5f800bcef180b612bd33c3ca9965571bc7b43cf26
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--labelvalue=csi-powerstore"
+            - "--arrayConnectivityPollRate=60"
+            - "--skipArrayConnectionValidation=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityConnectionLossThreshold=3"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/run/csi/csi.sock"
+            - "--mode=controller"
+            - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
+            - "--driverPath=csi-powerstore.dellemc.com"
+        - name: podmon-node
+          image: docker.io/dellemc/podmon@sha256:818d32881238b4f91fef65f5f800bcef180b612bd33c3ca9965571bc7b43cf26
+          imagePullPolicy: IfNotPresent
+          envs:
+            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
+            # Allowed values: Any valid and free port (string)
+            # Default value: 8083
+            - name: "X_CSI_PODMON_API_PORT"
+              value: "8083"
+          args:
+            - "--labelvalue=csi-powerstore"
+            - "--arrayConnectivityPollRate=60"
+            - "--leaderelection=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/csi_sock"
+            - "--mode=node"
+            - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
+            - "--driverPath=csi-powerstore.dellemc.com"

--- a/samples/ocp/1.6.0/storage_csm_unity_v2110.yaml
+++ b/samples/ocp/1.6.0/storage_csm_unity_v2110.yaml
@@ -1,0 +1,168 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: unity
+  namespace: unity
+spec:
+  driver:
+    csiDriverType: "unity"
+    csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
+      # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+      # Allowed values: ReadWriteOnceWithFSType, File , None
+      # Default value: ReadWriteOnceWithFSType
+      fSGroupPolicy: "ReadWriteOnceWithFSType"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
+    configVersion: v2.11.0
+    # Controller count
+    replicas: 2
+    dnsPolicy: ClusterFirstWithHostNet
+    forceUpdate: false
+    forceRemoveDriver: true
+    common:
+      image: "registry.connect.redhat.com/dell-emc/csi-unity@sha256:5ffef0bbaad3ae5b658c5be0d9704715964ed818a18af1552159907114f7b5f2"
+      imagePullPolicy: IfNotPresent
+      envs:
+        # X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS - Flag to enable sharing of volumes across multiple pods within the same node in RWO access mode.
+        # Allowed values: boolean
+        # Default value: "false"
+        # Examples : "true" , "false"
+        - name: X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS
+          value: "false"
+        - name: X_CSI_EPHEMERAL_STAGING_PATH
+          value: "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+        # X_CSI_ISCSI_CHROOT is the path to which the driver will chroot before
+        # running any iscsi commands. This value should only be set when instructed
+        # by technical support
+        - name: X_CSI_ISCSI_CHROOT
+          value: "/noderoot"
+        # X_CSI_UNITY_SYNC_NODEINFO_INTERVAL - Time interval to add node info to array. Default 15 minutes. Minimum value should be 1.
+        # Allowed values: integer
+        # Default value: 15
+        # Examples : 0 , 2
+        - name: X_CSI_UNITY_SYNC_NODEINFO_INTERVAL
+          value: "15"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
+        - name: KUBELET_CONFIG_DIR
+          value: /var/lib/kubelet
+        # CSI_LOG_LEVEL is used to set the logging level of the driver.
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "info"
+        - name: CSI_LOG_LEVEL
+          value: debug
+        # CSI driver log format
+        # Allowed values: "TEXT" or "JSON"
+        # Default value: "TEXT"
+        - name: CSI_LOG_FORMAT
+          value: "TEXT"
+        # TENANT_NAME - Tenant name that need to added while adding host entry to the array.
+        # Allowed values: string
+        # Default value: ""
+        # Examples : "tenant2" , "tenant3"
+        - name: TENANT_NAME
+          value: ""
+        # CERT_SECRET_COUNT: Represents number of certificate secrets, which user is going to create for
+        # ssl authentication. (unity-cert-0..unity-cert-n)
+        # This field is only verified if X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION is set to false
+        # Allowed values: n, where n > 0
+        # Default value: None
+        - name: CERT_SECRET_COUNT
+          value: "1"
+        # X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION: Specifies if the driver is going to validate unisphere certs while connecting to the Unisphere REST API interface.
+        # If it is set to false, then a secret unity-certs has to be created with an X.509 certificate of CA which signed the Unisphere certificate
+        # Allowed values:
+        #   true: skip Unisphere API server's certificate verification
+        #   false: verify Unisphere API server's certificates
+        # Default value: true
+        - name: X_CSI_UNITY_SKIP_CERTIFICATE_VALIDATION
+          value: "true"
+    sideCars:
+      # 'csivol' represents a string prepended to each volume created by the CSI driver
+      - name: provisioner
+        image: registry.k8s.io/sig-storage/csi-provisioner@sha256:405a14e1aa702f7ea133cea459e8395fe40a6125c088c55569e696d48e1bd385
+        args: ["--volume-name-prefix=csivol"]
+      - name: attacher
+        image: registry.k8s.io/sig-storage/csi-attacher@sha256:b4d611100ece2f9bc980d1cb19c2285b8868da261e3b1ee8f45448ab5512ab94
+      - name: registrar
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f25af73ee708ff9c82595ae99493cdef9295bd96953366cddf36305f82555dac
+      - name: resizer
+        image: registry.k8s.io/sig-storage/csi-resizer@sha256:a541e6cc2d8b011bb21b1d4ffec6b090e85270cce6276ee302d86153eec0af43
+      - name: snapshotter
+        image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:2e04046334baf9be425bb0fa1d04c2d1720d770825eedbdbcdb10d430da4ad8c
+      - name: csi-metadata-retriever
+        image: registry.connect.redhat.com/dell-emc/csi-metadata-retriever@sha256:abf97fc03ff59147ef0cd9ec3e58fcd5ef499aa9c13da53a8b99731884cb87d9
+      # health monitor is disabled by default, refer to driver documentation before enabling it
+      - name: external-health-monitor
+        # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+        # Configure when the storageCapacity is set as "true"
+        # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+        #- name: provisioner
+        #  args: ["--capacity-poll-interval=5m"]
+
+        enabled: false
+        args: ["--monitor-interval=60s"]
+        image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller@sha256:7ecd3509367bcc2db5d599cdff9f3afb6f13e7b664a10785dec2459c7ee50a9c
+    controller:
+      envs:
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin - volume condition.
+        # Install the 'external-health-monitor' sidecar accordingly.
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the controllers, if required.
+      # Leave as blank to install controller on worker nodes
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+    node:
+      envs:
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin - volume usage
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_ALLOWED_NETWORKS: Custom networks for Unity export
+        # Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
+        # Allowed values: list of one or more networks (comma separated)
+        # Default value: ""
+        # Provide them in the following format: "net1, net2"
+        # CIDR format should be used
+        # eg: "192.168.1.0/24, 192.168.100.0/22"
+        - name: X_CSI_ALLOWED_NETWORKS
+          value: ""
+      # nodeSelector: Define node selection constraints for node pods.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the controllers, if required.
+      # Leave as blank to install controller on worker nodes
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"


### PR DESCRIPTION
# Description
Created a folder under samples folder for ocp and added the latest samples of CSM 1.6.0 which reflects the redhat registry and SHA ids specific to the release

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1221|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?

- The samples added are already tested after the certification and these samples are added for reference so that customers can avoid manual work of finding out the SHA ids and registry details for different images used 
