### PR TITLE
Remove mode: StandAlone from reverseproxy config.yaml

### DIFF
--- a/samples/csireverseproxy/config.yaml
+++ b/samples/csireverseproxy/config.yaml
@@ -15,11 +15,10 @@
 # Fill in the appropriate values, refer to docs if required
 # Create the configmap using following cmd
 # kubectl/oc create configmap powermax-reverseproxy-config --from-file config.yaml -n <namespace>
-mode: StandAlone  # Mode for the reverseproxy, should not be changed
 port: 2222
 logLevel: debug
 logFormat: text
-standAloneConfig:
+Config:
   storageArrays:
     - storageArrayId: "000000000001"  # arrayID
       primaryURL: https://primary-1.unisphe.re:8443  # primary unisphere for arrayID

--- a/samples/csireverseproxy/config.yaml
+++ b/samples/csireverseproxy/config.yaml
@@ -18,7 +18,7 @@
 port: 2222
 logLevel: debug
 logFormat: text
-Config:
+config:
   storageArrays:
     - storageArrayId: "000000000001"  # arrayID
       primaryURL: https://primary-1.unisphe.re:8443  # primary unisphere for arrayID

--- a/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config.yaml
@@ -15,11 +15,10 @@
 # Fill in the appropriate values, refer to docs if required
 # Create the configmap using following cmd
 # kubectl/oc create configmap powermax-reverseproxy-config --from-file config.yaml -n <namespace>
-mode: StandAlone  # Mode for the reverseproxy, should not be changed
 port: 2222
 logLevel: debug
 logFormat: text
-standAloneConfig:
+Config:
   storageArrays:
     - storageArrayId: "REPLACE_SYSTEMID"
       primaryURL: "https://REPLACE_ENDPOINT"

--- a/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config.yaml
@@ -18,7 +18,7 @@
 port: 2222
 logLevel: debug
 logFormat: text
-Config:
+config:
   storageArrays:
     - storageArrayId: "REPLACE_SYSTEMID"
       primaryURL: "https://REPLACE_ENDPOINT"

--- a/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml
@@ -15,11 +15,10 @@
 # Fill in the appropriate values, refer to docs if required
 # Create the configmap using following cmd
 # kubectl/oc create configmap powermax-reverseproxy-config --from-file config.yaml -n <namespace>
-mode: StandAlone  # Mode for the reverseproxy, should not be changed
 port: 2222
 logLevel: debug
 logFormat: text
-standAloneConfig:
+Config:
   storageArrays:
     - storageArrayId: "REPLACE_SYSTEMID"
       primaryURL: "https://REPLACE_AUTH_ENDPOINT:9400"

--- a/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml
@@ -18,7 +18,7 @@
 port: 2222
 logLevel: debug
 logFormat: text
-Config:
+config:
   storageArrays:
     - storageArrayId: "REPLACE_SYSTEMID"
       primaryURL: "https://REPLACE_AUTH_ENDPOINT:9400"


### PR DESCRIPTION
# Description
Remove mode: StandAlone from reverseproxy config.yaml

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1567

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
-Executed cert-csi successfully
[cert-csi-logs.txt.txt](https://github.com/user-attachments/files/17798819/cert-csi-logs.txt.txt)

E2E powermax scenario has passed:
```
[root@master-1-vxa4Qh4cj2ZFH e2e]# ./run-e2e-test.sh --pmax --cert-csi=/root/cert-csi
/root/kk/new-defect/csm-operator/tests/e2e
  W1122 10:04:14.081149  609344 test_context.go:538] Unable to find in-cluster config, using default host : https://127.0.0    .1:6443
  I1122 10:04:14.081329 609344 test_context.go:561] The --provider flag is not set. Continuing as if --provider=skeleton ha    d been used.
Running Suite: CSM Operator End-to-End Tests - /root/kk/new-defect/csm-operator/tests/e2e
=========================================================================================
Random Seed: 1732269845

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/kk/new-defect/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 11/22/24 10:04:14.088
  STEP: [powermax] @ 11/22/24 10:04:14.088
  STEP: Reading values file @ 11/22/24 10:04:14.088
  STEP: Getting a k8s client @ 11/22/24 10:04:14.095
[BeforeSuite] PASSED [0.013 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/kk/new-defect/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver(Standalone)  @ 11/22/24 10:04:14.099
  STEP: Returning false here @ 11/22/24 10:04:14.099
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 11/22/24 10:04:14.099
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-sto    rageclass-template.yaml] for [pmax] @ 11/22/24 10:04:14.112
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCr    eds] @ 11/22/24 10:04:14.816
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] na    me [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar] @ 11/22/24 10:04:15.355
  STEP:      Executing  Apply custom resource [1] @ 11/22/24 10:04:15.876
  I1122 10:04:15.876544 609344 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I1122 10:04:16.106782 609344 builder.go:146] stderr: ""
  I1122 10:04:16.106846 609344 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 11/22/24 10:04:16.106

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 11/22/24 10:05:06.154
  STEP:      Executing  Run custom test @ 11/22/24 10:05:26.167
  I1122 10:05:26.167096 609344 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2024-11-22 10:05:26]  INFO Starting cert-csi; ver. 1.4.0
[2024-11-22 10:05:26]  INFO Using EVENT observer type
[2024-11-22 10:05:26]  INFO Using config from /root/.kube/config
[2024-11-22 10:05:26]  INFO Successfully loaded config. Host: https://10.247.22.239:6443
[2024-11-22 10:05:26]  INFO Created new KubeClient
[2024-11-22 10:05:26]  INFO Running 1 iteration(s)
[2024-11-22 10:05:26]  INFO     *** ITERATION NUMBER 1 ***
[2024-11-22 10:05:26]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2024-11-22 10:05:26]  INFO Successfully created namespace volumeio-test-aef1e93c
[2024-11-22 10:05:26]  INFO Using default number of volumes
[2024-11-22 10:05:26]  INFO Using default image: docker.io/centos:latest
[2024-11-22 10:05:26]  INFO Creating IO pod
[2024-11-22 10:05:26]  INFO Waiting for pod iowriter-test-gdthz to be READY
[2024-11-22 10:05:42]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-    0.data]
[2024-11-22 10:05:42]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2024-11-22 10:05:53]  INFO Waiting until no Volume Attachments with PV  left
[2024-11-22 10:05:53]  INFO VolumeAttachment deleted


[2024-11-22 10:42:14]  INFO Avg time of a run:   45.22s
[2024-11-22 10:42:14]  INFO Avg time of a del:   12.01s
[2024-11-22 10:42:14]  INFO Avg time of all:     60.10s
[2024-11-22 10:42:14]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 11/22/24 10:42:14.614
  STEP:      Executing  Delete custom resource [1] @ 11/22/24 10:42:14.629
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxReverse    Proxy] @ 11/22/24 10:42:14.643
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 11    /22/24 10:42:14.673
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 11/    22/24 10:42:14.71
  STEP: Ending: Install PowerMax Driver(Standalone)
   @ 11/22/24 10:42:14.73
• [137.327 seconds]
------------------------------

Ran 1 of 1 Specs in 137.333 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```
