### PR TITLE
Fix PowerMax E2E

### DIFF
--- a/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config.yaml
@@ -26,6 +26,6 @@ standAloneConfig:
       proxyCredentialSecrets:
         - powermax-creds
   managementServers:
-    - url: "https://REPLACE_ENDPOINT" 
+    - url: "https://REPLACE_ENDPOINT"
       arrayCredentialSecret: powermax-creds
       skipCertificateValidation: true

--- a/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml
@@ -22,10 +22,10 @@ logFormat: text
 standAloneConfig:
   storageArrays:
     - storageArrayId: "REPLACE_SYSTEMID"
-      primaryURL: "https://REPLACE_ENDPOINT"
+      primaryURL: "https://REPLACE_AUTH_ENDPOINT:9400"
       proxyCredentialSecrets:
         - powermax-creds
   managementServers:
-    - url: "https://REPLACE_ENDPOINT" 
+    - url: "https://REPLACE_AUTH_ENDPOINT:9400"
       arrayCredentialSecret: powermax-creds
       skipCertificateValidation: true

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1807,7 +1807,6 @@
   tags:
     - "authorizationproxyserver"
     - "authorization"
-    - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Install Authorization CRDs [2]"
@@ -1849,7 +1848,6 @@
   tags:
     - "authorizationproxyserver"
     - "authorization"
-    - "powermax"
     - "observability"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1702,18 +1702,20 @@
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar]"
     - "Apply custom resource [1]"
     - "Validate custom resource [1]"
     - "Validate [powermax] driver from CR [1] is installed"
     - "Run custom test"
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar]"
     - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
   customTest:
     name: Cert CSI
     run:
-      - cert-csi test vio --sc op-e2e-pmax --chainNumber 2 --chainLength 2
+      - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
 - scenario: "Install PowerMax Driver(Sidecar)"
   paths:
@@ -1724,6 +1726,7 @@
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar]"
     - "Apply custom resource [1]"
     - "Validate custom resource [1]"
     - "Validate [powermax] driver from CR [1] is installed"
@@ -1731,12 +1734,13 @@
     # Last two steps perform Clean Up
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar]"
     - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
   customTest:
     name: Cert CSI
     run:
-      - cert-csi test vio --sc op-e2e-pmax --chainNumber 2 --chainLength 2
+      - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
 - scenario: "Install PowerMax Driver(With Observability)"
   paths:
@@ -1748,6 +1752,7 @@
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar]"
     - "Apply custom resource [1]"
     - "Validate custom resource [1]"
     - "Validate [powermax] driver from CR [1] is installed"
@@ -1755,6 +1760,7 @@
     # cleanup
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar]"
     - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
 
@@ -1775,7 +1781,7 @@
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
-    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxReverseProxy]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxReverseProxy]"
     - "Apply custom resource [2]"
     - "Validate custom resource [2]"
     - "Validate [powermax] driver from CR [2] is installed"
@@ -1787,11 +1793,11 @@
     - "Delete custom resource [1]"
     - "Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar]"
     - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
-    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxReverseProxy]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy]"
   customTest:
     name: Cert CSI
     run:
-      - cert-csi test vio --sc op-e2e-pmax --chainNumber 2 --chainLength 2
+      - cert-csi test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1
 
 - scenario: "Install Powermax Driver (With Authorization v2)"
   paths:
@@ -1813,7 +1819,7 @@
     - "Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
-    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxReverseProxy]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxReverseProxy]"
     - "Apply custom resource [3]"
     - "Validate custom resource [3]"
     - "Validate [powermax] driver from CR [3] is installed"
@@ -1827,13 +1833,13 @@
     - "Delete Authorization CRDs [2]"
     - "Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar]"
     - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
-    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxReverseProxy]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy]"
     - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
   customTest:
     name: Cert CSI
     run:
-      - cert-csi test vio --sc op-e2e-pmax --chainNumber 2 --chainLength 2
+      - cert-csi test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1
 
 - scenario: "Install Powermax Driver (With Authorization v2 and Observability)"
   paths:
