### PR TITLE
Detect Zone info in node labels 

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -280,7 +280,7 @@ func (r *ContainerStorageModuleReconciler) Reconcile(_ context.Context, req ctrl
 	nodeList, err := r.GetMatchingNodes(ctx, "topology.kubernetes.io/zone", "US-EAST")
 	if err != nil {
 		log.Errorw("Failed to retrieve list of nodes for label",
-				"topology.kubernetes.io/zone")
+			"topology.kubernetes.io/zone")
 	}
 	log.Infow("nodeList with labels", "csm", nodeList)
 

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -277,13 +277,12 @@ func (r *ContainerStorageModuleReconciler) Reconcile(_ context.Context, req ctrl
 		return ctrl.Result{}, err
 	}
 
-	nodeList, err := GetMatchingNodes(ctx, r, "topology.kubernetes.io/zone", "US-EAST")
+	nodeList, err := r.GetMatchingNodes(ctx, "topology.kubernetes.io/zone", "US-EAST")
 	if err != nil {
 		log.Errorw("Failed to retrieve list of nodes for label",
 				"topology.kubernetes.io/zone")
 	}
 	log.Infow("nodeList with labels", "csm", nodeList)
-
 
 	// perform prechecks
 	err = r.PreChecks(ctx, csm, *operatorConfig)
@@ -1526,7 +1525,7 @@ func (r *ContainerStorageModuleReconciler) GetK8sClient() kubernetes.Interface {
 	return r.K8sClient
 }
 
-func GetMatchingNodes(ctx context.Context, r *ContainerStorageModuleReconciler, labelKey string, labelValue string) (*corev1.NodeList, error) {
+func (r *ContainerStorageModuleReconciler) GetMatchingNodes(ctx context.Context, labelKey string, labelValue string) (*corev1.NodeList, error) {
 	nodeList := &corev1.NodeList{}
 	opts := []client.ListOption{
 		client.MatchingLabels{labelKey: labelValue},

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -277,13 +277,6 @@ func (r *ContainerStorageModuleReconciler) Reconcile(_ context.Context, req ctrl
 		return ctrl.Result{}, err
 	}
 
-	nodeList, err := r.GetMatchingNodes(ctx, "topology.kubernetes.io/zone", "US-EAST")
-	if err != nil {
-		log.Errorw("Failed to retrieve list of nodes for label",
-			"topology.kubernetes.io/zone")
-	}
-	log.Infow("nodeList with labels", "csm", nodeList)
-
 	// perform prechecks
 	err = r.PreChecks(ctx, csm, *operatorConfig)
 	if err != nil {

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -277,6 +277,14 @@ func (r *ContainerStorageModuleReconciler) Reconcile(_ context.Context, req ctrl
 		return ctrl.Result{}, err
 	}
 
+	nodeList, err := GetMatchingNodes(ctx, r, "topology.kubernetes.io/zone", "US-EAST")
+	if err != nil {
+		log.Errorw("Failed to retrieve list of nodes for label",
+				"topology.kubernetes.io/zone")
+	}
+	log.Infow("nodeList with labels", "csm", nodeList)
+
+
 	// perform prechecks
 	err = r.PreChecks(ctx, csm, *operatorConfig)
 	if err != nil {
@@ -1516,4 +1524,14 @@ func (r *ContainerStorageModuleReconciler) GetUpdateCount() int32 {
 // GetK8sClient - Returns the current update count
 func (r *ContainerStorageModuleReconciler) GetK8sClient() kubernetes.Interface {
 	return r.K8sClient
+}
+
+func GetMatchingNodes(ctx context.Context, r *ContainerStorageModuleReconciler, labelKey string, labelValue string) (*corev1.NodeList, error) {
+	nodeList := &corev1.NodeList{}
+	opts := []client.ListOption{
+		client.MatchingLabels{labelKey: labelValue},
+	}
+	err := r.List(ctx, nodeList, opts...)
+
+	return nodeList, err
 }

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -2435,5 +2435,4 @@ func (suite *CSMControllerTestSuite) TestGetNodeLabels() {
 		panic(err)
 	}
 	assert.Nil(suite.T(), err)
-
 }

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -2385,7 +2385,7 @@ func (suite *CSMControllerTestSuite) makeFakeRevProxyCSM(name string, ns string,
 
 func (suite *CSMControllerTestSuite) TestGetNodeLabels() {
 	// TBD: crclient/client.go needs to be augmented to filter on labels during
-	// the List return for a viable thorough test. Since this functionality is 
+	// the List return for a viable thorough test. Since this functionality is
 	// missing, this test is quite elementary as a result.
 
 	csm := shared.MakeCSM(csmName, suite.namespace, configVersion)
@@ -2423,7 +2423,7 @@ func (suite *CSMControllerTestSuite) TestGetNodeLabels() {
 
 	// Check the len to be 1 else fail
 	if len(nodeListMatching.Items) != 1 {
-		ctrl.Log.Error(err, "Unexpected length on node list.","length",len(nodeListMatching.Items))
+		ctrl.Log.Error(err, "Unexpected length on node list.", "length", len(nodeListMatching.Items))
 		panic(err)
 	}
 

--- a/tests/shared/common.go
+++ b/tests/shared/common.go
@@ -195,6 +195,19 @@ func MakePod(name, ns string) corev1.Pod {
 	return podObj
 }
 
+// MakeNode returns a node object
+func MakeNode(name, ns string) corev1.Node {
+	nodeObj := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{},
+		},
+	}
+
+	return nodeObj
+}
+
 // MakeReverseProxyModule returns a csireverseproxy object
 func MakeReverseProxyModule(_ string) csmv1.Module {
 	revproxy := csmv1.Module{

--- a/tests/shared/crclient/client.go
+++ b/tests/shared/crclient/client.go
@@ -127,7 +127,10 @@ func (f Client) listPodList(list *corev1.PodList) error {
 func (f Client) listNodeList(list *corev1.NodeList) error {
 	for k, v := range f.Objects {
 		if k.Kind == "Node" {
-			list.Items = append(list.Items, *v.(*corev1.Node))
+			node, ok := v.(*corev1.Node)
+			if ok {
+				list.Items = append(list.Items, *node)
+			}
 		}
 	}
 	return nil

--- a/tests/shared/crclient/client.go
+++ b/tests/shared/crclient/client.go
@@ -106,6 +106,8 @@ func (f Client) List(ctx context.Context, list client.ObjectList, _ ...client.Li
 	switch l := list.(type) {
 	case *corev1.PodList:
 		return f.listPodList(l)
+	case *corev1.NodeList:
+		return f.listNodeList(l)
 	case *appsv1.DeploymentList:
 		return f.listDeploymentList(ctx, &appsv1.DeploymentList{})
 	default:
@@ -117,6 +119,15 @@ func (f Client) listPodList(list *corev1.PodList) error {
 	for k, v := range f.Objects {
 		if k.Kind == "Pod" {
 			list.Items = append(list.Items, *v.(*corev1.Pod))
+		}
+	}
+	return nil
+}
+
+func (f Client) listNodeList(list *corev1.NodeList) error {
+	for k, v := range f.Objects {
+		if k.Kind == "Node" {
+			list.Items = append(list.Items, *v.(*corev1.Node))
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description
Detect Zone info in node labels and return the list of nodes with this label-value pair.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1613|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] k8s cluster add node labels to some workers, and dump the nodelist that the function returns
