### PR TITLE
Fix PowerScale e2e alternate values tests in OCP cluster

### DIFF
--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_1.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_1.yaml
@@ -171,7 +171,7 @@ spec:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"    
+          effect: "NoSchedule"
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -232,7 +232,7 @@ spec:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"    
+          effect: "NoSchedule"
     sideCars:
       - name: provisioner
         args: ["--volume-name-prefix=pscale"]

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_1.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_1.yaml
@@ -171,7 +171,7 @@ spec:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"  
+          effect: "NoSchedule"    
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -232,7 +232,7 @@ spec:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"            
+          effect: "NoSchedule"    
     sideCars:
       - name: provisioner
         args: ["--volume-name-prefix=pscale"]

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_1.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_1.yaml
@@ -168,6 +168,10 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
+        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"  
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -225,6 +229,10 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
+        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"            
     sideCars:
       - name: provisioner
         args: ["--volume-name-prefix=pscale"]

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
@@ -155,7 +155,7 @@ spec:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"            
+          effect: "NoSchedule"                      
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -209,11 +209,11 @@ spec:
         - key: "node.kubernetes.io/network-unavailable"
           operator: "Exists"
           effect: "NoExecute"
-       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
-        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"        

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
@@ -155,7 +155,7 @@ spec:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"                   
+          effect: "NoSchedule"
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -216,7 +216,7 @@ spec:
        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"     
+          effect: "NoSchedule"
     sideCars:
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
@@ -155,7 +155,7 @@ spec:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"                      
+          effect: "NoSchedule"                   
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -216,7 +216,7 @@ spec:
        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"        
+          effect: "NoSchedule"     
     sideCars:
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
@@ -211,8 +211,8 @@ spec:
           effect: "NoExecute"
        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
         - key: "node-role.kubernetes.io/control-plane"
-        operator: "Exists"
-        effect: "NoSchedule"
+          operator: "Exists"
+          effect: "NoSchedule"
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_2.yaml
@@ -152,6 +152,10 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
+        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"            
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -196,19 +200,23 @@ spec:
       # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      # - key: "node.kubernetes.io/memory-pressure"
-      #   operator: "Exists"
-      #   effect: "NoExecute"
-      # - key: "node.kubernetes.io/disk-pressure"
-      #   operator: "Exists"
-      #   effect: "NoExecute"
-      # - key: "node.kubernetes.io/network-unavailable"
-      #   operator: "Exists"
-      #   effect: "NoExecute"
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
-      # - key: "node-role.kubernetes.io/control-plane"
-      #  operator: "Exists"
-      #  effect: "NoSchedule"
+        - key: "node.kubernetes.io/memory-pressure"
+          operator: "Exists"
+          effect: "NoExecute"
+        - key: "node.kubernetes.io/disk-pressure"
+          operator: "Exists"
+          effect: "NoExecute"
+        - key: "node.kubernetes.io/network-unavailable"
+          operator: "Exists"
+          effect: "NoExecute"
+       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+        - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"
+        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"        
     sideCars:
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_3.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_3.yaml
@@ -156,7 +156,7 @@ spec:
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"            
+          effect: "NoSchedule"     
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -216,7 +216,7 @@ spec:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"            
+          effect: "NoSchedule"    
     sideCars:
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_3.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_3.yaml
@@ -153,10 +153,10 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
-        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"        
+          effect: "NoSchedule"            
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_3.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_3.yaml
@@ -156,7 +156,7 @@ spec:
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"     
+          effect: "NoSchedule"
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -216,7 +216,7 @@ spec:
         # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
-          effect: "NoSchedule"    
+          effect: "NoSchedule"
     sideCars:
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]

--- a/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_3.yaml
+++ b/tests/e2e/testfiles/storage_csm_powerscale_alt_vals_3.yaml
@@ -150,9 +150,13 @@ spec:
       # Default value: None
       tolerations:
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
-      # - key: "node-role.kubernetes.io/control-plane"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"        
     node:
       envs:
         # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.
@@ -209,6 +213,10 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
+        # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"            
     sideCars:
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]


### PR DESCRIPTION
# Description
In OCP clusters, the master nodes have the taint - key: "node-role.kubernetes.io/master" and not - key: "node-role.kubernetes.io/control-plane" so the controller pods are looking for a taint that doesn't exist in the E2E test scenarios that uses existing alternate values file. The toleration - key: "node-role.kubernetes.io/master" should be added. More details in the ticket

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| KRV-30361 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Executed the E2E scenarios that uses updated values file in OCP cluster 
[Testing_KRV-30361.txt](https://github.com/user-attachments/files/17747876/Testing_KRV-30361.txt)