@@ -1856,9 +1862,9 @@
     - "Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
-    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxReverseProxy]"
-    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxReverseProxy]"
-    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [karavi] for [pmaxReverseProxy]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxReverseProxy]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] name [powermax-reverseproxy-config] in namespace [karavi] for [pmaxReverseProxy]"
     - "Apply custom resource [3]"
     - "Validate custom resource [3]"
     - "Validate [powermax] driver from CR [3] is installed"
@@ -1873,13 +1879,13 @@
     - "Delete Authorization CRDs [2]"
     - "Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar]"
     - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
-    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxReverseProxy]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy]"
     - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
   customTest:
     name: Cert CSI
     run:
-      - cert-csi test vio --sc op-e2e-pmax --chainNumber 2 --chainLength 2
+      - cert-csi test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1
 
 - scenario: "Install Powermax Driver(Standalone), Enable Resiliency"
   paths:
@@ -1891,6 +1897,7 @@
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar]"
     - "Apply custom resource [1]"
     - "Validate custom resource [1]"
     - "Validate [powermax] driver from CR [1] is installed"
@@ -1901,6 +1908,7 @@
     # cleanup
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar]"
     - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
 
@@ -1914,6 +1922,7 @@
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar]"
     - "Apply custom resource [1]"
     - "Validate custom resource [1]"
     - "Validate [powermax] driver from CR [1] is installed"
@@ -1924,5 +1933,6 @@
     # cleanup
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar]"
     - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"

--- a/tests/e2e/testfiles/storage_csm_powermax.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax.yaml
@@ -45,7 +45,7 @@ spec:
     forceRemoveDriver: true
     common:
       # Image for CSI PowerMax driver v2.12.0
-      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
+      image: dellemc/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax.yaml
@@ -45,7 +45,7 @@ spec:
     forceRemoveDriver: true
     common:
       # Image for CSI PowerMax driver v2.12.0
-      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd 
+      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax.yaml
@@ -37,15 +37,15 @@ spec:
     # to deploy to the Kubernetes release
     # Allowed values: n, where n > 0
     # Default value: None
-    replicas: 2
+    replicas: 1
     # Default credential secret for Powermax, if not set it to ""
     authSecret: powermax-creds
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerMax driver v2.10.1
-      image: dellemc/csi-powermax:v2.12.0
+      # Image for CSI PowerMax driver v2.12.0
+      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd 
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_authorization.yaml
@@ -37,14 +37,14 @@ spec:
     # to deploy to the Kubernetes release
     # Allowed values: n, where n > 0
     # Default value: None
-    replicas: 2
+    replicas: 1
     # Default credential secret for Powermax, if not set it to ""
     authSecret: powermax-creds
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      image: dellemc/csi-powermax:nightly
+      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_authorization.yaml
@@ -44,7 +44,7 @@ spec:
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
+      image: dellemc/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
@@ -45,7 +45,7 @@ spec:
     forceRemoveDriver: true
     common:
       # Image for CSI PowerMax driver v2.12.0
-      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
+      image: dellemc/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
@@ -37,15 +37,15 @@ spec:
     # to deploy to the Kubernetes release
     # Allowed values: n, where n > 0
     # Default value: None
-    replicas: 2
+    replicas: 1
     # Default credential secret for Powermax, if not set it to ""
     authSecret: powermax-creds
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerMax driver v2.10.1
-      image: dellemc/csi-powermax:nightly
+      # Image for CSI PowerMax driver v2.12.0
+      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_observability_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_observability_authorization.yaml
@@ -37,14 +37,14 @@ spec:
     # to deploy to the Kubernetes release
     # Allowed values: n, where n > 0
     # Default value: None
-    replicas: 2
+    replicas: 1
     # Default credential secret for Powermax, if not set it to ""
     authSecret: powermax-creds
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      image: dellemc/csi-powermax:nightly
+      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_observability_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_observability_authorization.yaml
@@ -44,7 +44,7 @@ spec:
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
+      image: dellemc/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_resiliency.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_resiliency.yaml
@@ -45,7 +45,7 @@ spec:
     forceRemoveDriver: true
     common:
       # Image for CSI PowerMax driver v2.12.0
