### PR TITLE
removed redeclared filepath

### DIFF
--- a/tests/e2e/steps/steps_def.go
+++ b/tests/e2e/steps/steps_def.go
@@ -26,9 +26,6 @@ import (
 
 	"encoding/json"
 	"path/filepath"
-
-	"path/filepath"
-
 	"github.com/dell/csm-operator/pkg/constants"
 	"github.com/dell/csm-operator/pkg/modules"
 	"github.com/dell/csm-operator/pkg/utils"

--- a/tests/e2e/steps/steps_def.go
+++ b/tests/e2e/steps/steps_def.go
@@ -25,7 +25,6 @@ import (
 	csmv1 "github.com/dell/csm-operator/api/v1"
 
 	"encoding/json"
-	"path/filepath"
 	"github.com/dell/csm-operator/pkg/constants"
 	"github.com/dell/csm-operator/pkg/modules"
 	"github.com/dell/csm-operator/pkg/utils"
@@ -39,6 +38,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/kubectl"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/utils/pointer"
+	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )


### PR DESCRIPTION
# Description
Filepath imported 2 times causing E2E compilation issue.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1642|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?

This compilation issue was coming before 
[root@e2e]# ./run-e2e-test.sh --unity --cert-csi=/root/cert-csi/cert-csi --dellctl=/root/dellctl --karavictl=/root/karavictl
go: downloading golang.org/x/sys v0.28.0
go: downloading golang.org/x/term v0.27.0
go: downloading golang.org/x/text v0.21.0
go: downloading golang.org/x/sync v0.10.0
go: downloading golang.org/x/crypto v0.31.0
/root/taran/csm-operator/tests/e2e
Failed to compile e2e:

# github.com/dell/csm-operator/tests/e2e/steps
steps/steps_def.go:30:2: filepath redeclared in this block
        steps/steps_def.go:28:2: other declaration of filepath
steps/steps_def.go:30:2: "path/filepath" imported and not used


Ginkgo ran 1 suite in 1m10.775356939s

Test Suite Failed
-----
After fixing 
Executed E2E after that compilation issue is not coming 

```
[root@ e2e]# ./run-e2e-test.sh --unity --cert-csi=/root/cert-csi/cert-csi --dellctl=/root/dellctl --karavictl=/root/karavictl
/root/taran/csm-operator/tests/e2e
  W1213 07:53:44.747935  538516 test_context.go:538] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I1213 07:53:44.748014 538516 test_context.go:561] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/taran/csm-operator/tests/e2e
```
=================================================================================
Random Seed: 1734094408

Will run 1 of 1 specs
------------------------------
[BeforeSuite] 
/root/taran/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 12/13/24 07:53:44.753
  STEP: [unity] @ 12/13/24 07:53:44.753
  STEP: Reading values file @ 12/13/24 07:53:44.753
  STEP: Getting a k8s client @ 12/13/24 07:53:44.756
[BeforeSuite] PASSED [0.008 seconds]
