### PR TITLE
Enables resiliency module for powerscale in the minimal manifest file

### DIFF
--- a/operatorconfig/moduleconfig/resiliency/v1.11.0/container-powerscale-controller.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.11.0/container-powerscale-controller.yaml
@@ -16,6 +16,18 @@
 name: podmon
 image: dellemc/podmon:v1.11.0
 imagePullPolicy: IfNotPresent
+args:
+  - "--labelvalue=csi-isilon"
+  - "--arrayConnectivityPollRate=60"
+  - "--skipArrayConnectionValidation=false"
+  - "--driverPodLabelValue=dell-storage"
+  - "--ignoreVolumelessPods=false"
+  - "--arrayConnectivityConnectionLossThreshold=3"
+  # Below 4 args should not be modified.
+  - "--csisock=unix:/var/run/csi/csi.sock"
+  - "--mode=controller"
+  - "--driverPath=csi-isilon.dellemc.com"
+  - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
 env:
   - name: MY_NODE_NAME
     valueFrom:

--- a/operatorconfig/moduleconfig/resiliency/v1.11.0/container-powerscale-node.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.11.0/container-powerscale-node.yaml
@@ -21,7 +21,20 @@ securityContext:
   capabilities:
     add: ["SYS_ADMIN"]
   allowPrivilegeEscalation: true
+args:
+  - "--labelvalue=csi-isilon"
+  - "--arrayConnectivityPollRate=60"
+  - "--leaderelection=false"
+  - "--driverPodLabelValue=dell-storage"
+  - "--ignoreVolumelessPods=false"
+  # Below 4 args should not be modified.
+  - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"
+  - "--mode=node"
+  - "--driverPath=csi-isilon.dellemc.com"
+  - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
 env:
+  - name: "X_CSI_PODMON_API_PORT"
+    value: "8083"
   - name: KUBE_NODE_NAME
     valueFrom:
       fieldRef:

--- a/samples/minimal-samples/powerscale.yaml
+++ b/samples/minimal-samples/powerscale.yaml
@@ -12,3 +12,10 @@ spec:
     - name: authorization
       # enable: Enable/Disable csm-authorization
       enabled: false
+    - name: resiliency
+      # enabled: Enable/Disable Resiliency feature
+      # Allowed values:
+      #   true: enable Resiliency feature(deploy podmon sidecar)
+      #   false: disable Resiliency feature(do not deploy podmon sidecar)
+      # Default value: false
+      enabled: false


### PR DESCRIPTION
# Description
Support was added to enable the resiliency module in the minimal manifest file.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1449 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Tested in the k8s cluster
