### PR TITLE
Add toolchain version to tests/e2e/go.mod

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -2,6 +2,8 @@ module github.com/dell/csm-operator/tests/e2e
 
 go 1.23
 
+toolchain go1.23.2
+
 require (
 	github.com/dell/csm-operator v0.0.0
 	github.com/onsi/ginkgo/v2 v2.20.2


### PR DESCRIPTION
# Description
This PR fixes the operator e2e tests not working because toolchain version is missing.
```
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1435 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Running Operator E2E on PowerMax with no modules

Before:
Test suite fails and exists with the following logs:
```
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```
After:
Test suite passes as expected:
```
go: downloading go1.23.2 (linux/amd64)
```