### PR TITLE
Minimal manifest for Powermax with authorization 2.0 

### DIFF
--- a/operatorconfig/driverconfig/powermax/v2.12.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/controller.yaml
@@ -248,7 +248,7 @@ spec:
             - name: X_CSI_POWERMAX_ENDPOINT
               value: "<X_CSI_POWERMAX_ENDPOINT>"
             - name: X_CSI_K8S_CLUSTER_PREFIX
-              value: "<X_CSI_K8S_CLUSTER_PREFIX>"
+              value: "CSM"
             - name: X_CSI_MODE
               value: controller
             - name: X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION

--- a/operatorconfig/driverconfig/powermax/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/node.yaml
@@ -101,7 +101,7 @@ spec:
             - name: X_CSI_POWERMAX_ENDPOINT
               value: "<X_CSI_POWERMAX_ENDPOINT>"
             - name: X_CSI_K8S_CLUSTER_PREFIX
-              value: "<X_CSI_K8S_CLUSTER_PREFIX>"
+              value: "CSM"
             - name: X_CSI_MODE
               value: node
             - name: X_CSI_PRIVATE_MOUNT_DIR

--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -118,7 +118,7 @@ func GetController(ctx context.Context, cr csmv1.ContainerStorageModule, operato
 
 	controllerYAML := driverYAML.(utils.ControllerYAML)
 	controllerYAML.Deployment.Spec.Replicas = &cr.Spec.Driver.Replicas
-	var defaultReplicas int32 = 1
+	var defaultReplicas int32 = 2
 	if *(controllerYAML.Deployment.Spec.Replicas) == 0 {
 		controllerYAML.Deployment.Spec.Replicas = &defaultReplicas
 	}


### PR DESCRIPTION
# Description
This PR has the changes for minimizing the manifest file for the AuthorizationV2.0 Module in the PowerMax Driver

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1449|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] I have run the basic sanity of attaching a volume for one pod. Below is the screenshot for the same:

![image (3)](https://github.com/user-attachments/assets/d0a6ac90-0f84-40ad-9db3-12e48a5eb5b7)
![image](https://github.com/user-attachments/assets/535b8c97-8b9a-4842-adea-8ba0dc0bc90f)

