### PR TITLE
[bug-1661]: Use OPA 0.70.0

### DIFF
--- a/samples/authorization/csm_authorization_proxy_server_v1110.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v1110.yaml
@@ -34,7 +34,7 @@ spec:
           tenantService: docker.io/dellemc/csm-authorization-tenant:v1.11.0
           roleService: docker.io/dellemc/csm-authorization-role:v1.11.0
           storageService: docker.io/dellemc/csm-authorization-storage:v1.11.0
-          opa: docker.io/openpolicyagent/opa:latest
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:0.11
           # certificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
           # for self-signed certs, leave empty string

--- a/samples/authorization/csm_authorization_proxy_server_v1120.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v1120.yaml
@@ -34,7 +34,7 @@ spec:
           tenantService: quay.io/dell/container-storage-modules/csm-authorization-tenant:v1.12.0
           roleService: quay.io/dell/container-storage-modules/csm-authorization-role:v1.12.0
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:v1.12.0
-          opa: docker.io/openpolicyagent/opa:latest
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:8.5.7
           # certificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
           # for self-signed certs, leave empty string

--- a/samples/authorization/csm_authorization_proxy_server_v1130.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v1130.yaml
@@ -34,7 +34,7 @@ spec:
           tenantService: quay.io/dell/container-storage-modules/csm-authorization-tenant:v1.13.0
           roleService: quay.io/dell/container-storage-modules/csm-authorization-role:v1.13.0
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:v1.13.0
-          opa: docker.io/openpolicyagent/opa:latest
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:8.5.7
           # certificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
           # for self-signed certs, leave empty string

--- a/samples/authorization/csm_authorization_proxy_server_v200-alpha.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v200-alpha.yaml
@@ -38,7 +38,7 @@ spec:
           roleServiceReplicas: 1
           storageService: docker.io/dellemc/csm-authorization-storage:v2.0.0-alpha
           storageServiceReplicas: 1
-          opa: docker.io/openpolicyagent/opa:latest
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:0.11
           authorizationController: docker.io/dellemc/csm-authorization-controller:v2.0.0-alpha
           authorizationControllerReplicas: 1

--- a/samples/authorization/csm_authorization_proxy_server_v200.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v200.yaml
@@ -38,7 +38,7 @@ spec:
           roleServiceReplicas: 1
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.0.0
           storageServiceReplicas: 1
-          opa: docker.io/openpolicyagent/opa:latest
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:8.5.7
           authorizationController: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.0.0
           authorizationControllerReplicas: 1

--- a/samples/authorization/csm_authorization_proxy_server_v210.yaml
+++ b/samples/authorization/csm_authorization_proxy_server_v210.yaml
@@ -38,7 +38,7 @@ spec:
           roleServiceReplicas: 1
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.1.0
           storageServiceReplicas: 1
-          opa: docker.io/openpolicyagent/opa:latest
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:8.5.7
           authorizationController: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.1.0
           authorizationControllerReplicas: 1

--- a/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server.yaml
+++ b/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server.yaml
@@ -34,7 +34,7 @@ spec:
           tenantService: quay.io/dell/container-storage-modules/csm-authorization-tenant:v1-nightly
           roleService: quay.io/dell/container-storage-modules/csm-authorization-role:v1-nightly
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:v1-nightly
-          opa: openpolicyagent/opa
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: openpolicyagent/kube-mgmt:8.5.7
           # certificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
           # for self-signed certs, leave empty string

--- a/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server_alt_ns.yaml
+++ b/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server_alt_ns.yaml
@@ -34,7 +34,7 @@ spec:
           tenantService: quay.io/dell/container-storage-modules/csm-authorization-tenant:nightly
           roleService: quay.io/dell/container-storage-modules/csm-authorization-role:nightly
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:nightly
-          opa: docker.io/openpolicyagent/opa:latest
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:8.5.7
           # certificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
           # for self-signed certs, leave empty string

--- a/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server_n_minus_1.yaml
+++ b/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server_n_minus_1.yaml
@@ -34,7 +34,7 @@ spec:
           tenantService: quay.io/dell/container-storage-modules/csm-authorization-tenant:v1.12.0
           roleService: quay.io/dell/container-storage-modules/csm-authorization-role:v1.12.0
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:v1.12.0
-          opa: openpolicyagent/opa
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: openpolicyagent/kube-mgmt:8.5.7
           # certificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
           # for self-signed certs, leave empty string

--- a/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server_no_cert.yaml
+++ b/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server_no_cert.yaml
@@ -34,7 +34,7 @@ spec:
           tenantService: quay.io/dell/container-storage-modules/csm-authorization-tenant:v1-nightly
           roleService: quay.io/dell/container-storage-modules/csm-authorization-role:v1-nightly
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:v1-nightly
-          opa: docker.io/openpolicyagent/opa:latest
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: docker.io/openpolicyagent/kube-mgmt:8.5.7
           # certificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
           # for self-signed certs, leave empty string

--- a/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v2_multiple_vaults.yaml
+++ b/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v2_multiple_vaults.yaml
@@ -38,7 +38,7 @@ spec:
           roleServiceReplicas: 1
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:nightly
           storageServiceReplicas: 1
-          opa: openpolicyagent/opa
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: openpolicyagent/kube-mgmt:8.5.7
           authorizationController: quay.io/dell/container-storage-modules/csm-authorization-controller:nightly
           authorizationControllerReplicas: 1

--- a/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v2_proxy_server.yaml
+++ b/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v2_proxy_server.yaml
@@ -38,7 +38,7 @@ spec:
           roleServiceReplicas: 1
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:nightly
           storageServiceReplicas: 1
-          opa: openpolicyagent/opa
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: openpolicyagent/kube-mgmt:8.5.7
           authorizationController: quay.io/dell/container-storage-modules/csm-authorization-controller:nightly
           authorizationControllerReplicas: 1

--- a/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v2_proxy_server_default_redis.yaml
+++ b/tests/e2e/testfiles/authorization-templates/storage_csm_authorization_v2_proxy_server_default_redis.yaml
@@ -38,7 +38,7 @@ spec:
           roleServiceReplicas: 1
           storageService: quay.io/dell/container-storage-modules/csm-authorization-storage:nightly
           storageServiceReplicas: 1
-          opa: openpolicyagent/opa
+          opa: docker.io/openpolicyagent/opa:0.70.0
           opaKubeMgmt: openpolicyagent/kube-mgmt:8.5.7
           authorizationController: quay.io/dell/container-storage-modules/csm-authorization-controller:nightly
           authorizationControllerReplicas: 1


### PR DESCRIPTION
# Description
OPA 1.0.0 fails to parse Authorization policies, so we will use the previous version which works.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1661|

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Ran Authorization e2e and manually verified that policy config maps have correct OPA annotations.

Installed Authorization via the Operator and verified that the policies are successfully parsed.

```
kubectl -n authorization get cm volumes-create -o yaml
...
metadata:
  annotations:
    openpolicyagent.org/kube-mgmt-retries: "0"
    openpolicyagent.org/kube-mgmt-status: '{"status":"ok"}'
```
