### PR TITLE
Added support for minimal manifests

### DIFF
--- a/operatorconfig/driverconfig/common/default.yaml
+++ b/operatorconfig/driverconfig/common/default.yaml
@@ -21,3 +21,5 @@ images:
   sdcmonitor: dellemc/sdc:4.5.2.1
   #"images.metadataretriever" defines the container images used for csi metadata retriever
   metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+  #"images.csiReverseProxy" defines the container images used for reverse-proxy
+  csiReverseProxy: dellemc/csipowermax-reverseproxy:v2.10.0

--- a/operatorconfig/driverconfig/common/k8s-1.24-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.24-values.yaml
@@ -21,3 +21,5 @@ images:
   sdcmonitor: dellemc/sdc:4.5.1
   #"images.metadataretriever" defines the container images used for csi metadata retriever
   metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+  #"images.csiReverseProxy" defines the container images used for reverse-proxy
+  csiReverseProxy: dellemc/csipowermax-reverseproxy:v2.10.0

--- a/operatorconfig/driverconfig/common/k8s-1.25-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.25-values.yaml
@@ -21,3 +21,5 @@ images:
   sdcmonitor: dellemc/sdc:4.5.1
   #"images.metadataretriever" defines the container images used for csi metadata retriever
   metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+  #"images.csiReverseProxy" defines the container images used for reverse-proxy
+  csiReverseProxy: dellemc/csipowermax-reverseproxy:v2.10.0

--- a/operatorconfig/driverconfig/common/k8s-1.26-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.26-values.yaml
@@ -21,3 +21,5 @@ images:
   sdcmonitor: dellemc/sdc:4.5.1
   #"images.metadataretriever" defines the container images used for csi metadata retriever
   metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+  #"images.csiReverseProxy" defines the container images used for reverse-proxy
+  csiReverseProxy: dellemc/csipowermax-reverseproxy:v2.10.0

--- a/operatorconfig/driverconfig/common/k8s-1.27-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.27-values.yaml
@@ -21,3 +21,5 @@ images:
   sdcmonitor: dellemc/sdc:4.5.1
   #"images.metadataretriever" defines the container images used for csi metadata retriever
   metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+  #"images.csiReverseProxy" defines the container images used for reverse-proxy
+  csiReverseProxy: dellemc/csipowermax-reverseproxy:v2.10.0

--- a/operatorconfig/driverconfig/common/k8s-1.28-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.28-values.yaml
@@ -21,3 +21,5 @@ images:
   sdcmonitor: dellemc/sdc:4.5.2.1
   #"images.metadataretriever" defines the container images used for csi metadata retriever
   metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+  #"images.csiReverseProxy" defines the container images used for reverse-proxy
+  csiReverseProxy: dellemc/csipowermax-reverseproxy:v2.10.0

--- a/operatorconfig/driverconfig/common/k8s-1.29-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.29-values.yaml
@@ -21,3 +21,5 @@ images:
   sdcmonitor: dellemc/sdc:4.5.2.1
   #"images.metadataretriever" defines the container images used for csi metadata retriever
   metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+  #"images.csiReverseProxy" defines the container images used for reverse-proxy
+  csiReverseProxy: dellemc/csipowermax-reverseproxy:v2.10.0

--- a/operatorconfig/driverconfig/common/k8s-1.30-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.30-values.yaml
@@ -21,3 +21,5 @@ images:
   sdcmonitor: dellemc/sdc:4.5.2.1
   #"images.metadataretriever" defines the container images used for csi metadata retriever
   metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+  #"images.csiReverseProxy" defines the container images used for reverse-proxy
+  csiReverseProxy: dellemc/csipowermax-reverseproxy:v2.10.0

--- a/operatorconfig/driverconfig/powerflex/v2.11.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.11.0/controller.yaml
@@ -235,6 +235,8 @@ spec:
               value: <X_CSI_QUOTA_ENABLED>
             - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
               value: <X_CSI_POWERFLEX_EXTERNAL_ACCESS>
+            - name: X_CSI_DEBUG
+              value: true
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/operatorconfig/driverconfig/powerflex/v2.11.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.11.0/node.yaml
@@ -111,6 +111,8 @@ spec:
               value: <X_CSI_RENAME_SDC_PREFIX>
             - name: X_CSI_MAX_VOLUMES_PER_NODE
               value: <X_CSI_MAX_VOLUMES_PER_NODE>
+            - name: X_CSI_DEBUG
+              value: true
             - name: X_CSI_POWERFLEX_KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/operatorconfig/driverconfig/powermax/v2.12.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/controller.yaml
