### PR TITLE
change incorrect GroupVersion

### DIFF
--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -173,7 +173,7 @@ func GetController(ctx context.Context, cr csmv1.ContainerStorageModule, operato
 	bController := true
 	bOwnerDeletion := cr.Spec.Driver.ForceRemoveDriver != nil && !*cr.Spec.Driver.ForceRemoveDriver
 	kind := cr.Kind
-	v1 := "apps/v1"
+	v1 := "storage.dell.com/v1"
 	controllerYAML.Deployment.OwnerReferences = []metacv1.OwnerReferenceApplyConfiguration{
 		{
 			APIVersion:         &v1,


### PR DESCRIPTION
# Description
Setting ownerReference was failing because the GroupVersion used is incorrect "apps/v1" instead of "storage.dell.com/v1".
So when in maximal/minimal CR, when forceRemoveDriver: false, CSM installation was failing when Operator deployed from UI

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| https://github.com/dell/csm/issues/1605 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
The operator e2e tests were executed successfully. Full log attached in Jira ticket.

- [x] Deploy operator from UI with changes by building catalogSource and catalog image. Deployed CSM with forceRemoveDriver: false -> CSM is getting installed and pods are in running state. Tested with forceRemoveDriver: true and CSM is getting installed successfully and pods are in running state

>  oc get csm -A
> NAMESPACE   NAME       CREATIONTIME   CSIDRIVERTYPE   CONFIGVERSION   STATE
> vxflexos    vxflexos   20m            powerflex       v2.12.0         Succeeded
> 

> oc get pods -n vxflexos
> NAME                                   READY   STATUS    RESTARTS      AGE
> vxflexos-controller-686749ddb4-8f7wl   5/5     Running   2 (19m ago)   20m
> vxflexos-controller-686749ddb4-lb7wz   5/5     Running   1 (19m ago)   20m
> vxflexos-node-9mxw7                          2/2     Running   0             20m
> vxflexos-node-g2wvl                            2/2     Running   0             20m
- [x] Executed tests to install Powerflex, Powerscale, and Unity (as Minimal, Standalone)
- [x] Executed tests to install Powerflex (Minimal, With Resiliency module)
