### PR TITLE
Fix --no-modules on e2e tests

### DIFF
--- a/operatorconfig/driverconfig/common/k8s-1.31-values.yaml
+++ b/operatorconfig/driverconfig/common/k8s-1.31-values.yaml
@@ -19,7 +19,7 @@ images:
   externalhealthmonitorcontroller: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
   # "images.sdcmonitor" defines the container images used to monitor sdc container
   sdcmonitor: dellemc/sdc:4.5.2.1
-  #"images.metadataretriever" defines the container images used for csi metadata retriever
+  # "images.metadataretriever" defines the container images used for csi metadata retriever
   metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
-  #"images.csiReverseProxy" defines the container images used for reverse-proxy
+  # "images.csiReverseProxy" defines the container images used for reverse-proxy
   csiReverseProxy: dellemc/csipowermax-reverseproxy:v2.11.0

--- a/operatorconfig/driverconfig/powermax/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/node.yaml
@@ -77,8 +77,8 @@ spec:
         kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccount: <DriverDefaultReleaseName>-node
-      #nodeSelector:
-      #tolerations:
+      # nodeSelector:
+      # tolerations:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:

--- a/samples/storage_csm_powerflex_v2120.yaml
+++ b/samples/storage_csm_powerflex_v2120.yaml
@@ -64,7 +64,7 @@ spec:
           - name: HOST_PID
             value: "1"
           - name: MDM
-            value: "10.xx.xx.xx,10.xx.xx.xx" #do not add mdm value here if it is present in secret
+            value: "10.xx.xx.xx,10.xx.xx.xx"  # do not add mdm value here if it is present in secret
             # health monitor is disabled by default, refer to driver documentation before enabling it
             # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED  to "true".
       - name: csi-external-health-monitor-controller
@@ -74,7 +74,7 @@ spec:
     # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
     # Configure when the storageCapacity is set as "true"
     # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
-    #- name: provisioner
+    # - name: provisioner
     #  args: ["--capacity-poll-interval=5m"]
 
     controller:
@@ -92,7 +92,7 @@ spec:
         # Default Value: None
         - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
           value:
-      #"controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
+      # "controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
       # Leave as blank to use all nodes
       # Allowed values: map of key-value pairs
       # Default value: None
@@ -178,11 +178,11 @@ spec:
         name: sdc
         envs:
           - name: MDM
-            value: "10.xx.xx.xx,10.xx.xx.xx" #provide MDM value
+            value: "10.xx.xx.xx,10.xx.xx.xx"  # provide MDM value
   modules:
     # Authorization: enable csm-authorization for RBAC
     - name: authorization
-      # enable: Enable/Disable csm-authorization
+      # enabled: Enable/Disable csm-authorization
       enabled: false
       # For PowerFlex Tech-Preview v2.0.0-alpha use v1.11.0 as configVersion.
       # Do not change the configVersion to v2.0.0-alpha

--- a/samples/storage_csm_powerscale_v2120.yaml
+++ b/samples/storage_csm_powerscale_v2120.yaml
@@ -245,7 +245,7 @@ spec:
         # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
         # Configure when the storageCapacity is set as "true"
         # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
-        #- name: provisioner
+        # - name: provisioner
         #  args: ["--capacity-poll-interval=5m"]
   modules:
     # Authorization: enable csm-authorization for RBAC

--- a/samples/storage_csm_powerstore_v2120.yaml
+++ b/samples/storage_csm_powerstore_v2120.yaml
@@ -80,7 +80,7 @@ spec:
     # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
     # Configure only when the storageCapacity is set as "true"
     # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
-    #- name: provisioner
+    # - name: provisioner
     #  args: ["--capacity-poll-interval=5m"]
 
     controller:

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,7 +58,7 @@ go get github.com/onsi/gomega/...
 
 ### Array Information
 