@@ -1,0 +1,334 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch", "update"]
+    # below for snapshotter
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots", "volumesnapshots/status"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+    # below for resizer
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+    # Permissions for CSIStorageCapacity
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  # Permissions for ReplicationReplicator
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-controller
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  selector:
+    matchLabels:
+      app: <DriverDefaultReleaseName>-controller
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: <DriverDefaultReleaseName>-controller
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
+    spec:
+      serviceAccount: <DriverDefaultReleaseName>-controller
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - <DriverDefaultReleaseName>-controller
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--timeout=180s"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+            - "--timeout=180s"
+            - "--worker-threads=6"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: external-health-monitor
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+            - "--enable-node-watcher=true"
+            - "--monitor-interval=60s"
+            - "--timeout=180s"
+            - "--http-endpoint=:8080"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--volume-name-prefix=pmax"
+            - "--volume-name-uuid-length=10"
+            - "--worker-threads=6"
+            - "--timeout=120s"
+            - "--v=5"
+            - "--feature-gates=Topology=true"
+            - "--leader-election"
+            - "--extra-create-metadata"
+            - "--default-fstype=ext4"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval=5m"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: snapshotter
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=180s"
+            - "--v=5"
+            - "--snapshot-name-prefix=pmsn"
+            - "--leader-election"
+            - "--snapshot-name-uuid-length=10"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: driver
+          image: dellemc/csi-powermax:nightly  # TODO image has to be updated once the driver is released
+          imagePullPolicy: IfNotPresent
+          command: ["/csi-powermax.sh"]
+          env:
+            - name: X_CSI_POWERMAX_DRIVER_NAME
+              value: csi-powermax.dellemc.com
+            - name: CSI_ENDPOINT
+              value: /var/run/csi/csi.sock
+            - name: X_CSI_MANAGED_ARRAYS
+              value: "<X_CSI_MANAGED_ARRAY>"
+            - name: X_CSI_POWERMAX_ENDPOINT
+              value: "<X_CSI_POWERMAX_ENDPOINT>"
+            - name: X_CSI_K8S_CLUSTER_PREFIX
+              value: "<X_CSI_K8S_CLUSTER_PREFIX>"
+            - name: X_CSI_MODE
+              value: controller
+            - name: X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
+            - name: X_CSI_POWERMAX_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: powermax-creds
+            - name: X_CSI_POWERMAX_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: powermax-creds
+            - name: X_CSI_POWERMAX_DEBUG
+              value: "<X_CSI_POWERMAX_DEBUG>"
+            - name: X_CSI_POWERMAX_PORTGROUPS
+              value: "<X_CSI_POWERMAX_PORTGROUPS>"
+            - name: X_CSI_GRPC_MAX_THREADS
+              value: "50"
+            - name: X_CSI_ENABLE_BLOCK
+              value: "true"
+            - name: X_CSI_TRANSPORT_PROTOCOL
+              value: "<X_CSI_TRANSPORT_PROTOCOL>"
+            - name: SSL_CERT_DIR
+              value: /certs
+            - name: X_CSI_IG_NODENAME_TEMPLATE
+              value: "<X_CSI_IG_NODENAME_TEMPLATE>"
+            - name: X_CSI_IG_MODIFY_HOSTNAME
+              value: "<X_CSI_IG_MODIFY_HOSTNAME>"
+            - name: X_CSI_UNISPHERE_TIMEOUT
+              value: 5m
+            - name: X_CSI_POWERMAX_CONFIG_PATH
+              value: /powermax-config-params/driver-config-params.yaml
+            - name: X_CSI_POWERMAX_ARRAY_CONFIG_PATH
+              value: /powermax-array-config/powermax-array-config.yaml
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_VSPHERE_ENABLED
+              value: "<X_CSI_VSPHERE_ENABLED>"
+            - name: X_CSI_VSPHERE_PORTGROUP
+              value: "<X_CSI_VSPHERE_PORTGROUP>"
+            - name: X_CSI_VSPHERE_HOSTNAME
+              value: "<X_CSI_VSPHERE_HOSTNAME>"
+            - name: X_CSI_VCENTER_HOST
+              value: "<X_CSI_VCENTER_HOST>"
+            - name: X_CSI_VCENTER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: vcenter-creds
+                  optional: true
+            - name: X_CSI_VCENTER_PWD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: vcenter-creds
+                  optional: true
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: powermax-config-params
+              mountPath: <DriverDefaultReleaseName>-config-params
+            - name: powermax-array-config
+              mountPath: /powermax-array-config
+      volumes:
+        - name: socket-dir
+          emptyDir:
+        - name: certs
+          secret:
+            secretName: <DriverDefaultReleaseName>-certs
+            optional: true
+        - name: powermax-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+        - name: powermax-array-config
+          configMap:
+            name: powermax-array-config
+        - name: cert-dir
+          emptyDir:

--- a/operatorconfig/driverconfig/powermax/v2.12.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/csidriver.yaml
@@ -1,0 +1,23 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi-powermax.dellemc.com
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+  storageCapacity: true
+  fsGroupPolicy: ReadWriteOnceWithFSType
+  volumeLifecycleModes:
+    - Persistent

--- a/operatorconfig/driverconfig/powermax/v2.12.0/driver-config-params.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/driver-config-params.yaml
@@ -1,0 +1,21 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: <DriverDefaultReleaseNamespace>
+data:
+  driver-config-params.yaml: |-
+    CSI_LOG_LEVEL: "debug"
+    CSI_LOG_FORMAT: "TEXT"

