### PR TITLE
[bug-1581]: Offline bundle contains Authorization v2 server images

### DIFF
--- a/bundle/manifests/csm-config-params_v1_configmap.yaml
+++ b/bundle/manifests/csm-config-params_v1_configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  csm-config-params.yaml: |-
+    CONCURRENT_POWERFLEX_REQUESTS: 10
+    CONCURRENT_POWERSCALE_REQUESTS: 10
+    LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m
+kind: ConfigMap
+metadata:
+  name: csm-config-params

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -3463,6 +3463,18 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
                 - auditregistration.k8s.io
               resources:
                 - auditsinks
@@ -3645,6 +3657,14 @@ spec:
                 - get
                 - patch
                 - update
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
             - apiGroups:
                 - csi.storage.k8s.io
               resources:
@@ -4393,7 +4413,7 @@ spec:
                         value: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
                       - name: RELATED_IMAGE_metadataretriever
                         value: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.9.0
-                    image: docker.io/dellemc/dell-csm-operator:v1.7.0
+                    image: quay.io/dell/container-storage-modules/dell-csm-operator:v1.7.0
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -8,6 +8,86 @@ metadata:
           "apiVersion": "storage.dell.com/v1",
           "kind": "ContainerStorageModule",
           "metadata": {
+            "name": "authorization",
+            "namespace": "authorization"
+          },
+          "spec": {
+            "modules": [
+              {
+                "components": [
+                  {
+                    "enabled": true,
+                    "name": "nginx"
+                  },
+                  {
+                    "enabled": true,
+                    "name": "cert-manager"
+                  },
+                  {
+                    "authorizationController": "quay.io/dell/container-storage-modules/csm-authorization-controller:v2.0.0",
+                    "authorizationControllerReplicas": 1,
+                    "certificate": "",
+                    "controllerReconcileInterval": "5m",
+                    "enabled": true,
+                    "hostname": "csm-authorization.com",
+                    "leaderElection": true,
+                    "name": "proxy-server",
+                    "opa": "docker.io/openpolicyagent/opa:latest",
+                    "opaKubeMgmt": "docker.io/openpolicyagent/kube-mgmt:8.5.7",
+                    "openTelemetryCollectorAddress": "",
+                    "privateKey": "",
+                    "proxyServerIngress": [
+                      {
+                        "annotations": {},
+                        "hosts": [],
+                        "ingressClassName": "nginx"
+                      }
+                    ],
+                    "proxyService": "quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0",
+                    "proxyServiceReplicas": 1,
+                    "roleService": "quay.io/dell/container-storage-modules/csm-authorization-role:v2.0.0",
+                    "roleServiceReplicas": 1,
+                    "storageService": "quay.io/dell/container-storage-modules/csm-authorization-storage:v2.0.0",
+                    "storageServiceReplicas": 1,
+                    "tenantService": "quay.io/dell/container-storage-modules/csm-authorization-tenant:v2.0.0",
+                    "tenantServiceReplicas": 1
+                  },
+                  {
+                    "commander": "docker.io/rediscommander/redis-commander:latest",
+                    "name": "redis",
+                    "redis": "docker.io/redis:7.4.0-alpine",
+                    "redisCommander": "rediscommander",
+                    "redisName": "redis-csm",
+                    "redisReplicas": 5,
+                    "sentinel": "sentinel"
+                  },
+                  {
+                    "name": "vault",
+                    "vaultConfigurations": [
+                      {
+                        "address": "https://10.0.0.1:8400",
+                        "certificateAuthority": "",
+                        "clientCertificate": "",
+                        "clientKey": "",
+                        "identifier": "vault0",
+                        "role": "csm-authorization",
+                        "skipCertificateValidation": true
+                      }
+                    ]
+                  }
+                ],
+                "configVersion": "v2.0.0",
+                "enabled": true,
+                "forceRemoveModule": true,
+                "name": "authorization-proxy-server"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "storage.dell.com/v1",
+          "kind": "ContainerStorageModule",
+          "metadata": {
             "name": "isilon",
             "namespace": "isilon"
           },
@@ -1419,7 +1499,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Storage
     containerImage: quay.io/dell/container-storage-modules/dell-csm-operator:v1.7.0
-    createdAt: "2024-09-30T10:28:43Z"
+    createdAt: "2024-11-13T20:54:04Z"
     description: Easily install and manage Dell’s CSI Drivers and CSM
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
@@ -3383,18 +3463,6 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - apps
-              resources:
-                - deployments
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
                 - auditregistration.k8s.io
               resources:
                 - auditsinks
@@ -3577,14 +3645,6 @@ spec:
                 - get
                 - patch
                 - update
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-              verbs:
-                - get
-                - list
-                - watch
             - apiGroups:
                 - csi.storage.k8s.io
               resources:
@@ -4333,7 +4393,7 @@ spec:
                         value: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
                       - name: RELATED_IMAGE_metadataretriever
                         value: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.9.0
-                    image: quay.io/dell/container-storage-modules/dell-csm-operator:v1.7.0
+                    image: docker.io/dellemc/dell-csm-operator:v1.7.0
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -4412,6 +4472,16 @@ spec:
       name: sdc
     - image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
       name: karavi-authorization-proxy
+    - image: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
+      name: csm-authorization-proxy
+    - image: quay.io/dell/container-storage-modules/csm-authorization-tenant:v2.0.0
+      name: csm-authorization-tenant
+    - image: quay.io/dell/container-storage-modules/csm-authorization-role:v2.0.0
+      name: csm-authorization-role
+    - image: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.0.0
+      name: csm-authorization-storage
+    - image: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.0.0
+      name: csm-authorization-controller
     - image: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.10.0
       name: dell-csi-replicator
     - image: quay.io/dell/container-storage-modules/dell-replication-controller:v1.10.0

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -177,7 +177,7 @@ metadata:
                         "value": "true"
                       }
                     ],
-                    "image": "quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0",
+                    "image": "quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0",
                     "name": "karavi-authorization-proxy"
                   }
                 ],
