### PR TITLE
Updated Operator E2E Test for PowerMax

### DIFF
--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1654,7 +1654,7 @@
       run:
         - /bin/bash verify-app-mobility.sh
 
-- scenario: "Install PowerMax Driver(Standalone)"
+- scenario: "Install PowerMax Driver"
   paths:
     - "testfiles/storage_csm_powermax.yaml"
   tags:
@@ -1670,34 +1670,6 @@
     - "Validate custom resource [1]"
     - "Validate [powermax] driver from CR [1] is installed"
     - "Run custom test"
-    - "Enable forceRemoveDriver on CR [1]"
-    - "Delete custom resource [1]"
-    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar]"
-    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
-    - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
-    - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
-  customTest:
-    - name: Cert CSI
-      run:
-        - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
-
-- scenario: "Install PowerMax Driver(Sidecar)"
-  paths:
-    - "testfiles/storage_csm_powermax_sidecar.yaml"
-  tags:
-    - "powermax"
-  steps:
-    - "Given an environment with k8s or openshift, and CSM operator installed"
-    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
-    - "Set up reverse proxy tls secret namespace [powermax]"
-    - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
-    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar]"
-    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
-    - "Apply custom resource [1]"
-    - "Validate custom resource [1]"
-    - "Validate [powermax] driver from CR [1] is installed"
-    - "Run custom test"
-    # Last two steps perform Clean Up
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"
     - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar]"


### PR DESCRIPTION
# Description
- Updated one test scenario name Operator E2E for PowerMax. It was still named as `Install PowerMax Driver(Standalone)` while the sample yaml file is deploying as sidecar now.
- Removed the duplicated test scenario of deploying as sidecar.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1614 |

