### PR TITLE
[BUG]: Remove entries in CSI PowerMax Samples of CSM operator

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ List the GitHub issues impacted by this PR:
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have maintained backward compatibility
+- [ ] I have executed the relevant end-to-end test scenarios
 
 # How Has This Been Tested?
 Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -99,9 +99,11 @@ func PrecheckPowerMax(ctx context.Context, cr *csmv1.ContainerStorageModule, ope
 	}
 
 	foundRevProxy := false
-	for _, mod := range cr.Spec.Modules {
+	for i, mod := range cr.Spec.Modules {
 		if mod.Name == csmv1.ReverseProxy {
 			foundRevProxy = true
+			cr.Spec.Modules[i].Enabled = true
+			cr.Spec.Modules[i].ForceRemoveModule = true
 			break
 		}
 	}

--- a/samples/storage_csm_powermax_v2120.yaml
+++ b/samples/storage_csm_powermax_v2120.yaml
@@ -226,9 +226,6 @@ spec:
   modules:
     # CSI Powermax Reverseproxy is a mandatory module for Powermax
     - name: csireverseproxy
-      # enabled: Always set to true
-      enabled: true
-      forceRemoveModule: true
       configVersion: v2.11.0
       components:
         - name: csipowermax-reverseproxy

--- a/tests/e2e/testfiles/storage_csm_powermax.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax.yaml
@@ -206,9 +206,6 @@ spec:
   modules:
     # CSI Powermax Reverseproxy is a mandatory module for Powermax
     - name: csireverseproxy
-      # enabled: Always set to true
-      enabled: true
-      forceRemoveModule: true
       configVersion: v2.11.0
       components:
         - name: csipowermax-reverseproxy

--- a/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
@@ -206,9 +206,6 @@ spec:
   modules:
     # CSI Powermax Reverseproxy is a mandatory module for Powermax
     - name: csireverseproxy
-      # enabled: Always set to true
-      enabled: true
-      forceRemoveModule: true
       configVersion: v2.10.0
       components:
         - name: csipowermax-reverseproxy


### PR DESCRIPTION
# Description
Remove stale entries from CSI Powermax Reverseproxy CR

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1585 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

The operator e2e tests were executed successfully. Full log attached in Jira ticket.
- [x] Install PowerMax Driver(Standalone)
- [x] Install PowerMax Driver(Sidecar)
