### PR TITLE
Add Resileincy Tolerations

### DIFF
--- a/samples/storage_csm_powerflex_v2101.yaml
+++ b/samples/storage_csm_powerflex_v2101.yaml
@@ -172,6 +172,13 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      #  - key: "offline.vxflexos.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+      #  - key: "vxflexos.podmon.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
     initContainers:
       - image: dellemc/sdc:4.5.1
         imagePullPolicy: IfNotPresent

--- a/samples/storage_csm_powerflex_v2110.yaml
+++ b/samples/storage_csm_powerflex_v2110.yaml
@@ -172,6 +172,13 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      #  - key: "offline.vxflexos.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+      #  - key: "vxflexos.podmon.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
     initContainers:
       - image: dellemc/sdc:4.5.2.1
         imagePullPolicy: IfNotPresent

--- a/samples/storage_csm_powerflex_v2120.yaml
+++ b/samples/storage_csm_powerflex_v2120.yaml
@@ -179,6 +179,13 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      #  - key: "offline.vxflexos.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+      #  - key: "vxflexos.podmon.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
     initContainers:
       - image: dellemc/sdc:4.5.2.1
         imagePullPolicy: IfNotPresent

--- a/samples/storage_csm_powermax_v2101.yaml
+++ b/samples/storage_csm_powermax_v2101.yaml
@@ -208,6 +208,17 @@ spec:
         - key: "node.kubernetes.io/network-unavailable"
           operator: "Exists"
           effect: "NoExecute"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      #  - key: "offline.powermax.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+      #  - key: "powermax.podmon.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
     sideCars:
       # 'pmax' represents a string prepended to each volume created by the CSI driver
       - name: provisioner

--- a/samples/storage_csm_powermax_v2110.yaml
+++ b/samples/storage_csm_powermax_v2110.yaml
@@ -218,6 +218,17 @@ spec:
         - key: "node.kubernetes.io/network-unavailable"
           operator: "Exists"
           effect: "NoExecute"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      #  - key: "offline.powermax.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+      #  - key: "powermax.podmon.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
     sideCars:
       # 'pmax' represents a string prepended to each volume created by the CSI driver
       - name: provisioner

--- a/samples/storage_csm_powermax_v2120.yaml
+++ b/samples/storage_csm_powermax_v2120.yaml
@@ -218,6 +218,17 @@ spec:
         - key: "node.kubernetes.io/network-unavailable"
           operator: "Exists"
           effect: "NoExecute"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      #  - key: "offline.powermax.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+      #  - key: "powermax.podmon.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
     sideCars:
       # 'pmax' represents a string prepended to each volume created by the CSI driver
       - name: provisioner

--- a/samples/storage_csm_powerscale_v2101.yaml
+++ b/samples/storage_csm_powerscale_v2101.yaml
@@ -225,6 +225,14 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      # - key: "offline.isilon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # - key: "isilon.podmon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0

--- a/samples/storage_csm_powerscale_v2110.yaml
+++ b/samples/storage_csm_powerscale_v2110.yaml
@@ -223,6 +223,13 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      # - key: "offline.isilon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # - key: "isilon.podmon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1

--- a/samples/storage_csm_powerscale_v2120.yaml
+++ b/samples/storage_csm_powerscale_v2120.yaml
@@ -223,6 +223,13 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      # - key: "offline.isilon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # - key: "isilon.podmon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1

--- a/samples/storage_csm_powerstore_v2101.yaml
+++ b/samples/storage_csm_powerstore_v2101.yaml
@@ -171,6 +171,13 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      # - key: "offline.powerstore.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # - key: "powerstore.podmon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
   modules:
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature

--- a/samples/storage_csm_powerstore_v2110.yaml
+++ b/samples/storage_csm_powerstore_v2110.yaml
@@ -169,6 +169,13 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      # - key: "offline.powerstore.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # - key: "powerstore.podmon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
   modules:
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature

--- a/samples/storage_csm_powerstore_v2120.yaml
+++ b/samples/storage_csm_powerstore_v2120.yaml
@@ -169,6 +169,13 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      # - key: "offline.powerstore.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # - key: "powerstore.podmon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
   modules:
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature

--- a/samples/storage_csm_unity_v2101.yaml
+++ b/samples/storage_csm_unity_v2101.yaml
@@ -150,8 +150,14 @@ spec:
       # Leave as blank to install controller on worker nodes
       # Default value: None
       tolerations:
-
-# Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
-# - key: "node-role.kubernetes.io/control-plane"
-#   operator: "Exists"
-#   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      #  - key: "offline.unity.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+      # - key: "unity.podmon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"

--- a/samples/storage_csm_unity_v2110.yaml
+++ b/samples/storage_csm_unity_v2110.yaml
@@ -166,3 +166,10 @@ spec:
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
       #   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      #  - key: "offline.unity.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+      # - key: "unity.podmon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"

--- a/samples/storage_csm_unity_v2120.yaml
+++ b/samples/storage_csm_unity_v2120.yaml
@@ -162,7 +162,14 @@ spec:
       # Leave as blank to install controller on worker nodes
       # Default value: None
       tolerations:
-# Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
-# - key: "node-role.kubernetes.io/control-plane"
-#   operator: "Exists"
-#   effect: "NoSchedule"
+      # Uncomment if CSM for Resiliency and CSI Driver pods monitor is enabled
+      #  - key: "offline.unity.storage.dell.com"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+      # - key: "unity.podmon.storage.dell.com"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # - key: "node-role.kubernetes.io/control-plane"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"


### PR DESCRIPTION
# Description
- Add Resiliency tolerations of PowerStore, PowerFLex, PowerMax, PowerScale and Unity

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1510 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [x] I installed the driver with resiliency enabled and configured tolerations. After inducing a node failure, the resiliency module added a taint to the failed node. Once the node was restored, I deleted the driver pods. The driver pods, which were configured to tolerate the taints added by the resiliency module, were successfully scheduled on the node. Afterward, the taints were cleared from the node.
- [x] I installed the driver with resiliency enabled but without configuring tolerations. After inducing a node failure, the resiliency module applied a taint to the failed node. Once the node was restored, I deleted the driver pods. However, the pods could not be scheduled on the node because they did not tolerate the taints. As a result, the taints on the node could not be cleared.
