### PR TITLE
E2E tests for PMax driver in minimal manifest file Auth v1

### DIFF
--- a/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
@@ -22,17 +22,3 @@ spec:
               value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"
             - name: "SKIP_CERTIFICATE_VALIDATION"
               value: "true"
-    - name: csireverseproxy
-      enabled: true
-      forceRemoveModule: true
-      configVersion: v2.11.0
-      components:
-        - name: csipowermax-reverseproxy
-          image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
-          envs:
-            - name: X_CSI_REVPROXY_TLS_SECRET
-              value: "csirevproxy-tls-secret"
-            - name: X_CSI_REVPROXY_PORT
-              value: "2222"
-            - name: X_CSI_CONFIG_MAP_NAME
-              value: "powermax-reverseproxy-config"

--- a/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_reverseproxy_authorization_v2.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_reverseproxy_authorization_v2.yaml
@@ -1,0 +1,26 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: powermax
+  namespace: powermax
+spec:
+  driver:
+    csiDriverType: "powermax"
+    configVersion: v2.12.0
+    common:
+      image: "quay.io/dell/container-storage-modules/csi-powermax:nightly"
+    forceRemoveDriver: true
+    replicas: 1
+  modules:
+    - name: authorization
+      enabled: true
+      configVersion: v2.0.0
+      components:
+        - name: karavi-authorization-proxy
+          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:nightly
+          envs:
+            - name: "PROXY_HOST"
+              value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"
+            - name: "SKIP_CERTIFICATE_VALIDATION"
+              value: "true"
+

--- a/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_reverseproxy_authorization_v2.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_reverseproxy_authorization_v2.yaml
@@ -23,4 +23,3 @@ spec:
               value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"
             - name: "SKIP_CERTIFICATE_VALIDATION"
               value: "true"
-


### PR DESCRIPTION
# Description

- Added e2e for Powermax Auth v1 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1449 |

# Checklist:

