### PR TITLE
Read zone information from PowerFlex secret

### DIFF
--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -347,6 +347,7 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 	return yamlString
 }
 
+// ExtractZonesFromSecret - Reads the array config secret and returns the zone label information
 func ExtractZonesFromSecret(ctx context.Context, kube client.Client, namespace string, secret string) (map[string]string, error) {
 	log := logger.GetLogger(ctx)
 

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -359,7 +359,8 @@ func ExtractZonesFromSecret(ctx context.Context, kube client.Client, namespace s
 	type StorageArrayConfig struct {
 		SystemID string `json:"systemId"`
 		Zone     struct {
-			Label string `json:"label"`
+			Name     string `json:"name"`
+			LabelKey string `json:"labelKey"`
 		} `json:"zone"`
 	}
 
@@ -382,10 +383,9 @@ func ExtractZonesFromSecret(ctx context.Context, kube client.Client, namespace s
 			if configParam.SystemID == "" {
 				return nil, fmt.Errorf("invalid value for SystemID")
 			}
-			if configParam.Zone.Label != "" {
-				keyVal := strings.Split(configParam.Zone.Label, "=")
-				if len(keyVal) == 2 {
-					zonesMapData[keyVal[0]] = keyVal[1]
+			if configParam.Zone.LabelKey != "" {
+				if configParam.Zone.Name != "" {
+					zonesMapData[configParam.Zone.LabelKey] = configParam.Zone.Name
 					log.Infof("Zoning information configured for systemID %s: %v ", configParam.SystemID, zonesMapData)
 				}
 			} else {

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -356,14 +356,8 @@ func ExtractZonesFromSecret(ctx context.Context, kube client.Client, namespace s
 	}
 
 	type StorageArrayConfig struct {
-		Username                  string `json:"username"`
-		Password                  string `json:"password"`
-		SystemID                  string `json:"systemId"`
-		Endpoint                  string `json:"endpoint"`
-		SkipCertificateValidation bool   `json:"skipCertificateValidation,omitempty"`
-		IsDefault                 bool   `json:"isDefault,omitempty"`
-		MDM                       string `json:"mdm"`
-		Zone                      struct {
+		SystemID string `json:"systemId"`
+		Zone     struct {
 			Label string `json:"label"`
 		} `json:"zone"`
 	}
@@ -378,9 +372,15 @@ func ExtractZonesFromSecret(ctx context.Context, kube client.Client, namespace s
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse multi-array configuration[%v]", err)
 		}
-		_ = yaml.Unmarshal(configs, &yamlConfig)
+		err = yaml.Unmarshal(configs, &yamlConfig)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshal multi-array configuration[%v]", err)
+		}
 
 		for _, configParam := range yamlConfig {
+			if configParam.SystemID == "" {
+				return nil, fmt.Errorf("invalid value for SystemID")
+			}
 			if configParam.Zone.Label != "" {
 				keyVal := strings.Split(configParam.Zone.Label, "=")
 				if len(keyVal) == 2 {

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -346,3 +346,7 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 	}
 	return yamlString
 }
+
+func ExtractZonesFromSecret(kube client.Client, namespace string, secret string) (map[string]string, error) {
+	return nil, nil
+}

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -199,6 +199,17 @@ func TestModifyPowerflexCR(t *testing.T) {
 
 func TestExtractZonesFromSecret(t *testing.T) {
 	emptySecret := ``
+	invalidSecret := `
+- username: "admin"
+	-
+`
+	secretWithNoSystemID := `
+- username: "admin"
+  password: "password"
+  endpoint: "https://127.0.0.2"
+  skipCertificateValidation: true
+  mdm: "10.0.0.3,10.0.0.4"
+`
 	dataWithZone := `
 - username: "admin"
   password: "password"
@@ -259,6 +270,34 @@ func TestExtractZonesFromSecret(t *testing.T) {
 				},
 				Data: map[string][]byte{
 					"config": []byte(emptySecret),
+				},
+			}
+
+			client := fake.NewClientBuilder().WithObjects(secret).Build()
+			return client, nil, "vxflexos-config", true
+		},
+		"error with no system id": func() (client.WithWatch, map[string]string, string, bool) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vxflexos-config",
+					Namespace: "vxflexos",
+				},
+				Data: map[string][]byte{
+					"config": []byte(secretWithNoSystemID),
+				},
+			}
+
+			client := fake.NewClientBuilder().WithObjects(secret).Build()
+			return client, nil, "vxflexos-config", true
+		},
+		"error unmarshaling config": func() (client.WithWatch, map[string]string, string, bool) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vxflexos-config",
+					Namespace: "vxflexos",
+				},
+				Data: map[string][]byte{
+					"config": []byte(invalidSecret),
 				},
 			}
 

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -198,12 +198,12 @@ func TestModifyPowerflexCR(t *testing.T) {
 }
 
 func TestExtractZonesFromSecret(t *testing.T) {
-	emptySecret := ``
-	invalidSecret := `
+	emptyConfigData := ``
+	invalidConfigData := `
 - username: "admin"
 	-
 `
-	secretWithNoSystemID := `
+	dataWithNoSystemID := `
 - username: "admin"
   password: "password"
   endpoint: "https://127.0.0.2"
@@ -269,7 +269,7 @@ func TestExtractZonesFromSecret(t *testing.T) {
 					Namespace: "vxflexos",
 				},
 				Data: map[string][]byte{
-					"config": []byte(emptySecret),
+					"config": []byte(emptyConfigData),
 				},
 			}
 
@@ -283,7 +283,7 @@ func TestExtractZonesFromSecret(t *testing.T) {
 					Namespace: "vxflexos",
 				},
 				Data: map[string][]byte{
-					"config": []byte(secretWithNoSystemID),
+					"config": []byte(dataWithNoSystemID),
 				},
 			}
 
@@ -297,7 +297,7 @@ func TestExtractZonesFromSecret(t *testing.T) {
 					Namespace: "vxflexos",
 				},
 				Data: map[string][]byte{
-					"config": []byte(invalidSecret),
+					"config": []byte(invalidConfigData),
 				},
 			}
 

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -218,7 +218,8 @@ func TestExtractZonesFromSecret(t *testing.T) {
   skipCertificateValidation: true
   mdm: "10.0.0.3,10.0.0.4"
   zone:
-    label: topology.kubernetes.io/zone=US-EAST
+    name: "US-EAST"
+    labelKey: "zone.csi-vxflexos.dellemc.com"
 `
 	dataWithoutZone := `
 - username: "admin"
@@ -242,7 +243,7 @@ func TestExtractZonesFromSecret(t *testing.T) {
 			}
 
 			client := fake.NewClientBuilder().WithObjects(secret).Build()
-			return client, map[string]string{"topology.kubernetes.io/zone": "US-EAST"}, "vxflexos-config", false
+			return client, map[string]string{"zone.csi-vxflexos.dellemc.com": "US-EAST"}, "vxflexos-config", false
 		},
 		"success no zone": func() (client.WithWatch, map[string]string, string, bool) {
 			secret := &corev1.Secret{


### PR DESCRIPTION
# Description
PR adds the method to read the zoning information from the PowerFlex array secret

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1613|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] unit tests
```
# go test ./... -cover -count=1
        github.com/dell/csm-operator/api/v1             coverage: 0.0% of statements
        github.com/dell/csm-operator            coverage: 0.0% of statements
        github.com/dell/csm-operator/core/semver                coverage: 0.0% of statements
?       github.com/dell/csm-operator/pkg/constants      [no test files]
        github.com/dell/csm-operator/core               coverage: 0.0% of statements
        github.com/dell/csm-operator/pkg/logger         coverage: 0.0% of statements
        github.com/dell/csm-operator/tests/shared               coverage: 0.0% of statements
        github.com/dell/csm-operator/tests/shared/clientgoclient                coverage: 0.0% of statements
        github.com/dell/csm-operator/tests/shared/crclient              coverage: 0.0% of statements
ok      github.com/dell/csm-operator/controllers        55.024s coverage: 89.1% of statements
ok      github.com/dell/csm-operator/k8s        0.068s  coverage: 90.3% of statements
ok      github.com/dell/csm-operator/pkg/drivers        0.234s  coverage: 96.1% of statements
ok      github.com/dell/csm-operator/pkg/modules        2.153s  coverage: 89.7% of statements
ok      github.com/dell/csm-operator/pkg/resources/configmap    0.032s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/csidriver    0.093s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/daemonset    0.117s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/deployment   0.114s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/rbac 0.041s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/serviceaccount       0.025s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/utils  3.110s  coverage: 81.9% of statements
```
- [x] E2E tests (PowerFlex standalone tests only, since new function isn't used anywhere yet)
![image](https://github.com/user-attachments/assets/3c4e8f9f-6397-4e97-98f7-b87586c67727)

[pflex-e2e-suite-standalone.txt](https://github.com/user-attachments/files/18027137/pflex-e2e-suite-standalone.txt)

