### PR TITLE
storage capacity update

### DIFF
--- a/operatorconfig/driverconfig/powerscale/v2.12.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.12.0/csidriver.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
-  storageCapacity: true
+  storageCapacity: false
   fsGroupPolicy: ReadWriteOnceWithFSType
   volumeLifecycleModes:
     - Persistent


### PR DESCRIPTION
# Description
Setting storageCapacity spec value to False so while updating it during the runtime it will be synchronized at csidriver level. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1475|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed CSI PowerScale driver with "storageCapacity" set to "true"
        
<img width="470" alt="image" src="https://github.com/user-attachments/assets/ae495365-82b1-44fc-bcc7-afa59606d6e6">


- [x] Update "storageCapacity" to "false", k edit csm -n isilon isilon
        
<img width="469" alt="image" src="https://github.com/user-attachments/assets/e709b1a5-6e42-490b-9bee-f1db101d5121">