Related to PR #831 as Operator E2E is needed for it.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested with the new changes
```
  STEP: Starting: Install PowerMax Driver  @ 12/30/24 12:35:44.918
  STEP: Returning false at end @ 12/30/24 12:35:44.918
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 12/30/24 12:35:44.918
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 12/30/24 12:35:44.931
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 12/30/24 12:35:45.493
Temporary directory created at: /root/csm-operator/tests/e2e/tls-setup3457619919
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 12/30/24 12:35:46.152
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar] @ 12/30/24 12:35:46.389
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 12/30/24 12:35:46.687
  STEP:      Executing  Apply custom resource [1] @ 12/30/24 12:35:46.978
  I1230 12:35:46.978910 380123 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I1230 12:35:47.150619 380123 builder.go:146] stderr: ""
  I1230 12:35:47.150707 380123 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 12/30/24 12:35:47.15

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 12/30/24 12:36:37.205
  STEP:      Executing  Run custom test @ 12/30/24 12:36:57.223
  I1230 12:36:57.224034 380123 util.go:645] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2024-12-30 12:36:57]  INFO Starting cert-csi; ver. 1.6.0
[2024-12-30 12:36:57]  INFO Using EVENT observer type
[2024-12-30 12:36:57]  INFO Using config from /root/.kube/config
[2024-12-30 12:36:57]  INFO Successfully loaded config. Host: https://api.ocppmx.hop.lab.emc.com:6443
[2024-12-30 12:36:57]  INFO Created new KubeClient
[2024-12-30 12:36:57]  INFO Running 1 iteration(s)
[2024-12-30 12:36:57]  INFO     *** ITERATION NUMBER 1 ***
[2024-12-30 12:36:57]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2024-12-30 12:36:57]  INFO Successfully created namespace volumeio-test-3bae9c6b
[2024-12-30 12:36:57]  INFO Using default number of volumes
[2024-12-30 12:36:57]  INFO Using default image: quay.io/centos/centos:latest
[2024-12-30 12:36:57]  INFO Creating IO pod
[2024-12-30 12:36:57]  INFO Waiting for pod iowriter-test-sml55 to be READY
[2024-12-30 12:37:09]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2024-12-30 12:37:10]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2024-12-30 12:37:13]  INFO Waiting until no Volume Attachments with PV  left
[2024-12-30 12:37:13]  INFO VolumeAttachment deleted
[2024-12-30 12:37:13]  INFO Deleting all resources in namespace volumeio-test-3bae9c6b
[2024-12-30 12:37:27]  INFO Namespace volumeio-test-3bae9c6b was deleted in 14.025339007s
[2024-12-30 12:37:27]  INFO SUCCESS: VolumeIoSuite in 30.064504069s
Collecting metrics
[2024-12-30 12:37:27]  INFO Started generating reports...
1 / 1 [------------------------------------------------------------------------------] 100.00% ? p/s[2024-12-30 12:37:27]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------->] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------] 100.00% 141 p/s[2024-12-30 12:37:27]  WARN No ResourceUsageMetrics provided
[2024-12-30 12:37:27] ERROR no ResourceUsageMetrics provided
report-test-run-cad2fd1c:
Name: test-run-cad2fd1c
Host: https://api.ocppmx.hop.lab.emc.com:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-cad2fd1c/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-cad2fd1c/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-cad2fd1c/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-cad2fd1c/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-cad2fd1c/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2024-12-30 12:36:57.365592884 -0500 -0500
            Ended:     2024-12-30 12:37:27.431654589 -0500 -0500
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 1.935847249s
                        Min: 1.935847249s
                        Max: 1.935847249s
                        Histogram:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.735026837s
                        Min: 2.735026837s
                        Max: 2.735026837s
                        Histogram:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 5.401685368s
                        Min: 5.401685368s
                        Max: 5.401685368s
                        Histogram:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 19.700441ms
                        Min: 19.700441ms
                        Max: 19.700441ms
                        Histogram:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.615952934s
                        Min: 1.615952934s
                        Max: 1.615952934s
                        Histogram:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 11.628982495s
                        Min: 11.628982495s
                        Max: 11.628982495s
                        Histogram:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.627582027s
                        Min: 1.627582027s
                        Max: 1.627582027s
                        Histogram:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-cad2fd1c/VolumeIoSuite1/EntityNumberOverTime.png

[2024-12-30 12:37:27]  INFO Avg time of a run:   15.77s
[2024-12-30 12:37:27]  INFO Avg time of a del:   14.03s
[2024-12-30 12:37:27]  INFO Avg time of all:     30.06s
[2024-12-30 12:37:27]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 12/30/24 12:37:27.946
  STEP:      Executing  Delete custom resource [1] @ 12/30/24 12:37:27.977
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar] @ 12/30/24 12:37:28
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 12/30/24 12:37:28.044
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 12/30/24 12:37:28.089
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 12/30/24 12:37:28.115
  STEP: Ending: Install PowerMax Driver
   @ 12/30/24 12:37:28.187
  STEP: Starting: Install PowerMax Driver(With Observability)  @ 12/30/24 12:37:33.188
  STEP: --no-modules specified, skipping @ 12/30/24 12:37:33.188
  STEP: Ending: Install PowerMax Driver(With Observability)
   @ 12/30/24 12:37:33.188
  STEP: Starting: Install PowerMax Driver (With Auth V1 module)  @ 12/30/24 12:37:33.188
  STEP: --no-modules specified, skipping @ 12/30/24 12:37:33.188
  STEP: Ending: Install PowerMax Driver (With Auth V1 module)
   @ 12/30/24 12:37:33.188
  STEP: Starting: Install Powermax Driver (With Authorization v2)  @ 12/30/24 12:37:33.188
  STEP: No matching tags for scenario @ 12/30/24 12:37:33.188
  STEP: Not tagged for this test run, skipping @ 12/30/24 12:37:33.188
  STEP: Ending: Install Powermax Driver (With Authorization v2)
   @ 12/30/24 12:37:33.188
  STEP: Starting: Install Powermax Driver (With Authorization v2 and Observability)  @ 12/30/24 12:37:33.188
  STEP: No matching tags for scenario @ 12/30/24 12:37:33.188
  STEP: Not tagged for this test run, skipping @ 12/30/24 12:37:33.188
  STEP: Ending: Install Powermax Driver (With Authorization v2 and Observability)
   @ 12/30/24 12:37:33.188
  STEP: Starting: Install Powermax Driver(Standalone), Enable Resiliency  @ 12/30/24 12:37:33.188
  STEP: --no-modules specified, skipping @ 12/30/24 12:37:33.188
  STEP: Ending: Install Powermax Driver(Standalone), Enable Resiliency
   @ 12/30/24 12:37:33.188
  STEP: Starting: Install Powermax Driver(With Resiliency), Disable Resiliency module  @ 12/30/24 12:37:33.188
  STEP: --no-modules specified, skipping @ 12/30/24 12:37:33.188
  STEP: Ending: Install Powermax Driver(With Resiliency), Disable Resiliency module
   @ 12/30/24 12:37:33.188
  STEP: Starting: Install PowerFlex Driver (Standalone) With Node Zoning  @ 12/30/24 12:37:33.188
  STEP: No matching tags for scenario @ 12/30/24 12:37:33.188
  STEP: Not tagged for this test run, skipping @ 12/30/24 12:37:33.188
  STEP: Ending: Install PowerFlex Driver (Standalone) With Node Zoning
   @ 12/30/24 12:37:33.188
• [108.276 seconds]
------------------------------

Ran 1 of 1 Specs in 108.431 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2m31.172900179s
Test Suite Passed
```