-      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
+      image: dellemc/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_resiliency.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_resiliency.yaml
@@ -32,20 +32,20 @@ spec:
       #   false: disable storage capacity tracking
       storageCapacity: true
     # Config version for CSI PowerMax v2.10.1 driver
-    configVersion: v2.11.0
+    configVersion: v2.12.0
     # replica: Define the number of PowerMax controller nodes
     # to deploy to the Kubernetes release
     # Allowed values: n, where n > 0
     # Default value: None
-    replicas: 2
+    replicas: 1
     # Default credential secret for Powermax, if not set it to ""
     authSecret: powermax-creds
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerMax driver v2.10.1
-      image: dellemc/csi-powermax:nightly
+      # Image for CSI PowerMax driver v2.12.0
+      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.
@@ -268,10 +268,10 @@ spec:
       #   false: disable Resiliency feature(do not deploy podmon sidecar)
       # Default value: false
       enabled: true
-      configVersion: v1.10.0
+      configVersion: v1.11.0
       components:
         - name: podmon-controller
-          image: dellemc/podmon:v1.10.0
+          image: dellemc/podmon:nightly
           imagePullPolicy: IfNotPresent
           args:
             - "--labelvalue=csi-powermax"

--- a/tests/e2e/testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
@@ -32,20 +32,20 @@ spec:
       #   false: disable storage capacity tracking
       storageCapacity: true
     # Config version for CSI PowerMax v2.10.1 driver
-    configVersion: v2.11.0
+    configVersion: v2.12.0
     # replica: Define the number of PowerMax controller nodes
     # to deploy to the Kubernetes release
     # Allowed values: n, where n > 0
     # Default value: None
-    replicas: 2
+    replicas: 1
     # Default credential secret for Powermax, if not set it to ""
     authSecret: powermax-creds
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerMax driver v2.10.1
-      image: dellemc/csi-powermax:nightly
+      # Image for CSI PowerMax driver v2.12.0
+      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.
@@ -268,7 +268,7 @@ spec:
       configVersion: v1.11.0
       components:
         - name: karavi-authorization-proxy
-          image: dellemc/csm-authorization-sidecar:nightly
+          image: dellemc/csm-authorization-sidecar:v1.11.0
           envs:
             # proxyHost: hostname of the csm-authorization server
             - name: "PROXY_HOST"

--- a/tests/e2e/testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
@@ -45,7 +45,7 @@ spec:
     forceRemoveDriver: true
     common:
       # Image for CSI PowerMax driver v2.12.0
-      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
+      image: dellemc/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
@@ -45,7 +45,7 @@ spec:
     forceRemoveDriver: true
     common:
       # Image for CSI PowerMax driver v2.12.0
-      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
+      image: dellemc/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.

--- a/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
@@ -37,15 +37,15 @@ spec:
     # to deploy to the Kubernetes release
     # Allowed values: n, where n > 0
     # Default value: None
-    replicas: 2
+    replicas: 1
     # Default credential secret for Powermax, if not set it to ""
     authSecret: powermax-creds
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerMax driver v2.10.1
-      image: dellemc/csi-powermax:nightly
+      # Image for CSI PowerMax driver v2.12.0
+      image: dellemc/csi-powermax@sha256:b0f35bd463e24ee5c2a9d11a3f7f2b92bc2e6c39890e32310503868b4df2c7cd
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
       #  Always: Always pull the image.


### PR DESCRIPTION
# Description
This PR fixes the pmax e2e tests in CSM Operator repo so that they may be run sequentially 
- Adds configmap creation/restore for pmax v1 scenarios 
- Adjusts cert-csi to lower the inconsistent error of failing to find device when running cert-csi
- Adjusts images/replica count to make tests more consistently pass 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1507 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] All tests are run using the ` nohup ./run-e2e-test.sh --pmax &`  command with special provisions made for a few that are still in alpha release. All tests are passed and logs with configurations are provided internally.

