### PR TITLE
Remove redundant volume mount from the pmax driver container

### DIFF
--- a/operatorconfig/driverconfig/powermax/v2.13.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.13.0/node.yaml
@@ -174,9 +174,6 @@ spec:
             - name: pods-path
               mountPath: <KUBELET_CONFIG_DIR>/pods
               mountPropagation: "Bidirectional"
-            - name: csi-path
-              mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
-              mountPropagation: "Bidirectional"
             - name: dev
               mountPath: /dev
             - name: sys


### PR DESCRIPTION
# Description
Extra and unused mount caused mount to double on every pod restart and uninstall/reinstall cycle. This will eventually cause some processes (e.g. system scanners, antivirus) to experience high CPU usage which renders the worker node unusable.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1659 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (see below)
- [X] I have maintained backward compatibility
- [X] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Installed the csi-powermax driver using Operator and uninstalled a few times to validate that the mount is not added. Validated that no mounts build up over time.
- [X] Ran e2e tests for powermax (--pmax).

We could add a test to check every node to validate the fix but given that the mount will no longer be present it may be more work than needed. Ideally we could have a general purpose e2e test that check for uninstall cleanup to cover all Operator installation and uninstallation cases.
