### PR TITLE
Updated kube-rbac-proxy image to the one packaged by Redhat

### DIFF
--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -4382,7 +4382,7 @@ spec:
                       - --upstream=http://127.0.0.1:8080/
                       - --logtostderr=true
                       - --v=10
-                    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
                     name: kube-rbac-proxy
                     ports:
                       - containerPort: 8443
@@ -4431,7 +4431,7 @@ spec:
                       - name: RELATED_IMAGE_podmon-node
                         value: docker.io/dellemc/podmon:v1.11.0
                       - name: RELATED_IMAGE_kube-rbac-proxy
-                        value: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                        value: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
                       - name: RELATED_IMAGE_attacher
                         value: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
                       - name: RELATED_IMAGE_provisioner
@@ -4545,7 +4545,7 @@ spec:
       name: metrics-powerflex
     - image: docker.io/dellemc/podmon:v1.11.0
       name: podmon-node
-    - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+    - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
       name: kube-rbac-proxy
     - image: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
       name: attacher

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,7 +63,7 @@ spec:
               name: RELATED_IMAGE_metrics-powerflex
             - value: docker.io/dellemc/podmon:v1.11.0
               name: RELATED_IMAGE_podmon-node
-            - value: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+            - value: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
               name: RELATED_IMAGE_kube-rbac-proxy
             - value: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
               name: RELATED_IMAGE_attacher

--- a/config/manifests/bases/dell-csm-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dell-csm-operator.clusterserviceversion.yaml
@@ -1845,7 +1845,7 @@ spec:
       name: metrics-powerflex
     - image: docker.io/dellemc/podmon:v1.11.0
       name: podmon-node
-    - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+    - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
       name: kube-rbac-proxy
     - image: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
       name: attacher

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1373,7 +1373,7 @@ spec:
             - name: RELATED_IMAGE_podmon-node
               value: docker.io/dellemc/podmon:v1.11.0
             - name: RELATED_IMAGE_kube-rbac-proxy
-              value: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+              value: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
             - name: RELATED_IMAGE_attacher
               value: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
             - name: RELATED_IMAGE_provisioner

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.0/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.0/app-mobility-controller-manager.yaml
@@ -24,7 +24,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.1/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.1/app-mobility-controller-manager.yaml
@@ -24,7 +24,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.2/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.2/app-mobility-controller-manager.yaml
@@ -24,7 +24,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.3/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.3/app-mobility-controller-manager.yaml
@@ -24,7 +24,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/operatorconfig/moduleconfig/application-mobility/v1.1.0/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.1.0/app-mobility-controller-manager.yaml
@@ -24,7 +24,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443


### PR DESCRIPTION
# Description
Updated kube-rbac-proxy image to the repackaged by Redhat:
 **Existing image**: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
 **New image**: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1435 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Did basic sanity by creating an image using these updates. Installed CSM Operator and created Unity CSM Object on top of that and brought up application pods with PVC s on that.. All looks good.

![image](https://github.com/user-attachments/assets/cf883c10-ebfd-465b-85da-a7414916a10c)
![image](https://github.com/user-attachments/assets/3321eda6-2fe5-4b73-b73e-0d6a3526b563)
![image](https://github.com/user-attachments/assets/7aeb9503-2616-480b-895e-e43cce141ecf)






