### PR TITLE
Fixing default value for X_CSI_K8S_CLUSTER_PREFIX

### DIFF
--- a/config/samples/storage_v1_csm_powermax.yaml
+++ b/config/samples/storage_v1_csm_powermax.yaml
@@ -56,10 +56,10 @@ spec:
         # all resources created in the Array
         # This should be unique per K8s/CSI deployment
         # maximum length of this value is 3 characters
-        # Default value: None
+        # Default value: "CSM"
         # Examples: "XYZ", "EMC"
         - name: X_CSI_K8S_CLUSTER_PREFIX
-          value: "XYZ"
+          value: "CSM"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/samples/storage_csm_powermax_v2130.yaml
+++ b/samples/storage_csm_powermax_v2130.yaml
@@ -57,10 +57,10 @@ spec:
         # all resources created in the Array
         # This should be unique per K8s/CSI deployment
         # maximum length of this value is 3 characters
-        # Default value: None
+        # Default value: "CSM"
         # Examples: "XYZ", "EMC"
         - name: X_CSI_K8S_CLUSTER_PREFIX
-          value: "XYZ"
+          value: "CSM"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/tests/e2e/testfiles/storage_csm_powermax.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax.yaml
@@ -57,10 +57,10 @@ spec:
         # all resources created in the Array
         # This should be unique per K8s/CSI deployment
         # maximum length of this value is 3 characters
-        # Default value: None
+        # Default value: "CSM"
         # Examples: "XYZ", "EMC"
         - name: X_CSI_K8S_CLUSTER_PREFIX
-          value: "XYZ"
+          value: "CSM"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/tests/e2e/testfiles/storage_csm_powermax_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_authorization.yaml
@@ -56,10 +56,10 @@ spec:
         # all resources created in the Array
         # This should be unique per K8s/CSI deployment
         # maximum length of this value is 3 characters
-        # Default value: None
+        # Default value: "CSM"
         # Examples: "XYZ", "EMC"
         - name: X_CSI_K8S_CLUSTER_PREFIX
-          value: "XYZ"
+          value: "CSM"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
@@ -57,10 +57,10 @@ spec:
         # all resources created in the Array
         # This should be unique per K8s/CSI deployment
         # maximum length of this value is 3 characters
-        # Default value: None
+        # Default value: "CSM"
         # Examples: "XYZ", "EMC"
         - name: X_CSI_K8S_CLUSTER_PREFIX
-          value: "XYZ"
+          value: "CSM"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/tests/e2e/testfiles/storage_csm_powermax_observability_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_observability_authorization.yaml
@@ -56,10 +56,10 @@ spec:
         # all resources created in the Array
         # This should be unique per K8s/CSI deployment
         # maximum length of this value is 3 characters
-        # Default value: None
+        # Default value: "CSM"
         # Examples: "XYZ", "EMC"
         - name: X_CSI_K8S_CLUSTER_PREFIX
-          value: "XYZ"
+          value: "CSM"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/tests/e2e/testfiles/storage_csm_powermax_resiliency.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_resiliency.yaml
@@ -57,10 +57,10 @@ spec:
         # all resources created in the Array
         # This should be unique per K8s/CSI deployment
         # maximum length of this value is 3 characters
-        # Default value: None
+        # Default value: "CSM"
         # Examples: "XYZ", "EMC"
         - name: X_CSI_K8S_CLUSTER_PREFIX
-          value: "XYZ"
+          value: "CSM"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/tests/e2e/testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
@@ -57,10 +57,10 @@ spec:
         # all resources created in the Array
         # This should be unique per K8s/CSI deployment
         # maximum length of this value is 3 characters
-        # Default value: None
+        # Default value: "CSM"
         # Examples: "XYZ", "EMC"
         - name: X_CSI_K8S_CLUSTER_PREFIX
-          value: "XYZ"
+          value: "CSM"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_sidecar.yaml
@@ -57,10 +57,10 @@ spec:
         # all resources created in the Array
         # This should be unique per K8s/CSI deployment
         # maximum length of this value is 3 characters
-        # Default value: None
+        # Default value: "CSM"
         # Examples: "XYZ", "EMC"
         - name: X_CSI_K8S_CLUSTER_PREFIX
-          value: "XYZ"
+          value: "CSM"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet


### PR DESCRIPTION
# Description
Fixing default value for X_CSI_K8S_CLUSTER_PREFIX

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1638 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility
- [X] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
I ran e2e powermax standalone and sidecar  test and it passed successfully.

[e2e with default value for cluster prefix.txt](https://github.com/user-attachments/files/18146080/e2e.with.default.value.for.cluster.prefix.txt)
![image](https://github.com/user-attachments/assets/519c67ec-b680-4198-917e-f6488392ebf1)


