### PR TITLE
Readme change for powermax and powerstore namespace

### DIFF
--- a/samples/storage_csm_powerflex_v2101.yaml
+++ b/samples/storage_csm_powerflex_v2101.yaml
@@ -172,13 +172,6 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      #  - key: "offline.vxflexos.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
-      #  - key: "vxflexos.podmon.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
     initContainers:
       - image: dellemc/sdc:4.5.1
         imagePullPolicy: IfNotPresent

--- a/samples/storage_csm_powerflex_v2110.yaml
+++ b/samples/storage_csm_powerflex_v2110.yaml
@@ -172,13 +172,6 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      #  - key: "offline.vxflexos.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
-      #  - key: "vxflexos.podmon.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
     initContainers:
       - image: dellemc/sdc:4.5.2.1
         imagePullPolicy: IfNotPresent

--- a/samples/storage_csm_powerflex_v2120.yaml
+++ b/samples/storage_csm_powerflex_v2120.yaml
@@ -179,13 +179,6 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      #  - key: "offline.vxflexos.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
-      #  - key: "vxflexos.podmon.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
     initContainers:
       - image: dellemc/sdc:4.5.2.1
         imagePullPolicy: IfNotPresent

--- a/samples/storage_csm_powermax_v2101.yaml
+++ b/samples/storage_csm_powermax_v2101.yaml
@@ -208,17 +208,6 @@ spec:
         - key: "node.kubernetes.io/network-unavailable"
           operator: "Exists"
           effect: "NoExecute"
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-      # - key: "node-role.kubernetes.io/master"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      #  - key: "offline.powermax.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
-      #  - key: "powermax.podmon.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
     sideCars:
       # 'pmax' represents a string prepended to each volume created by the CSI driver
       - name: provisioner

--- a/samples/storage_csm_powermax_v2110.yaml
+++ b/samples/storage_csm_powermax_v2110.yaml
@@ -218,17 +218,6 @@ spec:
         - key: "node.kubernetes.io/network-unavailable"
           operator: "Exists"
           effect: "NoExecute"
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-      # - key: "node-role.kubernetes.io/master"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      #  - key: "offline.powermax.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
-      #  - key: "powermax.podmon.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
     sideCars:
       # 'pmax' represents a string prepended to each volume created by the CSI driver
       - name: provisioner

--- a/samples/storage_csm_powermax_v2120.yaml
+++ b/samples/storage_csm_powermax_v2120.yaml
@@ -218,17 +218,6 @@ spec:
         - key: "node.kubernetes.io/network-unavailable"
           operator: "Exists"
           effect: "NoExecute"
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-      # - key: "node-role.kubernetes.io/master"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      #  - key: "offline.powermax.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
-      #  - key: "powermax.podmon.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
     sideCars:
       # 'pmax' represents a string prepended to each volume created by the CSI driver
       - name: provisioner

--- a/samples/storage_csm_powerscale_v2101.yaml
+++ b/samples/storage_csm_powerscale_v2101.yaml
@@ -225,14 +225,6 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      # - key: "offline.isilon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # - key: "isilon.podmon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0

--- a/samples/storage_csm_powerscale_v2110.yaml
+++ b/samples/storage_csm_powerscale_v2110.yaml
@@ -223,13 +223,6 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      # - key: "offline.isilon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # - key: "isilon.podmon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1

--- a/samples/storage_csm_powerscale_v2120.yaml
+++ b/samples/storage_csm_powerscale_v2120.yaml
@@ -223,13 +223,6 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      # - key: "offline.isilon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # - key: "isilon.podmon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1

--- a/samples/storage_csm_powerstore_v2101.yaml
+++ b/samples/storage_csm_powerstore_v2101.yaml
@@ -171,13 +171,6 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      # - key: "offline.powerstore.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # - key: "powerstore.podmon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
   modules:
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature

--- a/samples/storage_csm_powerstore_v2110.yaml
+++ b/samples/storage_csm_powerstore_v2110.yaml
@@ -169,13 +169,6 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      # - key: "offline.powerstore.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # - key: "powerstore.podmon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
   modules:
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature

--- a/samples/storage_csm_powerstore_v2120.yaml
+++ b/samples/storage_csm_powerstore_v2120.yaml
@@ -169,13 +169,6 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      # - key: "offline.powerstore.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # - key: "powerstore.podmon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
   modules:
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature

--- a/samples/storage_csm_unity_v2101.yaml
+++ b/samples/storage_csm_unity_v2101.yaml
@@ -150,14 +150,8 @@ spec:
       # Leave as blank to install controller on worker nodes
       # Default value: None
       tolerations:
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      #  - key: "offline.unity.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
-      # - key: "unity.podmon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
-      # - key: "node-role.kubernetes.io/control-plane"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
+
+# Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+# - key: "node-role.kubernetes.io/control-plane"
+#   operator: "Exists"
+#   effect: "NoSchedule"

--- a/samples/storage_csm_unity_v2110.yaml
+++ b/samples/storage_csm_unity_v2110.yaml
@@ -166,10 +166,3 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      #  - key: "offline.unity.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
-      # - key: "unity.podmon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"

--- a/samples/storage_csm_unity_v2120.yaml
+++ b/samples/storage_csm_unity_v2120.yaml
@@ -162,14 +162,7 @@ spec:
       # Leave as blank to install controller on worker nodes
       # Default value: None
       tolerations:
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
-      #  - key: "offline.unity.storage.dell.com"
-      #    operator: "Exists"
-      #    effect: "NoSchedule"
-      # - key: "unity.podmon.storage.dell.com"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
-      # - key: "node-role.kubernetes.io/control-plane"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
+# Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+# - key: "node-role.kubernetes.io/control-plane"
+#   operator: "Exists"
+#   effect: "NoSchedule"

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,6 +43,8 @@ Any time changes made to the operator are being checked into the main branch, sa
   - (if running sanity, powerflex, or modules suites) `test-vxflexos`
   - (if running sanity, powerscale, or modules suites) `isilon`
   - (if running unity suite) `unity`
+  - (if running powermax e2e tests) `powermax`
+  - (if running powerstore e2e tests) `powerstore`
 - For auth: edit your `/etc/hosts` file to include the following line: `<master node IP> csm-authorization.com`
 - Cert-CSI needs to be installed  
   - See [here](https://dell.github.io/csm-docs/docs/support/cert-csi/#download-release-linux) for instructions 

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,8 +43,8 @@ Any time changes made to the operator are being checked into the main branch, sa
   - (if running sanity, powerflex, or modules suites) `test-vxflexos`
   - (if running sanity, powerscale, or modules suites) `isilon`
   - (if running unity suite) `unity`
-  - (if running powermax suite) powermax
-  - (if running powerstore suite) powerstore 
+  - (if running powermax suite) `powermax`
+  - (if running powerstore suite) `powerstore` 
 - For auth: edit your `/etc/hosts` file to include the following line: `<master node IP> csm-authorization.com`
 - Cert-CSI needs to be installed  
   - See [here](https://dell.github.io/csm-docs/docs/support/cert-csi/#download-release-linux) for instructions 

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,8 +43,8 @@ Any time changes made to the operator are being checked into the main branch, sa
   - (if running sanity, powerflex, or modules suites) `test-vxflexos`
   - (if running sanity, powerscale, or modules suites) `isilon`
   - (if running unity suite) `unity`
-  - (if running powermax e2e tests) `powermax`
-  - (if running powerstore e2e tests) `powerstore`
+  - (if running powermax suite) powermax
+  - (if running powerstore suite) powerstore 
 - For auth: edit your `/etc/hosts` file to include the following line: `<master node IP> csm-authorization.com`
 - Cert-CSI needs to be installed  
   - See [here](https://dell.github.io/csm-docs/docs/support/cert-csi/#download-release-linux) for instructions 


### PR DESCRIPTION
# Description
This PR includes a small change in the readme file. For e2e testing of powermax and powerstore, namespace 'powermax' and 'powerstore' need to be created. This detail was missing from the previous prerequisites mentioned in the readme which has now been added. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1507 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
