### PR TITLE
Retrieve zone information from multi array secret

### DIFF
--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -359,8 +359,7 @@ func ExtractZonesFromSecret(ctx context.Context, kube client.Client, namespace s
 	type StorageArrayConfig struct {
 		SystemID string `json:"systemId"`
 		Zone     struct {
-			Name     string `json:"name"`
-			LabelKey string `json:"labelKey"`
+			Name string `json:"name"`
 		} `json:"zone"`
 	}
 
@@ -383,11 +382,9 @@ func ExtractZonesFromSecret(ctx context.Context, kube client.Client, namespace s
 			if configParam.SystemID == "" {
 				return nil, fmt.Errorf("invalid value for SystemID")
 			}
-			if configParam.Zone.LabelKey != "" {
-				if configParam.Zone.Name != "" {
-					zonesMapData[configParam.Zone.LabelKey] = configParam.Zone.Name
-					log.Infof("Zoning information configured for systemID %s: %v ", configParam.SystemID, zonesMapData)
-				}
+			if configParam.Zone.Name != "" {
+				zonesMapData[configParam.SystemID] = configParam.Zone.Name
+				log.Infof("Zoning information configured for systemID %s: %v ", configParam.SystemID, zonesMapData)
 			} else {
 				log.Info("Zoning information not found in the array config. Continue with topology-unaware driver installation mode")
 				return zonesMapData, nil

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -221,6 +221,26 @@ func TestExtractZonesFromSecret(t *testing.T) {
     name: "US-EAST"
     labelKey: "zone.csi-vxflexos.dellemc.com"
 `
+	zoneDataWithMultiArray := `
+- username: "admin"
+  password: "password"
+  systemID: "2b11bb111111bb1b"
+  endpoint: "https://127.0.0.2"
+  skipCertificateValidation: true
+  mdm: "10.0.0.3,10.0.0.4"
+  zone:
+    name: "ZONE-1"
+    labelKey: "zone.csi-vxflexos.dellemc.com"
+- username: "admin"
+  password: "password"
+  systemID: "1a99aa999999aa9a"
+  endpoint: "https://127.0.0.1"
+  skipCertificateValidation: true
+  mdm: "10.0.0.5,10.0.0.6"
+  zone:
+    name: "ZONE-2"
+    labelKey: "zone.csi-vxflexos.dellemc.com"
+`
 	dataWithoutZone := `
 - username: "admin"
   password: "password"
@@ -243,7 +263,21 @@ func TestExtractZonesFromSecret(t *testing.T) {
 			}
 
 			client := fake.NewClientBuilder().WithObjects(secret).Build()
-			return client, map[string]string{"zone.csi-vxflexos.dellemc.com": "US-EAST"}, "vxflexos-config", false
+			return client, map[string]string{"2b11bb111111bb1b": "US-EAST"}, "vxflexos-config", false
+		},
+		"success with zone and multi array": func() (client.WithWatch, map[string]string, string, bool) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vxflexos-config",
+					Namespace: "vxflexos",
+				},
+				Data: map[string][]byte{
+					"config": []byte(zoneDataWithMultiArray),
+				},
+			}
+
+			client := fake.NewClientBuilder().WithObjects(secret).Build()
+			return client, map[string]string{"2b11bb111111bb1b": "ZONE-1", "1a99aa999999aa9a": "ZONE-2"}, "vxflexos-config", false
 		},
 		"success no zone": func() (client.WithWatch, map[string]string, string, bool) {
 			secret := &corev1.Secret{


### PR DESCRIPTION
# Description
PR fixes retrieving zone information from multi array secret

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1613|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] unit tests
```
        github.com/dell/csm-operator            coverage: 0.0% of statements
        github.com/dell/csm-operator/api/v1             coverage: 0.0% of statements
        github.com/dell/csm-operator/core               coverage: 0.0% of statements
?       github.com/dell/csm-operator/pkg/constants      [no test files]
        github.com/dell/csm-operator/core/semver                coverage: 0.0% of statements
        github.com/dell/csm-operator/pkg/logger         coverage: 0.0% of statements
        github.com/dell/csm-operator/tests/shared/clientgoclient                coverage: 0.0% of statements
        github.com/dell/csm-operator/tests/shared               coverage: 0.0% of statements
        github.com/dell/csm-operator/tests/shared/crclient              coverage: 0.0% of statements
ok      github.com/dell/csm-operator/controllers        55.161s coverage: 89.2% of statements
ok      github.com/dell/csm-operator/k8s        0.052s  coverage: 90.3% of statements
ok      github.com/dell/csm-operator/pkg/drivers        0.237s  coverage: 96.1% of statements
ok      github.com/dell/csm-operator/pkg/modules        2.211s  coverage: 90.1% of statements
ok      github.com/dell/csm-operator/pkg/resources/configmap    0.043s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/csidriver    0.022s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/daemonset    0.086s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/deployment   0.049s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/rbac 0.076s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/serviceaccount       0.065s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/utils  3.109s  coverage: 81.9% of statements

```

