### PR TITLE
Added deployAsSidecar for reversproxy as default for minimal manifests

### DIFF
--- a/controllers/acc_controller.go
+++ b/controllers/acc_controller.go
@@ -502,10 +502,7 @@ func (r *ApexConnectivityClientReconciler) SyncACC(ctx context.Context, cr csmv1
 
 	controller := accconfig.Controller
 
-	_, clusterClients, err := utils.GetAccDefaultClusters(ctx, cr, r)
-	if err != nil {
-		return err
-	}
+	_, clusterClients := utils.GetAccDefaultClusters(ctx, cr, r)
 
 	for _, cluster := range clusterClients {
 		log.Infof("Starting SYNC for %s cluster", cluster.ClusterID)

--- a/controllers/acc_controller_test.go
+++ b/controllers/acc_controller_test.go
@@ -636,7 +636,7 @@ func (suite *AccControllerTestSuite) handleAccPodTest(r *ApexConnectivityClientR
 	err := suite.fakeClient.Get(accCtx, client.ObjectKey{Namespace: suite.namespace, Name: name}, pod)
 	assert.Nil(suite.T(), err)
 
-	// since deployments/daemonsets dont create pod in non-k8s env, we have to explicitely create pod
+	// since deployments/daemonsets don't create pod in non-k8s env, we have to explicitly create pod
 	r.handlePodsUpdate(pod, pod)
 }
 

--- a/pkg/drivers/powermax_test.go
+++ b/pkg/drivers/powermax_test.go
@@ -26,12 +26,13 @@ import (
 )
 
 var (
-	powerMaxCSM           = csmForPowerMax()
-	powerMaxCSMNoProxy    = csmForPowerMaxNOProxy()
-	powerMaxCSMBadVersion = csmForPowerMaxBadVersion()
-	powerMaxClient        = crclient.NewFakeClientNoInjector(objects)
-	powerMaxSecret        = shared.MakeSecret("csm-creds", "pmax-test", shared.PmaxConfigVersion)
-	pMaxfakeSecret        = shared.MakeSecret("fake-creds", "fake-test", shared.PmaxConfigVersion)
+	powerMaxCSM                = csmForPowerMax()
+	powerMaxCSMNoProxy         = csmForPowerMaxNOProxy()
+	powerMaxCSMBadVersion      = csmForPowerMaxBadVersion()
+	powermaxDefaultKubeletPath = getDefaultKubeletPath()
+	powerMaxClient             = crclient.NewFakeClientNoInjector(objects)
+	powerMaxSecret             = shared.MakeSecret("csm-creds", "pmax-test", shared.PmaxConfigVersion)
+	pMaxfakeSecret             = shared.MakeSecret("fake-creds", "fake-test", shared.PmaxConfigVersion)
 
 	powerMaxTests = []struct {
 		// every single unit test name
@@ -62,6 +63,7 @@ var (
 	}{
 		{"missing secret", powerMaxCSM, powerMaxClient, pMaxfakeSecret, "failed to find secret"},
 		{"bad version", powerMaxCSMBadVersion, powerMaxClient, powerMaxSecret, "not supported"},
+		{"bad latest version", powermaxDefaultKubeletPath, powerMaxClient, powerMaxSecret, ""},
 	}
 )
 
@@ -124,6 +126,15 @@ func csmForPowerMaxBadVersion() csmv1.ContainerStorageModule {
 	// Add pmax driver version
 	res.Spec.Driver.ConfigVersion = "v0"
 	res.Spec.Driver.CSIDriverType = csmv1.PowerMax
+
+	return res
+}
+
+func getDefaultKubeletPath() csmv1.ContainerStorageModule {
+	res := shared.MakeCSM("csm", "pmax-test", shared.PmaxConfigVersion)
+
+	kubeEnv := corev1.EnvVar{Name: "KUBELET_CONFIG_DIR", Value: "/fake"}
+	res.Spec.Driver.Common.Envs = []corev1.EnvVar{kubeEnv}
 
 	return res
 }

--- a/pkg/modules/reverseproxy_test.go
+++ b/pkg/modules/reverseproxy_test.go
@@ -252,6 +252,16 @@ func TestReverseProxyServer(t *testing.T) {
 			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
 			return true, false, tmpCR, sourceClient, operatorConfig
 		},
+		"success - creating with minimal manifest": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			tmpCR, err := getCustomResource("./testdata/cr_powermax_reverseproxy.yaml")
+			if err != nil {
+				panic(err)
+			}
+			tmpCR.Spec.Modules[0].Components = nil
+			deployAsSidecar = false
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+			return true, false, tmpCR, sourceClient, operatorConfig
+		},
 		"fail - reverseproxy module not found": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
 			tmpCR, err := getCustomResource("./testdata/cr_powermax_replica.yaml")
 			if err != nil {

--- a/pkg/utils/status.go
+++ b/pkg/utils/status.go
@@ -117,10 +117,7 @@ func getAccStatefulSetStatus(ctx context.Context, instance *csmv1.ApexConnectivi
 	totalReadyPods := 0
 	totalFailedCount := 0
 
-	_, clusterClients, err := GetAccDefaultClusters(ctx, *instance, r)
-	if err != nil {
-		return int32(totalReplicas), csmv1.PodStatus{}, err
-	}
+	_, clusterClients := GetAccDefaultClusters(ctx, *instance, r)
 
 	for _, cluster := range clusterClients {
 		log.Infof("statefulSet status for cluster: %s", cluster.ClusterID)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1059,7 +1059,7 @@ func GetDefaultClusters(ctx context.Context, instance csmv1.ContainerStorageModu
 }
 
 // GetAccDefaultClusters - get default clusters
-func GetAccDefaultClusters(_ context.Context, _ csmv1.ApexConnectivityClient, r ReconcileCSM) (bool, []ReplicaCluster, error) {
+func GetAccDefaultClusters(_ context.Context, _ csmv1.ApexConnectivityClient, r ReconcileCSM) (bool, []ReplicaCluster) {
 	clusterClients := []ReplicaCluster{
 		{
 			ClusterCTRLClient: r.GetClient(),
@@ -1067,9 +1067,7 @@ func GetAccDefaultClusters(_ context.Context, _ csmv1.ApexConnectivityClient, r 
 			ClusterID:         DefaultSourceClusterID,
 		},
 	}
-
-	replicaEnabled := false
-	return replicaEnabled, clusterClients, nil
+	return false, clusterClients
 }
 
 // GetSecret - check if the secret is present


### PR DESCRIPTION
# Description
1. Added deployAsSidecar for reversproxy as default for minimal manifests
2. Updated code coverage

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1449 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested by installing the CSI Powermax driver with Reverseproxy as both sidecar and standalone 