- [X ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ X] I have verified that new and existing unit tests pass locally with my changes
- [ X] I have not allowed coverage numbers to degenerate
- [ X] I have maintained at least 90% code coverage
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ X] Run the test on k8s cluster:
![image](https://github.com/user-attachments/assets/7247fe5f-87c0-4bee-8019-5079286970c8)

- [X] Run test with Auth v2:
```
# ./run-e2e-test.sh --minimal --pmax --auth
/root/meg/csm-operator/tests/e2e
  W1018 16:29:57.274648 3633008 test_context.go:538] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I1018 16:29:57.274751 3633008 test_context.go:561] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/meg/csm-operator/tests/e2e
===============================================================================
Random Seed: 1729268986

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/meg/csm-operator/tests/e2e/e2e_test.go:99
  STEP: Getting test environment variables @ 10/18/24 16:29:57.275
  STEP: [authorization powermax] @ 10/18/24 16:29:57.275
  STEP: Reading values file @ 10/18/24 16:29:57.275
  STEP: Getting a k8s client @ 10/18/24 16:29:57.278
[BeforeSuite] PASSED [0.006 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/meg/csm-operator/tests/e2e/e2e_test.go:140
  STEP: Starting: Install Powermax Driver (With Authorization v2)  @ 10/18/24 16:29:57.281
  STEP: Returning false here @ 10/18/24 16:29:57.281
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 10/18/24 16:29:57.281
  STEP:      Executing  Install Authorization CRDs [2] @ 10/18/24 16:29:57.294
  STEP:      Executing  Create [authorization-proxy-server] prerequisites from CR [1] @ 10/18/24 16:29:57.546
=== Creating Authorization Proxy Server Prerequisites ===

Deleting all CSM from namespace: authorization
  STEP:      Executing  Apply custom resource [1] @ 10/18/24 16:30:06.035
  I1018 16:30:06.038205 3633008 builder.go:121] Running '/usr/bin/kubectl --namespace=authorization apply --validate=true -f -'
  I1018 16:30:06.270798 3633008 builder.go:146] stderr: ""
  I1018 16:30:06.270865 3633008 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/authorization created\nconfigmap/csm-config-params created\n"
  STEP:      Executing  Validate [authorization-proxy-server] module from CR [1] is installed @ 10/18/24 16:30:06.27

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-78f685bc67-9x7nt) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-10-18 16:30:09 +0000 UTC,FinishedAt:2024-10-18 16:30:09 +0000 UTC,ContainerID:containerd://b43f7c410ddf4247c129401416705a211a431445a728372cdc00adfccfd27ef4,}}
The container(tenant-service) in pod(tenant-service-655dd5b49f-zflq7) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 10s restarting failed container=tenant-service pod=tenant-service-655dd5b49f-zflq7_authorization(bb56e854-b705-4d33-a37a-bff0ee14ad44),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-78f685bc67-9x7nt) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-10-18 16:30:25 +0000 UTC,FinishedAt:2024-10-18 16:30:25 +0000 UTC,ContainerID:containerd://631d82efe2c1d4a793e59e66d56cc6bd6f58fdbbb89dbad311408546616082df,}}
The container(tenant-service) in pod(tenant-service-655dd5b49f-zflq7) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-10-18 16:30:29 +0000 UTC,FinishedAt:2024-10-18 16:30:29 +0000 UTC,ContainerID:containerd://475a61eb17c8d7358bed0de6c0a80d28a96323603fa8d49f05a50b5cc485a0c7,}}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-78f685bc67-9x7nt) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-10-18 16:30:54 +0000 UTC,FinishedAt:2024-10-18 16:30:55 +0000 UTC,ContainerID:containerd://984b8476a1b8e41d13c4d9780eccbeb67fc2083a81bd170e0d5ade1bde1c9a61,}}
The container(tenant-service) in pod(tenant-service-655dd5b49f-zflq7) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-10-18 16:30:54 +0000 UTC,FinishedAt:2024-10-18 16:30:54 +0000 UTC,ContainerID:containerd://42e26a3b34d497a42168c8eb92f8f7603f72abfacba01163bb221d1439e78d3d,}}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-78f685bc67-9x7nt) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 40s restarting failed container=proxy-server pod=proxy-server-78f685bc67-9x7nt_authorization(834d6a88-0aa9-4eaf-acfa-26a99c6a935f),} nil nil}
The container(tenant-service) in pod(tenant-service-655dd5b49f-zflq7) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 40s restarting failed container=tenant-service pod=tenant-service-655dd5b49f-zflq7_authorization(bb56e854-b705-4d33-a37a-bff0ee14ad44),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-78f685bc67-9x7nt) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-10-18 16:31:35 +0000 UTC,FinishedAt:2024-10-18 16:31:36 +0000 UTC,ContainerID:containerd://4883da2715000c5016dc981a7c90c9622b1c646e8aa28706dde751e60d2e6b26,}}
The container(tenant-service) in pod(tenant-service-655dd5b49f-zflq7) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 40s restarting failed container=tenant-service pod=tenant-service-655dd5b49f-zflq7_authorization(bb56e854-b705-4d33-a37a-bff0ee14ad44),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-78f685bc67-9x7nt) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=proxy-server pod=proxy-server-78f685bc67-9x7nt_authorization(834d6a88-0aa9-4eaf-acfa-26a99c6a935f),} nil nil}
The pod(sentinel-2) is Pending
The container(storage-service) in pod(storage-service-c64f765bc-cd4tx) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 10s restarting failed container=storage-service pod=storage-service-c64f765bc-cd4tx_authorization(347eaa2b-5d16-4240-b126-b461b6dd502d),} nil nil}
The container(tenant-service) in pod(tenant-service-655dd5b49f-zflq7) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=tenant-service pod=tenant-service-655dd5b49f-zflq7_authorization(bb56e854-b705-4d33-a37a-bff0ee14ad44),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-78f685bc67-9x7nt) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=proxy-server pod=proxy-server-78f685bc67-9x7nt_authorization(834d6a88-0aa9-4eaf-acfa-26a99c6a935f),} nil nil}
The container(storage-service) in pod(storage-service-c64f765bc-cd4tx) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 20s restarting failed container=storage-service pod=storage-service-c64f765bc-cd4tx_authorization(347eaa2b-5d16-4240-b126-b461b6dd502d),} nil nil}
The container(tenant-service) in pod(tenant-service-655dd5b49f-zflq7) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=tenant-service pod=tenant-service-655dd5b49f-zflq7_authorization(bb56e854-b705-4d33-a37a-bff0ee14ad44),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-78f685bc67-9x7nt) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=proxy-server pod=proxy-server-78f685bc67-9x7nt_authorization(834d6a88-0aa9-4eaf-acfa-26a99c6a935f),} nil nil}
The container(tenant-service) in pod(tenant-service-655dd5b49f-zflq7) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=tenant-service pod=tenant-service-655dd5b49f-zflq7_authorization(bb56e854-b705-4d33-a37a-bff0ee14ad44),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-78f685bc67-9x7nt) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=proxy-server pod=proxy-server-78f685bc67-9x7nt_authorization(834d6a88-0aa9-4eaf-acfa-26a99c6a935f),} nil nil}
The container(tenant-service) in pod(tenant-service-655dd5b49f-zflq7) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=tenant-service pod=tenant-service-655dd5b49f-zflq7_authorization(bb56e854-b705-4d33-a37a-bff0ee14ad44),} nil nil}
  STEP:      Executing  Configure authorization-proxy-server for [powermax] for CR [1] @ 10/18/24 16:33:36.521
=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===

err: failed to create admin token: exec: "dellctl": executable file not found in $PATH
ErrMessage:

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===

err: failed to create admin token: exec: "dellctl": executable file not found in $PATH
ErrMessage:

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===

err: failed to create admin token: exec: "dellctl": executable file not found in $PATH
ErrMessage:

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551

err: failed to generate token for csmtenant-powermax: exit status 1
ErrMessage:
{
  "ErrorMsg": "generating token for csmtenant-powermax: rpc error: code = InvalidArgument desc = tenant not found"
}

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powermax.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powermax --insecure --addr csm-authorization.com:31551
=== Applying token ===

=== Token Applied ===

  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 10/18/24 16:38:21.271
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar] @ 10/18/24 16:38:21.529
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 10/18/24 16:38:21.741
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 10/18/24 16:38:21.976
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxReverseProxy] @ 10/18/24 16:38:22.242
  STEP:      Executing  Apply custom resource [3] @ 10/18/24 16:38:22.469
  I1018 16:38:22.469465 3633008 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I1018 16:38:22.564007 3633008 builder.go:146] stderr: ""
  I1018 16:38:22.564074 3633008 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [3] @ 10/18/24 16:38:22.564

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [3] is installed @ 10/18/24 16:42:12.696
  STEP:      Executing  Validate [authorization] module from CR [3] is installed @ 10/18/24 16:42:32.707
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:2]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
  STEP:      Executing  Run custom test @ 10/18/24 16:42:42.734
  I1018 16:42:42.734251 3633008 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1]
[2024-10-18 16:42:42]  INFO Starting cert-csi; ver. 1.4.0
[2024-10-18 16:42:42]  INFO Using EVENT observer type
[2024-10-18 16:42:42]  INFO Using config from /root/.kube/config
[2024-10-18 16:42:42]  INFO Successfully loaded config. Host: https://<redacted>
[2024-10-18 16:42:42]  INFO Created new KubeClient
[2024-10-18 16:42:42]  INFO Running 1 iteration(s)
[2024-10-18 16:42:42]  INFO     *** ITERATION NUMBER 1 ***
[2024-10-18 16:42:42]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2024-10-18 16:42:42]  INFO Successfully created namespace volumeio-test-f8edc0c7
[2024-10-18 16:42:42]  INFO Using default number of volumes
[2024-10-18 16:42:42]  INFO Using default image: docker.io/centos:latest
[2024-10-18 16:42:42]  INFO Creating IO pod
[2024-10-18 16:42:42]  INFO Waiting for pod iowriter-test-kltkc to be READY
[2024-10-18 16:43:02]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2024-10-18 16:43:03]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2024-10-18 16:43:14]  INFO Waiting until no Volume Attachments with PV  left
[2024-10-18 16:43:14]  INFO VolumeAttachment deleted
[2024-10-18 16:43:14]  INFO Deleting all resources in namespace volumeio-test-f8edc0c7
[2024-10-18 16:43:26]  INFO Namespace volumeio-test-f8edc0c7 was deleted in 12.009996742s
[2024-10-18 16:43:26]  INFO Waiting for volumeattachments to be deleted
[2024-10-18 16:43:30]  INFO SUCCESS: VolumeIoSuite in 47.431362872s
[2024-10-18 16:43:30]  INFO Started generating reports...
Collecting metrics
1 / 1 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2024-10-18 16:43:30]  INFO Started generating reports...
Collecting metrics
1 / 1 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sGenerating plots
1 / 1 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2024-10-18 16:43:30]  WARN No ResourceUsageMetrics provided
[2024-10-18 16:43:30] ERROR no ResourceUsageMetrics provided
report-test-run-1793df7b:
Name: test-run-1793df7b
Host: https://<redacted>
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-1793df7b/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-1793df7b/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-1793df7b/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-1793df7b/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-1793df7b/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2024-10-18 16:42:42.851641452 +0000 UTC
            Ended:     2024-10-18 16:43:30.283140524 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 6.599860156s
                        Min: 6.599860156s
                        Max: 6.599860156s
                        Histogram:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 3.789383185s
                        Min: 3.789383185s
                        Max: 3.789383185s
                        Histogram:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 10.633608065s
                        Min: 10.633608065s
                        Max: 10.633608065s
                        Histogram:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 16.272067ms
                        Min: 16.272067ms
                        Max: 16.272067ms
                        Histogram:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.968085923s
                        Min: 1.968085923s
                        Max: 1.968085923s
                        Histogram:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 18.408997812s
                        Min: 18.408997812s
                        Max: 18.408997812s
                        Histogram:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 8.163283631s
                        Min: 8.163283631s
                        Max: 8.163283631s
                        Histogram:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-1793df7b/VolumeIoSuite1/EntityNumberOverTime.png

[2024-10-18 16:43:30]  INFO Avg time of a run:   31.20s
[2024-10-18 16:43:30]  INFO Avg time of a del:   12.01s
[2024-10-18 16:43:30]  INFO Avg time of all:     47.43s
[2024-10-18 16:43:30]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [3] @ 10/18/24 16:43:30.723
  STEP:      Executing  Delete custom resource [3] @ 10/18/24 16:43:30.734
  STEP:      Executing  Delete Authorization CRs for [powermax] @ 10/18/24 16:43:30.744
  STEP:      Executing  Delete custom resource [1] @ 10/18/24 16:43:31.502
  STEP:      Executing  Delete Authorization CRDs [2] @ 10/18/24 16:43:31.513
  STEP:      Executing  Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar] @ 10/18/24 16:43:31.717
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 10/18/24 16:43:31.744
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy] @ 10/18/24 16:43:31.761
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 10/18/24 16:43:31.779
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 10/18/24 16:43:31.813
  STEP: Ending: Install Powermax Driver (With Authorization v2)
   @ 10/18/24 16:43:31.862
• [819.582 seconds]
------------------------------

Ran 1 of 1 Specs in 819.588 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 13m50.539257976s
Test Suite Passed
```