@@ -577,7 +577,7 @@ metadata:
                         "value": "true"
                       }
                     ],
-                    "image": "quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0",
+                    "image": "quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0",
                     "name": "karavi-authorization-proxy"
                   }
                 ],
@@ -1229,7 +1229,7 @@ metadata:
                         "value": "true"
                       }
                     ],
-                    "image": "quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0",
+                    "image": "quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0",
                     "name": "karavi-authorization-proxy"
                   }
                 ],
@@ -4289,7 +4289,7 @@ spec:
                         value: quay.io/dell/container-storage-modules/csi-vxflexos:v2.12.0
                       - name: RELATED_IMAGE_sdc
                         value: docker.io/dellemc/sdc:4.5.2.1
-                      - name: RELATED_IMAGE_csm-authorization-sidecar
+                      - name: RELATED_IMAGE_karavi-authorization-proxy
                         value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
                       - name: RELATED_IMAGE_csm-authorization-proxy
                         value: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
@@ -4410,7 +4410,7 @@ spec:
       name: csi-vxflexos
     - image: docker.io/dellemc/sdc:4.5.2.1
       name: sdc
-    - image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
+    - image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
       name: karavi-authorization-proxy
     - image: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.10.0
       name: dell-csi-replicator

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -4289,8 +4289,17 @@ spec:
                         value: quay.io/dell/container-storage-modules/csi-vxflexos:v2.12.0
                       - name: RELATED_IMAGE_sdc
                         value: docker.io/dellemc/sdc:4.5.2.1