--- a/operatorconfig/driverconfig/powermax/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/node.yaml
@@ -1,0 +1,286 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["create", "delete", "get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["privileged"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-node
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-node
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  selector:
+    matchLabels:
+      app: <DriverDefaultReleaseName>-node
+  template:
+    metadata:
+      labels:
+        app: <DriverDefaultReleaseName>-node
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
+    spec:
+      serviceAccount: <DriverDefaultReleaseName>-node
+      # nodeSelector:
+      # tolerations:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: driver
+          command: ["/csi-powermax.sh"]
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: dellemc/csi-powermax:nightly  # TODO image has to be updated once the driver is released
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: X_CSI_POWERMAX_DRIVER_NAME
+              value: csi-powermax.dellemc.com
+            - name: CSI_ENDPOINT
+              value: unix://<KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com/csi_sock
+            - name: X_CSI_MANAGED_ARRAYS
+              value: "<X_CSI_MANAGED_ARRAY>"
+            - name: X_CSI_POWERMAX_ENDPOINT
+              value: "<X_CSI_POWERMAX_ENDPOINT>"
+            - name: X_CSI_K8S_CLUSTER_PREFIX
+              value: "<X_CSI_K8S_CLUSTER_PREFIX>"
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_PRIVATE_MOUNT_DIR
+              value: "<KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com/disks"
+            - name: X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION
+              value: true
+            - name: X_CSI_POWERMAX_USER
+              valueFrom:
+                secretKeyRef:
+                  name: powermax-creds
+                  key: username
+            - name: X_CSI_POWERMAX_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: powermax-creds
+                  key: password
+            - name: X_CSI_POWERMAX_NODENAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
+              value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
+            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
+              value: noderoot
+            - name: X_CSI_GRPC_MAX_THREADS
+              value: "50"
+            - name: X_CSI_TRANSPORT_PROTOCOL
+              value: "<X_CSI_TRANSPORT_PROTOCOL>"
+            - name: SSL_CERT_DIR
+              value: /certs
+            - name: X_CSI_POWERMAX_CONFIG_PATH
+              value: /powermax-config-params/driver-config-params.yaml
+            - name: X_CSI_POWERMAX_ARRAY_CONFIG_PATH
+              value: /powermax-array-config/powermax-array-config.yaml
+            - name: X_CSI_POWERMAX_TOPOLOGY_CONFIG_PATH
+              value: /node-topology-config/topologyConfig.yaml
+            - name: X_CSI_IG_NODENAME_TEMPLATE
+              value: "<X_CSI_IG_NODENAME_TEMPLATE>"
+            - name: X_CSI_IG_MODIFY_HOSTNAME
+              value: "<X_CSI_IG_MODIFY_HOSTNAME>"
+            - name: X_CSI_POWERMAX_PORTGROUPS
+              value: "<X_CSI_POWERMAX_PORTGROUPS>"
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_MAX_VOLUMES_PER_NODE
+              value: "<X_CSI_MAX_VOLUMES_PER_NODE>"
+            - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+              value: "<X_CSI_TOPOLOGY_CONTROL_ENABLED>"
+            - name: X_CSI_VSPHERE_ENABLED
+              value: "<X_CSI_VSPHERE_ENABLED>"
+            - name: X_CSI_VSPHERE_PORTGROUP
+              value: "<X_CSI_VSPHERE_PORTGROUP>"
+            - name: X_CSI_VCENTER_HOST
+              value: "<X_CSI_VCENTER_HOST>"
+            - name: X_CSI_VSPHERE_HOSTNAME
+              value: "<X_CSI_VSPHERE_HOSTNAME>"
+            - name: X_CSI_VCENTER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: vcenter-creds
+                  optional: true
+            - name: X_CSI_VCENTER_PWD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: vcenter-creds
+                  optional: true
+          volumeMounts:
+            - name: driver-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com
+            - name: volumedevices-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices
+              mountPropagation: "Bidirectional"
+            - name: pods-path
+              mountPath: <KUBELET_CONFIG_DIR>/pods
+              mountPropagation: "Bidirectional"
+            - name: csi-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
+              mountPropagation: "Bidirectional"
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+            - name: noderoot
+              mountPath: /noderoot
+            - name: dbus-socket
+              mountPath: /run/dbus/system_bus_socket
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: powermax-config-params
+              mountPath: /powermax-config-params
+            - name: powermax-array-config
+              mountPath: /powermax-array-config
+            - name: node-topology-config
+              mountPath: /node-topology-config
+        - name: registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - --kubelet-registration-path=<KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com/csi_sock
+          env:
+            - name: ADDRESS
+              value: /csi/csi_sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: registration-dir
+              mountPath: /registration
+            - name: driver-path
+              mountPath: /csi
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins_registry/
+            type: DirectoryOrCreate
+        - name: driver-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com
+            type: DirectoryOrCreate
+        - name: volumedevices-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices
+            type: DirectoryOrCreate
+        - name: csi-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
+        - name: pods-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/pods
+            type: Directory
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: noderoot
+          hostPath:
+            path: /
+            type: Directory
+        - name: dbus-socket
+          hostPath:
+            path: /run/dbus/system_bus_socket
+            type: Socket
+        - name: certs
+          secret:
+            secretName: <DriverDefaultReleaseName>-certs
+            optional: true
+        - name: powermax-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+        - name: powermax-array-config
+          configMap:
+            name: powermax-array-config
+        - name: node-topology-config
+          configMap:
+            name: node-topology-config
+            optional: true
+        - name: kubelet-pods
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: usr-bin
+          hostPath:
+            path: /usr/bin
+            type: Directory
+        - name: var-run
+          hostPath:
+            path: /var/run
+            type: Directory

--- a/operatorconfig/driverconfig/powermax/v2.12.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/upgrade-path.yaml
@@ -1,0 +1,1 @@
+minUpgradePath: v2.10.1

--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -106,6 +106,9 @@ func GetController(ctx context.Context, cr csmv1.ContainerStorageModule, operato
 	if cr.Spec.Driver.CSIDriverType == "powermax" {
 		YamlString = ModifyPowermaxCR(YamlString, cr, "Controller")
 	}
+	if cr.Spec.Driver.CSIDriverType == "isilon" {
+		YamlString = ModifyPowerScaleCR(YamlString, cr, "Controller")
+	}
 
 	driverYAML, err := utils.GetDriverYaml(YamlString, "Deployment")
 	if err != nil {
@@ -115,6 +118,10 @@ func GetController(ctx context.Context, cr csmv1.ContainerStorageModule, operato
 
 	controllerYAML := driverYAML.(utils.ControllerYAML)
 	controllerYAML.Deployment.Spec.Replicas = &cr.Spec.Driver.Replicas
+	var defaultReplicas int32 = 1
+	if *(controllerYAML.Deployment.Spec.Replicas) == 0 {
+		controllerYAML.Deployment.Spec.Replicas = &defaultReplicas
+	}
 
 	if len(cr.Spec.Driver.Controller.Tolerations) != 0 {
 		tols := make([]acorev1.TolerationApplyConfiguration, 0)
@@ -151,15 +158,25 @@ func GetController(ctx context.Context, cr csmv1.ContainerStorageModule, operato
 		}
 
 		removeContainer := false
+		if string(*c.Name) == "csi-external-health-monitor-controller" || string(*c.Name) == "external-health-monitor" {
+			removeContainer = true
+		}
 		for _, s := range cr.Spec.Driver.SideCars {
 			if s.Name == *c.Name {
 				if s.Enabled == nil {
+					if string(*c.Name) == "csi-external-health-monitor-controller" || string(*c.Name) == "external-health-monitor" {
+						removeContainer = true
+						log.Infow("Container to be removed", "name", *c.Name)
+						break
+					}
+					removeContainer = false
 					log.Infow("Container to be enabled", "name", *c.Name)
 					break
 				} else if !*s.Enabled {
 					removeContainer = true
 					log.Infow("Container to be removed", "name", *c.Name)
 				} else {
+					removeContainer = false
 					log.Infow("Container to be enabled", "name", *c.Name)
 				}
 				break
@@ -320,6 +337,9 @@ func GetNode(ctx context.Context, cr csmv1.ContainerStorageModule, operatorConfi
 	if cr.Spec.Driver.CSIDriverType == "powermax" {
 		YamlString = ModifyPowermaxCR(YamlString, cr, "Node")
 	}
+	if cr.Spec.Driver.CSIDriverType == "isilon" {
+		YamlString = ModifyPowerScaleCR(YamlString, cr, "Node")
+	}
 
 	driverYAML, err := utils.GetDriverYaml(YamlString, "DaemonSet")
 	if err != nil {
@@ -332,6 +352,10 @@ func GetNode(ctx context.Context, cr csmv1.ContainerStorageModule, operatorConfi
 	if cr.Spec.Driver.DNSPolicy != "" {
 		dnspolicy := corev1.DNSPolicy(cr.Spec.Driver.DNSPolicy)
 		nodeYaml.DaemonSetApplyConfig.Spec.Template.Spec.DNSPolicy = &dnspolicy
+	}
+	var defaultDNSPolicy corev1.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+	if cr.Spec.Driver.DNSPolicy == "" {
+		nodeYaml.DaemonSetApplyConfig.Spec.Template.Spec.DNSPolicy = &defaultDNSPolicy
 	}
 
 	if len(cr.Spec.Driver.Node.Tolerations) != 0 {
@@ -368,15 +392,24 @@ func GetNode(ctx context.Context, cr csmv1.ContainerStorageModule, operatorConfi
 			}
 		}
 		removeContainer := false
+		if string(*c.Name) == "sdc-monitor" {
+			removeContainer = true
+		}
 		for _, s := range cr.Spec.Driver.SideCars {
 			if s.Name == *c.Name {
 				if s.Enabled == nil {
-					log.Infow("Container to be enabled", "name", *c.Name)
-					break
+					if string(*c.Name) == "sdc-monitor" {
+						removeContainer = true
+						log.Infow("Container to be removed", "name", *c.Name)
+					} else {
+						removeContainer = false
+						log.Infow("Container to be enabled", "name", *c.Name)
+					}
 				} else if !*s.Enabled {
 					removeContainer = true
 					log.Infow("Container to be removed", "name", *c.Name)
 				} else {
+					removeContainer = false
 					log.Infow("Container to be enabled", "name", *c.Name)
 				}
 				break

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -67,6 +67,86 @@ var (
 		{"empty config", csmForPowerFlex("empty"), powerFlexClient, shared.MakeSecretWithJSON("empty-config", pFlexNS, configJSONFileEmpty), "Arrays details are not provided"},
 		{"bad config", csmForPowerFlex("bad"), powerFlexClient, shared.MakeSecretWithJSON("bad-config", pFlexNS, configJSONFileBad), "unable to parse"},
 	}
+
+	modifyPowerflexCRTests = []struct {
+		name       string
+		yamlString string
+		cr         csmv1.ContainerStorageModule
+		fileType   string
+		expected   string
+	}{
+		{
+			name:       "Controller case with values",
+			yamlString: "CSI_HEALTH_MONITOR_ENABLED=OLD CSI_POWERFLEX_EXTERNAL_ACCESS=OLD CSI_DEBUG=OLD",
+			cr: csmv1.ContainerStorageModule{
+				Spec: csmv1.ContainerStorageModuleSpec{
+					Driver: csmv1.Driver{
+						Controller: csmv1.ContainerTemplate{
+							Envs: []corev1.EnvVar{
+								{Name: "X_CSI_POWERFLEX_EXTERNAL_ACCESS", Value: "NEW_POWERFLEX_ACCESS"},
+								{Name: "X_CSI_HEALTH_MONITOR_ENABLED", Value: "NEW_HEALTH_MONITOR"},
+								{Name: "X_CSI_DEBUG", Value: "NEW_DEBUG"},
+							},
+						},
+					},
+				},
+			},
+			fileType: "Controller",
+			expected: "CSI_HEALTH_MONITOR_ENABLED=OLD CSI_POWERFLEX_EXTERNAL_ACCESS=OLD CSI_DEBUG=OLD",
+		},
+		{
+			name:       "Node case with values",
+			yamlString: "CSI_APPROVE_SDC_ENABLED=NEW_APPROVE_SDC CSI_RENAME_SDC_ENABLED=NEW_RENAME_SDC CSI_PREFIX_RENAME_SDC=NEW_RENAME_PREFIX CSI_VXFLEXOS_MAX_VOLUMES_PER_NODE=NEW_MAX_VOLUMES CSI_HEALTH_MONITOR_ENABLED=NEW_HEALTH_MONITOR_NODE CSI_DEBUG=NEW_DEBUG",
+			cr: csmv1.ContainerStorageModule{
+				Spec: csmv1.ContainerStorageModuleSpec{
+					Driver: csmv1.Driver{
+						Node: csmv1.ContainerTemplate{
+							Envs: []corev1.EnvVar{
+								{Name: "X_CSI_APPROVE_SDC_ENABLED", Value: "NEW_APPROVE_SDC"},
+								{Name: "X_CSI_RENAME_SDC_ENABLED", Value: "NEW_RENAME_SDC"},
+								{Name: "X_CSI_PREFIX_RENAME_SDC", Value: "NEW_RENAME_PREFIX"},
+								{Name: "X_CSI_VXFLEXOS_MAX_VOLUMES_PER_NODE", Value: "NEW_MAX_VOLUMES"},
+								{Name: "X_CSI_HEALTH_MONITOR_ENABLED", Value: "NEW_HEALTH_MONITOR_NODE"},
+								{Name: "X_CSI_DEBUG", Value: "NEW_DEBUG"},
+							},
+						},
+					},
+				},
+			},
+			fileType: "Node",
+			expected: "CSI_APPROVE_SDC_ENABLED=NEW_APPROVE_SDC CSI_RENAME_SDC_ENABLED=NEW_RENAME_SDC CSI_PREFIX_RENAME_SDC=NEW_RENAME_PREFIX CSI_VXFLEXOS_MAX_VOLUMES_PER_NODE=NEW_MAX_VOLUMES CSI_HEALTH_MONITOR_ENABLED=NEW_HEALTH_MONITOR_NODE CSI_DEBUG=NEW_DEBUG",
+		},
+		{
+			name:       "CSIDriverSpec case with storage capacity",
+			yamlString: "CSI_STORAGE_CAPACITY_ENABLED=OLD CSI_VXFLEXOS_QUOTA_ENABLED=OLD",
+			cr: csmv1.ContainerStorageModule{
+				Spec: csmv1.ContainerStorageModuleSpec{
+					Driver: csmv1.Driver{
+						CSIDriverSpec: csmv1.CSIDriverSpec{
+							StorageCapacity: true,
+						},
+					},
+				},
+			},
+			fileType: "CSIDriverSpec",
+			expected: "CSI_STORAGE_CAPACITY_ENABLED=OLD CSI_VXFLEXOS_QUOTA_ENABLED=OLD",
+		},
+		{
+			name:       "CSIDriverSpec case without storage capacity",
+			yamlString: "CSI_STORAGE_CAPACITY_ENABLED=OLD CSI_VXFLEXOS_QUOTA_ENABLED=OLD",
+			cr: csmv1.ContainerStorageModule{
+				Spec: csmv1.ContainerStorageModuleSpec{
+					Driver: csmv1.Driver{
+						CSIDriverSpec: csmv1.CSIDriverSpec{
+							StorageCapacity: false,
+						},
+					},
+				},
+			},
+			fileType: "CSIDriverSpec",
+			expected: "CSI_STORAGE_CAPACITY_ENABLED=OLD CSI_VXFLEXOS_QUOTA_ENABLED=OLD",
+		},
+	}
 )
 
 func TestPowerFlexGo(t *testing.T) {
@@ -93,4 +173,13 @@ func csmForPowerFlexBadVersion() csmv1.ContainerStorageModule {
 	res.Spec.Driver.CSIDriverType = csmv1.PowerFlex
 
 	return res
+}
+
+func TestModifyPowerflexCR(t *testing.T) {
+	for _, tt := range modifyPowerflexCRTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ModifyPowerflexCR(tt.yamlString, tt.cr, tt.fileType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -82,7 +82,18 @@ func PrecheckPowerMax(ctx context.Context, cr *csmv1.ContainerStorageModule, ope
 			}
 		}
 	}
-
+	kubeletConfigDirFound := false
+	for _, env := range cr.Spec.Driver.Common.Envs {
+		if env.Name == "KUBELET_CONFIG_DIR" {
+			kubeletConfigDirFound = true
+		}
+	}
+	if !kubeletConfigDirFound {
+		cr.Spec.Driver.Common.Envs = append(cr.Spec.Driver.Common.Envs, corev1.EnvVar{
+			Name:  "KUBELET_CONFIG_DIR",
+			Value: "/var/lib/kubelet",
+		})
+	}
 	foundRevProxy := false
 	for _, mod := range cr.Spec.Modules {
 		if mod.Name == csmv1.ReverseProxy {
@@ -178,6 +189,7 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 				maxVolumesPerNode = env.Value
 			}
 		}
+
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxManagedArray, managedArray)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxEndpoint, endpoint)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxClusterPrefix, clusterPrefix)
@@ -259,6 +271,7 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiStorageCapacityEnabled, storageCapacity)
 	}
+
 	return yamlString
 }
 

--- a/pkg/drivers/powerscale.go
+++ b/pkg/drivers/powerscale.go
@@ -58,6 +58,7 @@ func PrecheckPowerScale(ctx context.Context, cr *csmv1.ContainerStorageModule, o
 	// check if skip validation is enabled:
 	skipCertValid := false
 	certCount := 1
+	kubeletConfigDirFound := false
 	for _, env := range cr.Spec.Driver.Common.Envs {
 		if env.Name == "X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION" {
 			b, err := strconv.ParseBool(env.Value)
@@ -73,6 +74,15 @@ func PrecheckPowerScale(ctx context.Context, cr *csmv1.ContainerStorageModule, o
 			}
 			certCount = int(d)
 		}
+		if env.Name == "KUBELET_CONFIG_DIR" {
+			kubeletConfigDirFound = true
+		}
+	}
+	if !kubeletConfigDirFound {
+		cr.Spec.Driver.Common.Envs = append(cr.Spec.Driver.Common.Envs, corev1.EnvVar{
+			Name:  "KUBELET_CONFIG_DIR",
+			Value: "/var/lib/kubelet",
+		})
 	}
 
 	secrets := []string{config}
@@ -102,6 +112,12 @@ func PrecheckPowerScale(ctx context.Context, cr *csmv1.ContainerStorageModule, o
 func getApplyCertVolume(cr csmv1.ContainerStorageModule) (*acorev1.VolumeApplyConfiguration, error) {
 	skipCertValid := false
 	certCount := 1
+
+	if len(cr.Spec.Driver.Common.Envs) == 0 ||
+		(len(cr.Spec.Driver.Common.Envs) == 1 && cr.Spec.Driver.Common.Envs[0].Name != "CERT_SECRET_COUNT") {
+		certCount = 0
+	}
+
 	for _, env := range cr.Spec.Driver.Common.Envs {
 		if env.Name == "X_CSI_ISI_SKIP_CERTIFICATE_VALIDATION" {
 			b, err := strconv.ParseBool(env.Value)
@@ -154,6 +170,8 @@ func getApplyCertVolume(cr csmv1.ContainerStorageModule) (*acorev1.VolumeApplyCo
 func ModifyPowerScaleCR(yamlString string, cr csmv1.ContainerStorageModule, fileType string) string {
 	// Parameters to initialise CR values
 	storageCapacity := "false"
+	healthMonitorNode := "false"
+	healthMonitorController := "false"
 
 	switch fileType {
 	case "CSIDriverSpec":
@@ -161,6 +179,20 @@ func ModifyPowerScaleCR(yamlString string, cr csmv1.ContainerStorageModule, file
 			storageCapacity = "true"
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiStorageCapacityEnabled, storageCapacity)
+	case "Controller":
+		for _, env := range cr.Spec.Driver.Controller.Envs {
+			if env.Name == "X_CSI_HEALTH_MONITOR_ENABLED" {
+				healthMonitorController = env.Value
+			}
+		}
+		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorController)
+	case "Node":
+		for _, env := range cr.Spec.Driver.Node.Envs {
+			if env.Name == "X_CSI_HEALTH_MONITOR_ENABLED" {
+				healthMonitorNode = env.Value
+			}
+		}
+		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorNode)
 	}
 	return yamlString
 }

--- a/pkg/drivers/powerstore.go
+++ b/pkg/drivers/powerstore.go
@@ -68,6 +68,19 @@ func PrecheckPowerStore(ctx context.Context, cr *csmv1.ContainerStorageModule, o
 		config = cr.Spec.Driver.AuthSecret
 	}
 
+	kubeletConfigDirFound := false
+	for _, env := range cr.Spec.Driver.Common.Envs {
+		if env.Name == "KUBELET_CONFIG_DIR" {
+			kubeletConfigDirFound = true
+		}
+	}
+	if !kubeletConfigDirFound {
+		cr.Spec.Driver.Common.Envs = append(cr.Spec.Driver.Common.Envs, corev1.EnvVar{
+			Name:  "KUBELET_CONFIG_DIR",
+			Value: "/var/lib/kubelet",
+		})
+	}
+
 	// Check if driver version is supported by doing a stat on a config file
 	configFilePath := fmt.Sprintf("%s/driverconfig/powerstore/%s/upgrade-path.yaml", operatorConfig.ConfigDirectory, cr.Spec.Driver.ConfigVersion)
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {

--- a/pkg/drivers/unity.go
+++ b/pkg/drivers/unity.go
@@ -112,8 +112,8 @@ func PrecheckUnity(ctx context.Context, cr *csmv1.ContainerStorageModule, operat
 // ModifyUnityCR - Configuring CR parameters
 func ModifyUnityCR(yamlString string, cr csmv1.ContainerStorageModule, fileType string) string {
 	// Parameters to initialise CR values
-	healthMonitorNode := ""
-	healthMonitorController := ""
+	healthMonitorNode := "false"
+	healthMonitorController := "false"
 	storageCapacity := "false"
 	allowedNetworks := ""
 

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -20,19 +20,19 @@ import (
 	"strconv"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	v1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	acorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	csmv1 "github.com/dell/csm-operator/api/v1"
 	"github.com/dell/csm-operator/pkg/drivers"
 	"github.com/dell/csm-operator/pkg/logger"
 	"github.com/dell/csm-operator/pkg/utils"
-	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Constants to be used in reverse proxy config files
@@ -84,18 +84,18 @@ func ReverseProxyPrecheck(ctx context.Context, op utils.OperatorConfig, revproxy
 	// Check for secrets
 	proxyServerSecret := "csirevproxy-tls-secret" // #nosec G101
 	proxyConfigMap := "powermax-reverseproxy-config"
-	if len(revproxy.Components) < 1 {
-		return fmt.Errorf("revproxy components can not be nil")
-	}
-	for _, env := range revproxy.Components[0].Envs {
-		if env.Name == "X_CSI_REVPROXY_TLS_SECRET" {
-			proxyServerSecret = env.Value
-		}
-		if env.Name == "X_CSI_CONFIG_MAP_NAME" {
-			proxyConfigMap = env.Value
-		}
-		if env.Name == "DeployAsSidecar" {
-			deployAsSidecar, _ = strconv.ParseBool(env.Value)
+
+	if revproxy.Components != nil {
+		for _, env := range revproxy.Components[0].Envs {
+			if env.Name == "X_CSI_REVPROXY_TLS_SECRET" {
+				proxyServerSecret = env.Value
+			}
+			if env.Name == "X_CSI_CONFIG_MAP_NAME" {
+				proxyConfigMap = env.Value
+			}
+			if env.Name == "DeployAsSidecar" {
+				deployAsSidecar, _ = strconv.ParseBool(env.Value)
+			}
 		}
 	}
 
@@ -240,9 +240,36 @@ func getReverseProxyDeployment(op utils.OperatorConfig, cr csmv1.ContainerStorag
 	proxyNamespace := cr.Namespace
 	var proxyTLSSecret, proxyPort, proxyConfig string
 
+	// we will populate default values for environments, if nothing is given (minimal yaml)
+
+	if revProxy.Components == nil {
+		components := make([]csmv1.ContainerTemplate, 0)
+		components = append(components, csmv1.ContainerTemplate{
+			Name: "csipowermax-reverseproxy",
+		})
+		revProxy.Components = components
+
+		revProxy.Components[0].Envs = append(revProxy.Components[0].Envs, corev1.EnvVar{
+			Name:  "X_CSI_REVPROXY_TLS_SECRET",
+			Value: "csirevproxy-tls-secret",
+		})
+		revProxy.Components[0].Envs = append(revProxy.Components[0].Envs, corev1.EnvVar{
+			Name:  "X_CSI_REVPROXY_PORT",
+			Value: "2222",
+		})
+		revProxy.Components[0].Envs = append(revProxy.Components[0].Envs, corev1.EnvVar{
+			Name:  "X_CSI_CONFIG_MAP_NAME",
+			Value: "powermax-reverseproxy-config",
+		})
+	}
+
 	for _, component := range revProxy.Components {
 		if component.Name == ReverseProxyServerComponent {
-			YamlString = strings.ReplaceAll(YamlString, ReverseProxyImage, string(component.Image))
+			image := op.K8sVersion.Images.CSIRevProxy
+			if string(component.Image) != "" {
+				image = string(component.Image)
+			}
+			YamlString = strings.ReplaceAll(YamlString, ReverseProxyImage, image)
 			for _, env := range component.Envs {
 				if env.Name == "X_CSI_REVPROXY_TLS_SECRET" {
 					proxyTLSSecret = env.Value

--- a/pkg/modules/reverseproxy_test.go
+++ b/pkg/modules/reverseproxy_test.go
@@ -162,7 +162,7 @@ func TestReverseProxyPrecheck(t *testing.T) {
 
 			return false, reverseProxy, tmpCR, sourceClient, fakeControllerRuntimeClient
 		},
-		"Fail - no components": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+		"success - no components": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
 			customResource, err := getCustomResource("./testdata/cr_powermax_reverseproxy.yaml")
 			if err != nil {
 				panic(err)
@@ -181,7 +181,7 @@ func TestReverseProxyPrecheck(t *testing.T) {
 				return ctrlClientFake.NewClientBuilder().WithObjects().Build(), nil
 			}
 
-			return false, reverseProxy, tmpCR, sourceClient, fakeControllerRuntimeClient
+			return true, reverseProxy, tmpCR, sourceClient, fakeControllerRuntimeClient
 		},
 	}
 	for name, tc := range tests {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -65,6 +65,7 @@ type K8sImagesConfig struct {
 		Sdc                   string `json:"sdc" yaml:"sdc"`
 		Sdcmonitor            string `json:"sdcmonitor" yaml:"sdcmonitor"`
 		Podmon                string `json:"podmon" yaml:"podmon"`
+		CSIRevProxy           string `json:"csiReverseProxy" yaml:"csiReverseProxy"`
 	} `json:"images" yaml:"images"`
 }
 
@@ -214,7 +215,7 @@ func ReplaceAllContainerImageApply(img K8sImagesConfig, c *acorev1.ContainerAppl
 	case csmv1.Externalhealthmonitor:
 		*c.Image = img.Images.Externalhealthmonitor
 	case csmv1.Sdc:
-		*c.Image = img.Images.Sdc
+		*c.Image = img.Images.Sdcmonitor
 	case csmv1.Sdcmonitor:
 		*c.Image = img.Images.Sdcmonitor
 	case string(csmv1.Resiliency):

--- a/samples/minimal-samples/powerflex.yaml
+++ b/samples/minimal-samples/powerflex.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: vxflexos
+  namespace: vxflexos
+spec:
+  driver:
+    csiDriverType: "powerflex"
+    configVersion: v2.11.0

--- a/samples/minimal-samples/powermax.yaml
+++ b/samples/minimal-samples/powermax.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: powermax
+  namespace: powermax
+spec:
+  driver:
+    csiDriverType: "powermax"
+    configVersion: v2.12.0
+  modules:
+    - name: csireverseproxy
+      enabled: true
+      configVersion: v2.10.0

--- a/samples/minimal-samples/powerscale.yaml
+++ b/samples/minimal-samples/powerscale.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: isilon
+  namespace: isilon
+spec:
+  driver:
+    csiDriverType: "isilon"
+    configVersion: v2.11.0

--- a/samples/minimal-samples/powerstore.yaml
+++ b/samples/minimal-samples/powerstore.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: powerstore
+  namespace: powerstore
+spec:
+  driver:
+    csiDriverType: "powerstore"
+    configVersion: v2.11.0

--- a/samples/minimal-samples/unity.yaml
+++ b/samples/minimal-samples/unity.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: unity
+  namespace: unity
+spec:
+  driver:
+    csiDriverType: "unity"
+    configVersion: v2.11.0


### PR DESCRIPTION
# Description
Need for a simple and minimal manifest file using existing Operator CRD.
Changes include adding the below default values in the code:

- Reverse proxy module for PowerMax driver
- Disable sdc-monitor and health-monitor by default
- Added the default check for kubelet config directory
- Fixed issues with initContainer and MDM key not found issue in PowerFlex driver

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1449 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested against kubernetes cluster
- [x] Ran unit tests

cert-csi  Test report for certify suite for ISCSI powerstore driver   
[report-test-run-bfdfd42b.txt](https://github.com/user-attachments/files/16942534/report-test-run-bfdfd42b.txt)

cert-csi  Test report for certify suite Unity driver
[unity-cert-csi-report.txt](https://github.com/user-attachments/files/16942812/unity-cert-csi-report.txt)

cert-csi test report for PowerScale:
[isilon-cert-csi-report.txt](https://github.com/user-attachments/files/16943119/isilon-cert-csi-report.txt)


   

