### PR TITLE
Added a --no-module flag to the Operator e2e tests

### DIFF
--- a/tests/e2e/run-e2e-test.sh
+++ b/tests/e2e/run-e2e-test.sh
@@ -149,6 +149,7 @@ function usage() {
   echo "  --auth-proxy                                 use to run e2e auth-proxy suite"
   echo "  --resiliency                                 use to run e2e resiliency suite"
   echo "  --app-mobility                               use to run e2e application-mobility suite"
+  echo "  --no-modules                                 use to run e2e suite without any modules"
   echo "  --pflex                                      use to run e2e powerflex suite"
   echo "  --pscale                                     use to run e2e powerscale suite"
   echo "  --pstore                                     use to run e2e powerstore suite"
@@ -183,6 +184,14 @@ while getopts ":h-:" optchar; do
       export APPLICATIONMOBILITY=true ;;
     pflex)
       export POWERFLEX=true ;;
+    no-modules) 
+      export AUTHORIZATION=false
+      export AUTHORIZATIONPROXYSERVER=false
+      export REPLICATION=false
+      export OBSERVABILITY=false
+      export RESILIENCY=false
+      export APPLICATIONMOBILITY=false 
+      ;;
     pscale)
       export POWERSCALE=true ;;
     pstore)
@@ -253,10 +262,12 @@ getArrayInfo
 checkForScenariosFile
 checkForCertCsi
 checkForKaravictl
-if [ -v APPLICATIONMOBILITY ]; then
+if [[ $APPLICATIONMOBILITY == "true" ]]; then
+  echo "Checking for dellctl - APPLICATIONMOBILITY"
   checkForDellctl
 fi
-if [ -v AUTHORIZATIONPROXYSERVER ]; then
+if [[ $AUTHORIZATIONPROXYSERVER == "true" ]]; then
+  echo "Checking for dellctl - AUTHORIZATIONPROXYSERVER"
   checkForDellctl
 fi
 checkForGinkgo


### PR DESCRIPTION
# Description
In the operator test suite, there were several flags the user could use to specify what subset of the whole test suite they wanted to run. There was no way to only run the tests that didn't test any of the CSM modules. These commits add that functionality through a flag called --no-modules. Any test scenarios tagged with one of the modules (authentication, resiliency, etc.) will be skipped with this flag.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| https://github.com/dell/csm/issues/1281 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] All tests with the powerflex tag AND a module tag get skipped when the test suite is run with the no-modules flag
See below: The following test has the powerflex tag but also the authorization module so it's skipped
![skipped-test](https://github.com/user-attachments/assets/803cde8c-6132-4d6b-a976-495e7e445d80)
