### PR TITLE
Enables resiliency module for powerflex driver in the minimal manifes…

### DIFF
--- a/operatorconfig/moduleconfig/resiliency/v1.11.0/container-powerflex-controller.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.11.0/container-powerflex-controller.yaml
@@ -16,6 +16,17 @@
 name: podmon
 image: dellemc/podmon:v1.11.0
 imagePullPolicy: IfNotPresent
+args:
+  - "--labelvalue=csi-vxflexos"
+  - "--skipArrayConnectionValidation=false"
+  - "--driverPodLabelValue=dell-storage"
+  - "--ignoreVolumelessPods=false"
+  - "--arrayConnectivityPollRate=5"
+  - "--arrayConnectivityConnectionLossThreshold=3"
+  # Below 3 args should not be modified.
+  - "--csisock=unix:/var/run/csi/csi.sock"
+  - "--mode=controller"
+  - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
 env:
   - name: MY_NODE_NAME
     valueFrom:

--- a/operatorconfig/moduleconfig/resiliency/v1.11.0/container-powerflex-node.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.11.0/container-powerflex-node.yaml
@@ -21,7 +21,19 @@ securityContext:
   capabilities:
     add: ["SYS_ADMIN"]
   allowPrivilegeEscalation: true
+args:
+  - "--labelvalue=csi-vxflexos"
+  - "--leaderelection=false"
+  - "--driverPodLabelValue=dell-storage"
+  - "--ignoreVolumelessPods=false"
+  - "--arrayConnectivityPollRate=5"
+  # Below 3 args should not be modified.
+  - "--csisock=unix:/var/lib/kubelet/plugins/vxflexos.emc.dell.com/csi_sock"
+  - "--mode=node"
+  - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
 env:
+  - name: "X_CSI_PODMON_API_PORT"
+    value: "8083"
   - name: KUBE_NODE_NAME
     valueFrom:
       fieldRef:

--- a/samples/minimal-samples/powerflex.yaml
+++ b/samples/minimal-samples/powerflex.yaml
@@ -7,3 +7,11 @@ spec:
   driver:
     csiDriverType: "powerflex"
     configVersion: v2.11.0
+  modules:
+    - name: resiliency
+      # enabled: Enable/Disable Resiliency feature
+      # Allowed values:
+      #   true: enable Resiliency feature(deploy podmon sidecar)
+      #   false: disable Resiliency feature(do not deploy podmon sidecar)
+      # Default value: false
+      enabled: false


### PR DESCRIPTION
Support was added to enable the resiliency module in the minimal manifest file.

# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1449 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Tested in the k8s cluster

