### PR TITLE
Remove mode: StandAlone from reverseproxy config.yaml

### DIFF
--- a/samples/csireverseproxy/config.yaml
+++ b/samples/csireverseproxy/config.yaml
@@ -15,11 +15,10 @@
 # Fill in the appropriate values, refer to docs if required
 # Create the configmap using following cmd
 # kubectl/oc create configmap powermax-reverseproxy-config --from-file config.yaml -n <namespace>
-mode: StandAlone  # Mode for the reverseproxy, should not be changed
 port: 2222
 logLevel: debug
 logFormat: text
-standAloneConfig:
+config:
   storageArrays:
     - storageArrayId: "000000000001"  # arrayID
       primaryURL: https://primary-1.unisphe.re:8443  # primary unisphere for arrayID

--- a/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config.yaml
@@ -15,11 +15,10 @@
 # Fill in the appropriate values, refer to docs if required
 # Create the configmap using following cmd
 # kubectl/oc create configmap powermax-reverseproxy-config --from-file config.yaml -n <namespace>
-mode: StandAlone  # Mode for the reverseproxy, should not be changed
 port: 2222
 logLevel: debug
 logFormat: text
-standAloneConfig:
+config:
   storageArrays:
     - storageArrayId: "REPLACE_SYSTEMID"
       primaryURL: "https://REPLACE_ENDPOINT"

--- a/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml
@@ -15,11 +15,10 @@
 # Fill in the appropriate values, refer to docs if required
 # Create the configmap using following cmd
 # kubectl/oc create configmap powermax-reverseproxy-config --from-file config.yaml -n <namespace>
-mode: StandAlone  # Mode for the reverseproxy, should not be changed
 port: 2222
 logLevel: debug
 logFormat: text
-standAloneConfig:
+config:
   storageArrays:
     - storageArrayId: "REPLACE_SYSTEMID"
       primaryURL: "https://REPLACE_AUTH_ENDPOINT"


### PR DESCRIPTION
# Description
Remove mode: StandAlone from reverseproxy config.yaml

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1567

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility
- [X] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Executed cert-csi successfully
- [X] E2E powermax with authorization v2 has passed

[cert-csi-logs.txt](https://github.com/user-attachments/files/18018242/cert-csi-logs.txt)

![image (24)](https://github.com/user-attachments/assets/3a8c63ca-9897-4873-85b5-87bf6d5f1519)

