### PR TITLE
Fix Powerflex e2e alternate values tests in OCP cluster

### DIFF
--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_1.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_1.yaml
@@ -79,9 +79,9 @@ spec:
       # Default value: None
       tolerations:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-        # - key: "node-role.kubernetes.io/master"
-        #   operator: "Exists"
-        #   effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
@@ -137,9 +137,9 @@ spec:
       # Default value: None
       tolerations:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-        # - key: "node-role.kubernetes.io/master"
-        #   operator: "Exists"
-        #   effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_2.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_2.yaml
@@ -78,9 +78,9 @@ spec:
       # Default value: None
       tolerations:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-        # - key: "node-role.kubernetes.io/master"
-        #   operator: "Exists"
-        #   effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_3.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerflex_alt_vals_3.yaml
@@ -136,9 +136,9 @@ spec:
       # Default value: None
       tolerations:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-        # - key: "node-role.kubernetes.io/master"
-        #   operator: "Exists"
-        #   effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/tests/shared/common.go
+++ b/tests/shared/common.go
@@ -13,7 +13,9 @@
 package shared
 
 import (
+	"log"
 	"os"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -172,7 +174,10 @@ func MakeConfigMap(name, ns, _ string) *corev1.ConfigMap {
 
 // MakeSecretWithJSON returns a driver pre-req secret array-config
 func MakeSecretWithJSON(name string, ns string, configFile string) *corev1.Secret {
-	configJSON, _ := os.ReadFile(configFile)
+	configJSON, err := os.ReadFile(filepath.Clean(configFile))
+	if err != nil {
+		log.Fatalf("failed to read testdata: %v", err)
+	}
 	data := map[string][]byte{
 		"config": configJSON,
 	}

--- a/tests/shared/common.go
+++ b/tests/shared/common.go
@@ -14,7 +14,6 @@ package shared
 
 import (
 	"os"
-	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -173,7 +172,7 @@ func MakeConfigMap(name, ns, _ string) *corev1.ConfigMap {
 
 // MakeSecretWithJSON returns a driver pre-req secret array-config
 func MakeSecretWithJSON(name string, ns string, configFile string) *corev1.Secret {
-	configJSON, _ := os.ReadFile(filepath.Clean(configFile)) // #nosec G304
+	configJSON, _ := os.ReadFile(configFile) // #nosec G304
 	data := map[string][]byte{
 		"config": configJSON,
 	}

--- a/tests/shared/common.go
+++ b/tests/shared/common.go
@@ -13,7 +13,6 @@
 package shared
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 
@@ -174,10 +173,7 @@ func MakeConfigMap(name, ns, _ string) *corev1.ConfigMap {
 
 // MakeSecretWithJSON returns a driver pre-req secret array-config
 func MakeSecretWithJSON(name string, ns string, configFile string) *corev1.Secret {
-	configJSON, err := os.ReadFile(filepath.Clean(configFile)) // #nosec G304
-	if err != nil {
-		log.Fatalf("failed to read testdata: %v", err)
-	}
+	configJSON, _ := os.ReadFile(filepath.Clean(configFile)) // #nosec G304
 	data := map[string][]byte{
 		"config": configJSON,
 	}


### PR DESCRIPTION
# Description
In OCP clusters, the master nodes have the taint - key: "node-role.kubernetes.io/master" and not - key: "node-role.kubernetes.io/control-plane" so the controller pods are looking for a taint that doesn't exist in the E2E test scenarios that uses existing alternate values file. The toleration - key: "node-role.kubernetes.io/master" should be added. More details in the ticket

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| https://github.com/dell/csm/issues/1591 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Executed the E2E scenarios that uses updated values file in OCP and K8S clusters and the tests pass. Results attached below:
[KRV-30363-e2e.txt](https://github.com/user-attachments/files/17745681/KRV-30363-e2e.txt)