-For PowerFlex, Unity, PowerScale, PowerStore, Authorization, and Application-Mobility, system-specific information (array login credentials, system IDs, endpoints, etc.) need to be provided so that all the required resources (secrets, storageclasses, etc.) can be created by the tests. Example values have been inserted; please replace these with values from your system. Refer to [CSM documentation](https://dell.github.io/csm-docs/docs/) for any further questions about driver or module pre-requisites.
+For PowerFlex, Unity, PowerScale, PowerStore, Authorization, and Application-Mobility, system-specific information (array login credentials, system IDs, endpoints, etc.) need to be provided in e2e/array-info.sh so that all the required resources (secrets, storageclasses, etc.) can be created by the tests. Example values have been inserted; please replace these with values from your system. Refer to [CSM documentation](https://dell.github.io/csm-docs/docs/) for any further questions about driver or module pre-requisites.
 
 Please note that, if tests are stopped in the middle of a run, some files in `testfiles/*-templates` folders may remain in a partially modified state and break subsequent test runs. To undo these changes, you can run `git checkout -- <template file>`.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,7 +58,7 @@ go get github.com/onsi/gomega/...
 
 ### Array Information
 
-For PowerFlex, Unity, PowerScale, Authorization, and Application-Mobility, system-specific information (array login credentials, system IDs, endpoints, etc.) need to be provided so that all the required resources (secrets, storageclasses, etc.) can be created by the tests. Example values have been inserted; please replace these with values from your system. Refer to [CSM documentation](https://dell.github.io/csm-docs/docs/) for any further questions about driver or module pre-requisites.
+For PowerFlex, Unity, PowerScale, PowerStore, Authorization, and Application-Mobility, system-specific information (array login credentials, system IDs, endpoints, etc.) need to be provided so that all the required resources (secrets, storageclasses, etc.) can be created by the tests. Example values have been inserted; please replace these with values from your system. Refer to [CSM documentation](https://dell.github.io/csm-docs/docs/) for any further questions about driver or module pre-requisites.
 
 Please note that, if tests are stopped in the middle of a run, some files in `testfiles/*-templates` folders may remain in a partially modified state and break subsequent test runs. To undo these changes, you can run `git checkout -- <template file>`.
 

--- a/tests/e2e/array-info.sh
+++ b/tests/e2e/array-info.sh
@@ -39,7 +39,7 @@ export PFLEX_TENANT_PREFIX="tn1"
 export PSCALE_CLUSTER="Isilon-System-Name"
 export PSCALE_USER="username"
 export PSCALE_PASS="password"
-export PSCALE_ENDPOINT="1.1.1.1:8080"
+export PSCALE_ENDPOINT="1.1.1.1"
 export PSCALE_AUTH_ENDPOINT="localhost"
 export PSCALE_AUTH_PORT="9400"
 # The following are Authorization Proxy Server specific for powerscale:

--- a/tests/e2e/array-info.sh
+++ b/tests/e2e/array-info.sh
@@ -73,6 +73,7 @@ export PMAX_TENANT_PREFIX="tn1"
 export PSTORE_USER="username"
 export PSTORE_PASS="password"
 export PSTORE_GLOBALID="myglobalpstoreid"
+# ip only, do not include /api/rest at end
 export PSTORE_ENDPOINT="1.1.1.1"
 
 # The following is Unity specific:

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -43,6 +43,7 @@ var (
 	stepRunner    *step.Runner
 	beautify      string
 	testApex      bool
+	moduleTags    = []string{"authorization", "replication", "observability", "authorizationproxyserver", "resiliency", "applicationmobility"}
 )
 
 func Contains(slice []string, str string) bool {
@@ -65,6 +66,25 @@ func ContainsTag(scenarioTags []string, tagsSpecified []string) bool {
 	return false
 }
 
+// if --no-modules was passed in, we need to make sure any test with modules is filtered out
+// even if it contains matching tags
+// return value of true - --no-modules will prevent this test from running
+// return value of false - --no-modules will not prevent this test from running
+func CheckNoModules(scenarioTags []string) bool {
+	if os.Getenv("NOMODULES") == "false" {
+		By(fmt.Sprintf("Returning false here"))
+		return false
+	}
+	for _, tag := range scenarioTags {
+		if Contains(moduleTags, tag) {
+			By(fmt.Sprintf("--no-modules specified, skipping"))
+			return true
+		}
+	}
+	By(fmt.Sprintf("Returning false at end"))
+	return false
+}
+
 // TestE2E -
 func TestE2E(t *testing.T) {
 	if testing.Short() {
@@ -77,7 +97,7 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	tagEnvVars := []string{"AUTHORIZATION", "REPLICATION", "OBSERVABILITY", "AUTHORIZATIONPROXYSERVER", "RESILIENCY", "APPLICATIONMOBILITY", "POWERFLEX", "POWERSCALE", "POWERMAX", "POWERSTORE", "UNITY", "SANITY", "CLIENT"}
+	tagEnvVars := []string{"NOMODULES", "AUTHORIZATION", "REPLICATION", "OBSERVABILITY", "AUTHORIZATIONPROXYSERVER", "RESILIENCY", "APPLICATIONMOBILITY", "POWERFLEX", "POWERSCALE", "POWERMAX", "POWERSTORE", "UNITY", "SANITY", "CLIENT"}
 	By("Getting test environment variables")
 	valuesFile := os.Getenv(valuesFileEnvVar)
 	Expect(valuesFile).NotTo(BeEmpty(), "Missing environment variable required for tests. E2E_SCENARIOS_FILE must be set.")
@@ -121,8 +141,14 @@ var _ = Describe("[run-e2e-test] E2E Testing", func() {
 		if testApex {
 			for _, test := range testResources {
 				By(fmt.Sprintf("Starting: %s ", test.Scenario.Scenario))
-				if ContainsTag(test.Scenario.Tags, tagsSpecified) == false {
+				if !ContainsTag(test.Scenario.Tags, tagsSpecified) {
 					By(fmt.Sprintf("Not tagged for this test run, skipping"))
+					By(fmt.Sprintf("Ending: %s\n", test.Scenario.Scenario))
+					continue
+				}
+
+				// if no-modules are enabled, skip this test if it has a module tag
+				if CheckNoModules(test.Scenario.Tags) {
 					By(fmt.Sprintf("Ending: %s\n", test.Scenario.Scenario))
 					continue
 				}
@@ -141,6 +167,12 @@ var _ = Describe("[run-e2e-test] E2E Testing", func() {
 				By(fmt.Sprintf("Starting: %s ", test.Scenario.Scenario))
 				if ContainsTag(test.Scenario.Tags, tagsSpecified) == false {
 					By(fmt.Sprintf("Not tagged for this test run, skipping"))
+					By(fmt.Sprintf("Ending: %s\n", test.Scenario.Scenario))
+					continue
+				}
+
+				// if no-modules are enabled, skip this test if it has a module tag
+				if CheckNoModules(test.Scenario.Tags) {
 					By(fmt.Sprintf("Ending: %s\n", test.Scenario.Scenario))
 					continue
 				}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -71,7 +71,7 @@ func ContainsTag(scenarioTags []string, tagsSpecified []string) bool {
 // return value of true - --no-modules will prevent this test from running
 // return value of false - --no-modules will not prevent this test from running
 func CheckNoModules(scenarioTags []string) bool {
-	if os.Getenv("NOMODULES") == "false" {
+	if os.Getenv("NOMODULES") == "false" || os.Getenv("NOMODULES") == "" {
 		By(fmt.Sprintf("Returning false here"))
 		return false
 	}

--- a/tests/e2e/run-e2e-test.sh
+++ b/tests/e2e/run-e2e-test.sh
@@ -21,6 +21,14 @@ export GO111MODULE=on
 export ACK_GINKGO_RC=true
 export PROG="${0}"
 
+# Start with all modules false, they can be enabled by command line arguments 
+export AUTHORIZATION=false
+export AUTHORIZATIONPROXYSERVER=false
+export REPLICATION=false
+export OBSERVABILITY=false
+export RESILIENCY=false
+export APPLICATIONMOBILITY=false
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -184,7 +192,8 @@ while getopts ":h-:" optchar; do
       export APPLICATIONMOBILITY=true ;;
     pflex)
       export POWERFLEX=true ;;
-    no-modules) 
+    no-modules)
+      export NOMODULES=true 
       export AUTHORIZATION=false
       export AUTHORIZATIONPROXYSERVER=false
       export REPLICATION=false


### PR DESCRIPTION
# Description
This PR fixes some issues found while testing Pstore. 
These issues were:
```   ./run-e2e-test.sh --pstore  
./run-e2e-test.sh: line 274: APPLICATIONMOBILITY: unbound variable
   ```
   and 
   ```
   ./run-e2e-test.sh --pstore  --no-modules
   ```
   resulting in the modules tests being ran anyway 
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1449 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran test: ```nohup ./run-e2e-test.sh --pstore &```
[nohup-pstore-all-final.txt](https://github.com/user-attachments/files/16999452/nohup-pstore-all-final.txt)
- [x] Ran test:  ```nohup ./run-e2e-test.sh --pstore --no-modules & ```
[nohup-pstore-nomod-final.txt](https://github.com/user-attachments/files/16999463/nohup-pstore-nomod-final.txt)

