### PR TITLE
Update bundle.Dockerfile file for the supported openshift lower bound(n-3) version

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
-LABEL com.redhat.openshift.versions=v4.14
+LABEL com.redhat.openshift.versions="v4.14"
 LABEL com.redhat.delivery.backport=false
 LABEL com.redhat.delivery.operator.bundle=true
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
-LABEL com.redhat.openshift.versions=v4.16-v4.17
+LABEL com.redhat.openshift.versions=v4.14
 LABEL com.redhat.delivery.backport=false
 LABEL com.redhat.delivery.operator.bundle=true
 


### PR DESCRIPTION
# Description
Update bundle.Dockerfile lowerbound to support installation on n-3 version clusters. (to install the CSM Operator on older OCP versions (up to n-3). More details in release activities feature)

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| https://github.com/dell/csm/issues/1435 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed in Openshift 4.14 cluster
- [x] Run e2e for Powerflex standalone

> [2024-10-29 19:26:42]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 10/29/24 19:26:42.652
  STEP:      Executing  Delete custom resource [1] @ 10/29/24 19:26:42.657
  STEP:      Executing  Restore template [testfiles/powerflex-templates/powerflex-secret-template.yaml] for [pflex] @ 10/29/24 19:26:42.68
  STEP:      Executing  Restore template [testfiles/powerflex-templates/powerflex-storageclass-template.yaml] for [pflex] @ 10/29/24 19:26:42.785
  STEP:      Executing  Restore template [testfiles/powerflex-templates/ephemeral.properties] for [pflexEphemeral] @ 10/29/24 19:26:42.831
  STEP: Ending: Install PowerFlex Driver(Standalone)
   @ 10/29/24 19:26:42.887
• [160.383 seconds]

------------------------------

Ran 1 of 1 Specs in 160.391 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2m32.286782304s
Test Suite Passed