-                      - name: RELATED_IMAGE_karavi-authorization-proxy
-                        value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
+                      - value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
+                      - name: RELATED_IMAGE_csm-authorization-proxy
+                        value: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
+                      - name: RELATED_IMAGE_csm-authorization-tenant
+                        value: quay.io/dell/container-storage-modules/csm-authorization-tenant:v2.0.0
+                      - name: RELATED_IMAGE_csm-authorization-role
+                        value: quay.io/dell/container-storage-modules/csm-authorization-role:v2.0.0
+                      - name: RELATED_IMAGE_csm-authorization-storage
+                        value: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.0.0
+                      - name: RELATED_IMAGE_csm-authorization-controller
+                        value: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.0.0
                       - name: RELATED_IMAGE_dell-csi-replicator
                         value: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.10.0
                       - name: RELATED_IMAGE_dell-replication-controller-manager

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
                     "leaderElection": true,
                     "name": "proxy-server",
                     "opa": "docker.io/openpolicyagent/opa:latest",
-                    "opaKubeMgmt": "docker.io/openpolicyagent/kube-mgmt:8.5.7",
+                    "opaKubeMgmt": "docker.io/openpolicyagent/kube-mgmt:8.5.10",
                     "openTelemetryCollectorAddress": "",
                     "privateKey": "",
                     "proxyServerIngress": [
@@ -55,7 +55,7 @@ metadata:
                   {
                     "commander": "docker.io/rediscommander/redis-commander:latest",
                     "name": "redis",
-                    "redis": "docker.io/redis:7.4.0-alpine",
+                    "redis": "docker.io/redis:7.4.1-alpine",
                     "redisCommander": "rediscommander",
                     "redisName": "redis-csm",
                     "redisReplicas": 5,

--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -4289,7 +4289,8 @@ spec:
                         value: quay.io/dell/container-storage-modules/csi-vxflexos:v2.12.0
                       - name: RELATED_IMAGE_sdc
                         value: docker.io/dellemc/sdc:4.5.2.1
-                      - value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
+                      - name: RELATED_IMAGE_csm-authorization-sidecar
+                        value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
                       - name: RELATED_IMAGE_csm-authorization-proxy
                         value: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
                       - name: RELATED_IMAGE_csm-authorization-tenant

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,8 +45,17 @@ spec:
               name: RELATED_IMAGE_csi-vxflexos
             - value: docker.io/dellemc/sdc:4.5.2.1
               name: RELATED_IMAGE_sdc
-            - value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
-              name: RELATED_IMAGE_karavi-authorization-proxy
+            - value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-proxy
+              value: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-tenant
+              value: quay.io/dell/container-storage-modules/csm-authorization-tenant:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-role
+              value: quay.io/dell/container-storage-modules/csm-authorization-role:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-storage
+              value: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-controller
+              value: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.0.0
             - value: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.10.0
               name: RELATED_IMAGE_dell-csi-replicator
             - value: quay.io/dell/container-storage-modules/dell-replication-controller:v1.10.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,7 +45,8 @@ spec:
               name: RELATED_IMAGE_csi-vxflexos
             - value: docker.io/dellemc/sdc:4.5.2.1
               name: RELATED_IMAGE_sdc
-            - value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-sidecar
+              value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
             - name: RELATED_IMAGE_csm-authorization-proxy
               value: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
             - name: RELATED_IMAGE_csm-authorization-tenant

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,7 +45,7 @@ spec:
               name: RELATED_IMAGE_csi-vxflexos
             - value: docker.io/dellemc/sdc:4.5.2.1
               name: RELATED_IMAGE_sdc
-            - name: RELATED_IMAGE_csm-authorization-sidecar
+            - name: RELATED_IMAGE_karavi-authorization-proxy
               value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
             - name: RELATED_IMAGE_csm-authorization-proxy
               value: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0

--- a/config/manifests/bases/dell-csm-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dell-csm-operator.clusterserviceversion.yaml
@@ -1753,8 +1753,18 @@ spec:
       name: csi-vxflexos
     - image: docker.io/dellemc/sdc:4.5.2.1
       name: sdc
-    - image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
+    - image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
       name: karavi-authorization-proxy
+    - image: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
+      name: csm-authorization-proxy
+    - image: quay.io/dell/container-storage-modules/csm-authorization-tenant:v2.0.0
+      name: csm-authorization-tenant
+    - image: quay.io/dell/container-storage-modules/csm-authorization-role:v2.0.0
+      name: csm-authorization-role
+    - image: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.0.0
+      name: csm-authorization-storage
+    - image: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.0.0
+      name: csm-authorization-controller
     - image: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.10.0
       name: dell-csi-replicator
     - image: quay.io/dell/container-storage-modules/dell-replication-controller:v1.10.0

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -261,18 +261,6 @@ rules:
       - update
       - watch
   - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - auditregistration.k8s.io
     resources:
       - auditsinks
@@ -455,14 +443,6 @@ rules:
       - get
       - patch
       - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - csi.storage.k8s.io
     resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -261,6 +261,18 @@ rules:
       - update
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - auditregistration.k8s.io
     resources:
       - auditsinks
@@ -443,6 +455,14 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - csi.storage.k8s.io
     resources:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - storage_v1_csm_powerstore.yaml
   - storage_v1_csm_unity.yaml
   - storage_v1_csm_powermax.yaml
+  - storage_v1_csm_authorization_v2.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/storage_v1_csm_authorization_v2.yaml
+++ b/config/samples/storage_v1_csm_authorization_v2.yaml
@@ -39,7 +39,7 @@ spec:
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.0.0
           storageServiceReplicas: 1
           opa: docker.io/openpolicyagent/opa:latest
-          opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:8.5.7
+          opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:8.5.10
           authorizationController: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.0.0
           authorizationControllerReplicas: 1
           leaderElection: true
@@ -69,7 +69,7 @@ spec:
           # openTelemetryCollectorAddress: the OTLP receiving endpoint using gRPC
           openTelemetryCollectorAddress: ""
         - name: redis
-          redis: docker.io/redis:7.4.0-alpine
+          redis: docker.io/redis:7.4.1-alpine
           commander: docker.io/rediscommander/redis-commander:latest
           redisName: redis-csm
           redisCommander: rediscommander

--- a/config/samples/storage_v1_csm_authorization_v2.yaml
+++ b/config/samples/storage_v1_csm_authorization_v2.yaml
@@ -1,0 +1,114 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: authorization
+  namespace: authorization
+spec:
+  modules:
+    # Authorization: enable csm-authorization proxy server for RBAC
+    - name: authorization-proxy-server
+      # enable: Enable/Disable csm-authorization
+      enabled: true
+      configVersion: v2.0.0
+      forceRemoveModule: true
+      components:
+        # For Kubernetes Container Platform only
+        # enabled: Enable/Disable NGINX Ingress Controller
+        # Allowed values:
+        #   true: enable deployment of NGINX Ingress Controller
+        #   false: disable deployment of NGINX Ingress Controller only if you have your own ingress controller. Set the appropriate annotations for the ingresses in the proxy-server section
+        # Default value: true
+        - name: nginx
+          enabled: true
+        # enabled: Enable/Disable cert-manager
+        # Allowed values:
+        #   true: enable deployment of cert-manager
+        #   false: disable deployment of cert-manager only if it's already deployed
+        # Default value: true
+        - name: cert-manager
+          enabled: true
+        - name: proxy-server
+          # enable: Enable/Disable csm-authorization proxy server
+          enabled: true
+          proxyService: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
+          proxyServiceReplicas: 1
+          tenantService: quay.io/dell/container-storage-modules/csm-authorization-tenant:v2.0.0
+          tenantServiceReplicas: 1
+          roleService: quay.io/dell/container-storage-modules/csm-authorization-role:v2.0.0
+          roleServiceReplicas: 1
+          storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.0.0
+          storageServiceReplicas: 1
+          opa: docker.io/openpolicyagent/opa:latest
+          opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:8.5.7
+          authorizationController: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.0.0
+          authorizationControllerReplicas: 1
+          leaderElection: true
+          # controllerReconcileInterval: interval for the authorization controllers to reconcile with Redis.
+          controllerReconcileInterval: 5m
+          # certificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
+          # for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+          # for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          # proxy-server ingress will use this hostname
+          # NOTE: an additional hostname can be configured in proxyServerIngress.hosts
+          # NOTE: proxy-server ingress is configured to accept IP address connections so hostnames are not required
+          hostname: "csm-authorization.com"
+          # proxy-server ingress configuration
+          proxyServerIngress:
+            - ingressClassName: nginx
+              # additional host rules for the proxy-server ingress
+              hosts: []
+              # - [application name]-ingress-nginx-controller.[namespace].svc.cluster.local
+
+              # additional annotations for the proxy-server ingress
+              annotations: {}
+          # openTelemetryCollectorAddress: the OTLP receiving endpoint using gRPC
+          openTelemetryCollectorAddress: ""
+        - name: redis
+          redis: docker.io/redis:7.4.0-alpine
+          commander: docker.io/rediscommander/redis-commander:latest
+          redisName: redis-csm
+          redisCommander: rediscommander
+          sentinel: sentinel
+          redisReplicas: 5
+        - name: vault
+          vaultConfigurations:
+            - identifier: vault0
+              address: https://10.0.0.1:8400
+              role: csm-authorization
+              skipCertificateValidation: true
+              # clientCertificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
+              # for self-signed certs, leave empty string
+              # Allowed values: string
+              clientCertificate: ""
+              # clientKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+              # for self-signed certs, leave empty string
+              # Allowed values: string
+              clientKey: ""
+              # certificateAuthority: base64-encoded certificate authority for validating vault server certificate -- add certificate authority here to use custom certificates
+              #  for self-signed certs, leave empty string
+              # Allowed values: string
+              certificateAuthority: ""
+#            - identifier: vault0
+#              address: https://10.0.0.1:8400
+#              role: csm-authorization
+#              skipCertificateValidation: true
+#              clientCertificate:
+#              clientKey:
+#              certificateAuthority:
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: csm-config-params
+  namespace: authorization
+data:
+  csm-config-params.yaml: |-
+    CONCURRENT_POWERFLEX_REQUESTS: 10
+    CONCURRENT_POWERSCALE_REQUESTS: 10
+    LOG_LEVEL: debug
+    STORAGE_CAPACITY_POLL_INTERVAL: 5m

--- a/config/samples/storage_v1_csm_powerflex.yaml
+++ b/config/samples/storage_v1_csm_powerflex.yaml
@@ -197,7 +197,7 @@ spec:
       components:
         - name: karavi-authorization-proxy
           # Use image: dellemc/csm-authorization-sidecar:v2.0.0-alpha for PowerFlex Tech-Preview v2.0.0-alpha
-          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
+          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
           envs:
             # proxyHost: hostname of the csm-authorization server
             - name: "PROXY_HOST"

--- a/config/samples/storage_v1_csm_powermax.yaml
+++ b/config/samples/storage_v1_csm_powermax.yaml
@@ -278,7 +278,7 @@ spec:
       configVersion: v1.12.0
       components:
         - name: karavi-authorization-proxy
-          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
+          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
           envs:
             # proxyHost: hostname of the csm-authorization server
             - name: "PROXY_HOST"

--- a/config/samples/storage_v1_csm_powerscale.yaml
+++ b/config/samples/storage_v1_csm_powerscale.yaml
@@ -255,7 +255,7 @@ spec:
       configVersion: v1.12.0
       components:
         - name: karavi-authorization-proxy
-          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
+          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
           envs:
             # proxyHost: hostname of the csm-authorization server
             - name: "PROXY_HOST"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1328,8 +1328,17 @@ spec:
               value: quay.io/dell/container-storage-modules/csi-vxflexos:v2.12.0
             - name: RELATED_IMAGE_sdc
               value: docker.io/dellemc/sdc:4.5.2.1
-            - name: RELATED_IMAGE_karavi-authorization-proxy
-              value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
+            - value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-proxy
+              value: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-tenant
+              value: quay.io/dell/container-storage-modules/csm-authorization-tenant:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-role
+              value: quay.io/dell/container-storage-modules/csm-authorization-role:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-storage
+              value: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-controller
+              value: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.0.0
             - name: RELATED_IMAGE_dell-csi-replicator
               value: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.10.0
             - name: RELATED_IMAGE_dell-replication-controller-manager

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -318,6 +318,18 @@ rules:
       - update
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - auditregistration.k8s.io
     resources:
       - auditsinks
@@ -500,6 +512,14 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - csi.storage.k8s.io
     resources:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1328,7 +1328,8 @@ spec:
               value: quay.io/dell/container-storage-modules/csi-vxflexos:v2.12.0
             - name: RELATED_IMAGE_sdc
               value: docker.io/dellemc/sdc:4.5.2.1
-            - value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
+            - name: RELATED_IMAGE_csm-authorization-sidecar
+              value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
             - name: RELATED_IMAGE_csm-authorization-proxy
               value: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0
             - name: RELATED_IMAGE_csm-authorization-tenant

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -318,18 +318,6 @@ rules:
       - update
       - watch
   - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - auditregistration.k8s.io
     resources:
       - auditsinks
@@ -512,14 +500,6 @@ rules:
       - get
       - patch
       - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - csi.storage.k8s.io
     resources:
@@ -1328,7 +1308,7 @@ spec:
               value: quay.io/dell/container-storage-modules/csi-vxflexos:v2.12.0
             - name: RELATED_IMAGE_sdc
               value: docker.io/dellemc/sdc:4.5.2.1
-            - name: RELATED_IMAGE_csm-authorization-sidecar
+            - name: RELATED_IMAGE_karavi-authorization-proxy
               value: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.0.0
             - name: RELATED_IMAGE_csm-authorization-proxy
               value: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.0.0


### PR DESCRIPTION
# Description

`bundle/manifests/dell-csm-operator.clusterserviceversion.yaml`, used to build an image manifest when building the offline bundle, is updated with the Authorization Server images. 

- Authorization v2 sample is created under `config/samples` for `make bundle` to generate an Authorization section in `alm-examples` in the bundle CSV.
- `bundle/manifests/csm-config-params_v1_configmap.yaml` is created because the Authorization v2 sample file contains this
- csm-authorization-sidecar images tags in the driver `config/samples` now use v2.0.0 to point to the latest release
- RELATED_IMAGE environment variables and fields are updated with Authorization v2


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1581|

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Built the offline bundle, prepared it, and successfully installed Authorization v2.

e2e with Authorization v2 without the bundle:
```
 # ./run-e2e-test.sh --auth-proxy
Checking for dellctl - AUTHORIZATIONPROXYSERVER
/root/csm-operator/tests/e2e
  W1119 16:59:47.359073   23554 test_context.go:538] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I1119 16:59:47.359310 23554 test_context.go:561] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/csm-operator/tests/e2e
===========================================================================
Random Seed: 1732035575

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 11/19/24 16:59:47.359
  STEP: [authorization authorizationproxyserver] @ 11/19/24 16:59:47.359
  STEP: Reading values file @ 11/19/24 16:59:47.359
  STEP: Getting a k8s client @ 11/19/24 16:59:47.362
[BeforeSuite] PASSED [0.007 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install Authorization Proxy Server V2  @ 11/19/24 16:59:47.366
  STEP: Returning false here @ 11/19/24 16:59:47.366
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 11/19/24 16:59:47.366
  STEP:      Executing  Install Authorization CRDs [2] @ 11/19/24 16:59:47.459
  STEP:      Executing  Create [authorization-proxy-server] prerequisites from CR [1] @ 11/19/24 16:59:47.892
=== Creating Authorization Proxy Server Prerequisites ===

Deleting all CSM from namespace: authorization
  STEP:      Executing  Apply custom resource [1] @ 11/19/24 16:59:57.563
  I1119 16:59:57.568131 23554 builder.go:121] Running '/usr/local/bin/kubectl --namespace=authorization apply --validate=true -f -'
  I1119 16:59:58.113379 23554 builder.go:146] stderr: ""
  I1119 16:59:58.113462 23554 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/authorization created\nconfigmap/csm-config-params created\n"
  STEP:      Executing  Validate [authorization-proxy-server] module from CR [1] is installed @ 11/19/24 16:59:58.113

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The pod(proxy-server-57b5bd9699-lmbvc) is Pending
The pod(role-service-5967bcbbf-fg4w9) is Pending
The pod(tenant-service-86dc6649bf-26kpd) is Pending

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-57b5bd9699-lmbvc) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 10s restarting failed container=proxy-server pod=proxy-server-57b5bd9699-lmbvc_authorization(1ed6deed-8e5d-4aa5-b55e-b859d5bffb88),} nil nil}
The container(tenant-service) in pod(tenant-service-86dc6649bf-26kpd) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 10s restarting failed container=tenant-service pod=tenant-service-86dc6649bf-26kpd_authorization(e2dc9774-8169-4031-a801-2ed3aa064cd5),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-57b5bd9699-lmbvc) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 20s restarting failed container=proxy-server pod=proxy-server-57b5bd9699-lmbvc_authorization(1ed6deed-8e5d-4aa5-b55e-b859d5bffb88),} nil nil}
The container(tenant-service) in pod(tenant-service-86dc6649bf-26kpd) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 20s restarting failed container=tenant-service pod=tenant-service-86dc6649bf-26kpd_authorization(e2dc9774-8169-4031-a801-2ed3aa064cd5),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-57b5bd9699-lmbvc) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-11-19 17:01:04 +0000 UTC,FinishedAt:2024-11-19 17:01:04 +0000 UTC,ContainerID:containerd://115da6a4aaa8233742c870287e02ea8277d5e431e7ea2807db77179a9523003c,}}
The container(tenant-service) in pod(tenant-service-86dc6649bf-26kpd) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-11-19 17:01:06 +0000 UTC,FinishedAt:2024-11-19 17:01:06 +0000 UTC,ContainerID:containerd://b44ffe90c4c4739ac1f7ed0ff9d30c07c5aba648d5de52400747084ecbaf09dc,}}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-57b5bd9699-lmbvc) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 40s restarting failed container=proxy-server pod=proxy-server-57b5bd9699-lmbvc_authorization(1ed6deed-8e5d-4aa5-b55e-b859d5bffb88),} nil nil}
The container(tenant-service) in pod(tenant-service-86dc6649bf-26kpd) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 40s restarting failed container=tenant-service pod=tenant-service-86dc6649bf-26kpd_authorization(e2dc9774-8169-4031-a801-2ed3aa064cd5),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-57b5bd9699-lmbvc) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-11-19 17:01:46 +0000 UTC,FinishedAt:2024-11-19 17:01:46 +0000 UTC,ContainerID:containerd://64c9c490949854fd33f448404b777ea706874f931ade1c4fc922a28b78e699b8,}}
The pod(sentinel-1) is Pending
The container(storage-service) in pod(storage-service-79f4b85947-nw22f) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 10s restarting failed container=storage-service pod=storage-service-79f4b85947-nw22f_authorization(c5c21c8a-e3b1-4cf9-8f29-37c3ed419ee3),} nil nil}
The container(tenant-service) in pod(tenant-service-86dc6649bf-26kpd) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 40s restarting failed container=tenant-service pod=tenant-service-86dc6649bf-26kpd_authorization(e2dc9774-8169-4031-a801-2ed3aa064cd5),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-57b5bd9699-lmbvc) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=proxy-server pod=proxy-server-57b5bd9699-lmbvc_authorization(1ed6deed-8e5d-4aa5-b55e-b859d5bffb88),} nil nil}
The container(storage-service) in pod(storage-service-79f4b85947-nw22f) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 20s restarting failed container=storage-service pod=storage-service-79f4b85947-nw22f_authorization(c5c21c8a-e3b1-4cf9-8f29-37c3ed419ee3),} nil nil}
The container(tenant-service) in pod(tenant-service-86dc6649bf-26kpd) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-11-19 17:01:58 +0000 UTC,FinishedAt:2024-11-19 17:01:58 +0000 UTC,ContainerID:containerd://360fcad4110c64fe48d65fcf59192469c58c40da62c2ba8dda16a3daf0465885,}}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-57b5bd9699-lmbvc) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=proxy-server pod=proxy-server-57b5bd9699-lmbvc_authorization(1ed6deed-8e5d-4aa5-b55e-b859d5bffb88),} nil nil}
The container(tenant-service) in pod(tenant-service-86dc6649bf-26kpd) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=tenant-service pod=tenant-service-86dc6649bf-26kpd_authorization(e2dc9774-8169-4031-a801-2ed3aa064cd5),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-57b5bd9699-lmbvc) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=proxy-server pod=proxy-server-57b5bd9699-lmbvc_authorization(1ed6deed-8e5d-4aa5-b55e-b859d5bffb88),} nil nil}
The container(tenant-service) in pod(tenant-service-86dc6649bf-26kpd) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=tenant-service pod=tenant-service-86dc6649bf-26kpd_authorization(e2dc9774-8169-4031-a801-2ed3aa064cd5),} nil nil}

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The container(proxy-server) in pod(proxy-server-57b5bd9699-lmbvc) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=proxy-server pod=proxy-server-57b5bd9699-lmbvc_authorization(1ed6deed-8e5d-4aa5-b55e-b859d5bffb88),} nil nil}
The container(tenant-service) in pod(tenant-service-86dc6649bf-26kpd) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 1m20s restarting failed container=tenant-service pod=tenant-service-86dc6649bf-26kpd_authorization(e2dc9774-8169-4031-a801-2ed3aa064cd5),} nil nil}
  STEP:      Executing  Configure authorization-proxy-server for [powerflex] for CR [1] @ 11/19/24 17:03:49.3
=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/local/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powerflex.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powerflex --insecure --addr csm-authorization.com:31963
=== Applying token ===


err: failed to apply token: exit status 1
ErrMessage:
Error from server (NotFound): error when creating "/tmp/token.yaml": namespaces "test-vxflexos" not found

=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===

=== Creating Storage, Role, and Tenant ===

=== Storage, Role, and Tenant ===
 /usr/local/bin/kubectl apply -f testfiles/authorization-templates/storage_csm_authorization_crs_powerflex.yaml
Waiting 5 seconds before generating token.
=== Generating token ===

=== Token ===
 /usr/local/bin/dellctl generate token --admin-token /tmp/adminToken.yaml --access-token-expiration 10m0s --refresh-token-expiration 48h --tenant csmtenant-powerflex --insecure --addr csm-authorization.com:31963
=== Applying token ===

=== Token Applied ===

  STEP:      Executing  Delete Authorization CRs for [powerflex] @ 11/19/24 17:04:11.613
  STEP:      Executing  Delete custom resource [1] @ 11/19/24 17:04:12.327
  STEP:      Executing  Delete Authorization CRDs [2] @ 11/19/24 17:04:12.376
  STEP: Ending: Install Authorization Proxy Server V2
   @ 11/19/24 17:04:12.658
• [270.293 seconds]
------------------------------

Ran 1 of 1 Specs in 270.300 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 4m41.804184588s
Test Suite Passed
```
