### PR TITLE
Add csm namespace label to components

### DIFF
--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -1437,7 +1437,7 @@ func (suite *CSMControllerTestSuite) handleDaemonsetTest(r *ContainerStorageModu
 	daemonset := &appsv1.DaemonSet{}
 	err := suite.fakeClient.Get(ctx, client.ObjectKey{Namespace: suite.namespace, Name: name}, daemonset)
 	assert.Nil(suite.T(), err)
-	daemonset.Spec.Template.Labels = map[string]string{"csm": "csm"}
+	daemonset.Spec.Template.Labels = map[string]string{"csm": "csm", "csmNamespace": suite.namespace}
 
 	r.handleDaemonsetUpdate(daemonset, daemonset)
 
@@ -1465,7 +1465,7 @@ func (suite *CSMControllerTestSuite) handleDeploymentTest(r *ContainerStorageMod
 	deployment := &appsv1.Deployment{}
 	err := suite.fakeClient.Get(ctx, client.ObjectKey{Namespace: suite.namespace, Name: name}, deployment)
 	assert.Nil(suite.T(), err)
-	deployment.Spec.Template.Labels = map[string]string{"csm": "csm"}
+	deployment.Spec.Template.Labels = map[string]string{"csm": "csm", "csmNamespace": suite.namespace}
 
 	r.handleDeploymentUpdate(deployment, deployment)
 
@@ -1493,7 +1493,7 @@ func (suite *CSMControllerTestSuite) handleDaemonsetTestFake(r *ContainerStorage
 	daemonset := &appsv1.DaemonSet{}
 	err := suite.fakeClient.Get(ctx, client.ObjectKey{Namespace: suite.namespace, Name: name}, daemonset)
 	assert.Error(suite.T(), err)
-	daemonset.Spec.Template.Labels = map[string]string{"csm": "csm"}
+	daemonset.Spec.Template.Labels = map[string]string{"csm": "csm", "csmNamespace": suite.namespace}
 
 	r.handleDaemonsetUpdate(daemonset, daemonset)
 
@@ -1521,7 +1521,7 @@ func (suite *CSMControllerTestSuite) handleDeploymentTestFake(r *ContainerStorag
 	deployment := &appsv1.Deployment{}
 	err := suite.fakeClient.Get(ctx, client.ObjectKey{Namespace: suite.namespace, Name: name}, deployment)
 	assert.Error(suite.T(), err)
-	deployment.Spec.Template.Labels = map[string]string{"csm": "csm"}
+	deployment.Spec.Template.Labels = map[string]string{"csm": "csm", "csmNamespace": suite.namespace}
 
 	r.handleDeploymentUpdate(deployment, deployment)
 

--- a/operatorconfig/driverconfig/powerflex/v2.11.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.11.0/controller.yaml
@@ -108,6 +108,7 @@ spec:
     metadata:
       labels:
         name: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerflex/v2.11.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.11.0/node.yaml
@@ -70,6 +70,7 @@ spec:
       labels:
         app: <DriverDefaultReleaseName>-node
         driver.dellemc.com: dell-storage
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerflex/v2.12.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.12.0/controller.yaml
@@ -112,6 +112,7 @@ spec:
     metadata:
       labels:
         name: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerflex/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.12.0/node.yaml
@@ -73,6 +73,7 @@ spec:
       labels:
         app: <DriverDefaultReleaseName>-node
         driver.dellemc.com: dell-storage
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerflex/v2.13.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.13.0/controller.yaml
@@ -112,6 +112,7 @@ spec:
     metadata:
       labels:
         name: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerflex/v2.13.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.13.0/node.yaml
@@ -76,6 +76,7 @@ spec:
       labels:
         app: <DriverDefaultReleaseName>-node
         driver.dellemc.com: dell-storage
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powermax/v2.11.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.11.0/controller.yaml
@@ -126,6 +126,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powermax/v2.11.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.11.0/node.yaml
@@ -73,6 +73,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powermax/v2.12.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/controller.yaml
@@ -126,6 +126,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powermax/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.12.0/node.yaml
@@ -73,6 +73,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powermax/v2.13.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.13.0/controller.yaml
@@ -126,6 +126,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powermax/v2.13.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.13.0/node.yaml
@@ -73,6 +73,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerscale/v2.11.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.11.0/controller.yaml
@@ -117,6 +117,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerscale/v2.11.0/node.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.11.0/node.yaml
@@ -61,6 +61,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerscale/v2.12.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.12.0/controller.yaml
@@ -117,6 +117,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerscale/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.12.0/node.yaml
@@ -61,6 +61,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerscale/v2.13.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.13.0/controller.yaml
@@ -117,6 +117,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerscale/v2.13.0/node.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.13.0/node.yaml
@@ -61,6 +61,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerstore/v2.11.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.11.0/controller.yaml
@@ -117,6 +117,7 @@ spec:
     metadata:
       labels:
         name: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerstore/v2.11.0/node.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.11.0/node.yaml
@@ -77,6 +77,7 @@ spec:
       labels:
         app: <DriverDefaultReleaseName>-node
         driver.dellemc.com: dell-storage
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerstore/v2.12.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.12.0/controller.yaml
@@ -117,6 +117,7 @@ spec:
     metadata:
       labels:
         name: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerstore/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.12.0/node.yaml
@@ -77,6 +77,7 @@ spec:
       labels:
         app: <DriverDefaultReleaseName>-node
         driver.dellemc.com: dell-storage
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerstore/v2.13.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.13.0/controller.yaml
@@ -117,6 +117,7 @@ spec:
     metadata:
       labels:
         name: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/powerstore/v2.13.0/node.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.13.0/node.yaml
@@ -77,6 +77,7 @@ spec:
       labels:
         app: <DriverDefaultReleaseName>-node
         driver.dellemc.com: dell-storage
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/unity/v2.11.0/controller.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/controller.yaml
@@ -106,6 +106,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/unity/v2.11.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.11.0/node.yaml
@@ -63,6 +63,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/unity/v2.12.0/controller.yaml
+++ b/operatorconfig/driverconfig/unity/v2.12.0/controller.yaml
@@ -106,6 +106,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/unity/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.12.0/node.yaml
@@ -63,6 +63,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/unity/v2.13.0/controller.yaml
+++ b/operatorconfig/driverconfig/unity/v2.13.0/controller.yaml
@@ -106,6 +106,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/driverconfig/unity/v2.13.0/node.yaml
+++ b/operatorconfig/driverconfig/unity/v2.13.0/node.yaml
@@ -63,6 +63,7 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         kubectl.kubernetes.io/default-container: driver
     spec:

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.0/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.0/app-mobility-controller-manager.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         control-plane: controller-manager
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.0/node-agent.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.0/node-agent.yaml
@@ -17,6 +17,7 @@ spec:
         csm: application-mobility
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: application-mobility-velero-server-service-account
       terminationGracePeriodSeconds: 3600

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.0/velero-deployment.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.0/velero-deployment.yaml
@@ -105,6 +105,7 @@ spec:
         csm: <NAME>
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8085"

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.1/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.1/app-mobility-controller-manager.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         control-plane: controller-manager
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.1/node-agent.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.1/node-agent.yaml
@@ -17,6 +17,7 @@ spec:
         csm: application-mobility
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: application-mobility-velero-server-service-account
       terminationGracePeriodSeconds: 3600

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.1/velero-deployment.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.1/velero-deployment.yaml
@@ -105,6 +105,7 @@ spec:
         csm: <NAME>
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8085"

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.2/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.2/app-mobility-controller-manager.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         control-plane: controller-manager
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.2/node-agent.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.2/node-agent.yaml
@@ -17,6 +17,7 @@ spec:
         csm: application-mobility
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: application-mobility-velero-server-service-account
       terminationGracePeriodSeconds: 3600

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.2/velero-deployment.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.2/velero-deployment.yaml
@@ -105,6 +105,7 @@ spec:
         csm: <NAME>
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8085"

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.3/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.3/app-mobility-controller-manager.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         control-plane: controller-manager
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.3/node-agent.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.3/node-agent.yaml
@@ -17,6 +17,7 @@ spec:
         csm: application-mobility
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: application-mobility-velero-server-service-account
       terminationGracePeriodSeconds: 3600

--- a/operatorconfig/moduleconfig/application-mobility/v1.0.3/velero-deployment.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.0.3/velero-deployment.yaml
@@ -105,6 +105,7 @@ spec:
         csm: <NAME>
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8085"

--- a/operatorconfig/moduleconfig/application-mobility/v1.1.0/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.1.0/app-mobility-controller-manager.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         control-plane: controller-manager
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/application-mobility/v1.1.0/node-agent.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.1.0/node-agent.yaml
@@ -17,6 +17,7 @@ spec:
         csm: application-mobility
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: application-mobility-velero-server-service-account
       terminationGracePeriodSeconds: 3600

--- a/operatorconfig/moduleconfig/application-mobility/v1.1.0/velero-deployment.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.1.0/velero-deployment.yaml
@@ -105,6 +105,7 @@ spec:
         csm: <NAME>
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8085"

--- a/operatorconfig/moduleconfig/application-mobility/v1.2.0/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.2.0/app-mobility-controller-manager.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         control-plane: controller-manager
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/application-mobility/v1.2.0/node-agent.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.2.0/node-agent.yaml
@@ -17,6 +17,7 @@ spec:
         csm: application-mobility
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: application-mobility-velero-server-service-account
       terminationGracePeriodSeconds: 3600

--- a/operatorconfig/moduleconfig/application-mobility/v1.2.0/velero-deployment.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.2.0/velero-deployment.yaml
@@ -105,6 +105,7 @@ spec:
         csm: <NAME>
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8085"

--- a/operatorconfig/moduleconfig/application-mobility/v1.3.0/app-mobility-controller-manager.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.3.0/app-mobility-controller-manager.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         control-plane: controller-manager
         csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/application-mobility/v1.3.0/node-agent.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.3.0/node-agent.yaml
@@ -17,6 +17,7 @@ spec:
         csm: application-mobility
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: application-mobility-velero-server-service-account
       terminationGracePeriodSeconds: 3600

--- a/operatorconfig/moduleconfig/application-mobility/v1.3.0/velero-deployment.yaml
+++ b/operatorconfig/moduleconfig/application-mobility/v1.3.0/velero-deployment.yaml
@@ -105,6 +105,7 @@ spec:
         csm: <NAME>
         app.kubernetes.io/name: application-mobility-velero
         app.kubernetes.io/instance: application-mobility
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8085"

--- a/operatorconfig/moduleconfig/authorization/v1.11.0/cert-manager.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.11.0/cert-manager.yaml
@@ -849,6 +849,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-cainjector
       securityContext:
@@ -894,6 +895,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "controller"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -947,6 +949,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-webhook
       securityContext:

--- a/operatorconfig/moduleconfig/authorization/v1.11.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.11.0/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         csm: <NAME>
         app: proxy-server
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: proxy-server
@@ -95,6 +96,7 @@ spec:
       labels:
         csm: <NAME>
         app: tenant-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: tenant-service
@@ -180,6 +182,7 @@ spec:
       labels:
         csm: <NAME>
         app: role-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: role-service
       containers:
@@ -277,6 +280,7 @@ spec:
         app: redis
         role: primary
         tier: backend
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: primary
@@ -328,6 +332,7 @@ spec:
         csm: <NAME>
         app: redis-commander
         tier: backend
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: redis-commander

--- a/operatorconfig/moduleconfig/authorization/v1.11.0/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.11.0/nginx-ingress-controller.yaml
@@ -430,6 +430,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/authorization/v1.12.0/cert-manager.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.12.0/cert-manager.yaml
@@ -849,6 +849,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-cainjector
       securityContext:
@@ -894,6 +895,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "controller"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -947,6 +949,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-webhook
       securityContext:

--- a/operatorconfig/moduleconfig/authorization/v1.12.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.12.0/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         csm: <NAME>
         app: proxy-server
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: proxy-server
@@ -95,6 +96,7 @@ spec:
       labels:
         csm: <NAME>
         app: tenant-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: tenant-service
@@ -180,6 +182,7 @@ spec:
       labels:
         csm: <NAME>
         app: role-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: role-service
       containers:
@@ -277,6 +280,7 @@ spec:
         app: redis
         role: primary
         tier: backend
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: primary
@@ -328,6 +332,7 @@ spec:
         csm: <NAME>
         app: redis-commander
         tier: backend
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: redis-commander

--- a/operatorconfig/moduleconfig/authorization/v1.12.0/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.12.0/nginx-ingress-controller.yaml
@@ -430,6 +430,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/authorization/v1.13.0/cert-manager.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.13.0/cert-manager.yaml
@@ -849,6 +849,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-cainjector
       securityContext:
@@ -894,6 +895,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "controller"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -947,6 +949,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-webhook
       securityContext:

--- a/operatorconfig/moduleconfig/authorization/v1.13.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.13.0/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         csm: <NAME>
         app: proxy-server
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: proxy-server
@@ -95,6 +96,7 @@ spec:
       labels:
         csm: <NAME>
         app: tenant-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: tenant-service
@@ -180,6 +182,7 @@ spec:
       labels:
         csm: <NAME>
         app: role-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: role-service
       containers:
@@ -277,6 +280,7 @@ spec:
         app: redis
         role: primary
         tier: backend
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: primary
@@ -328,6 +332,7 @@ spec:
         csm: <NAME>
         app: redis-commander
         tier: backend
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: redis-commander

--- a/operatorconfig/moduleconfig/authorization/v1.13.0/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v1.13.0/nginx-ingress-controller.yaml
@@ -430,6 +430,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/cert-manager.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/cert-manager.yaml
@@ -849,6 +849,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-cainjector
       securityContext:
@@ -894,6 +895,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "controller"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -947,6 +949,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-webhook
       securityContext:

--- a/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/deployment.yaml
@@ -57,6 +57,7 @@ spec:
       labels:
         csm: <NAME>
         app: proxy-server
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: proxy-server
       containers:
@@ -141,6 +142,7 @@ spec:
       labels:
         csm: <NAME>
         app: tenant-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: tenant-service
@@ -235,6 +237,7 @@ spec:
       labels:
         csm: <NAME>
         app: role-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: role-service
       containers:
@@ -443,6 +446,7 @@ spec:
       labels:
         csm: <NAME>
         app: authorization-controller
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: authorization-controller
       containers:
@@ -510,6 +514,7 @@ spec:
       labels:
         csm: <NAME>
         app: <AUTHORIZATION_REDIS_NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       initContainers:
         - name: config
@@ -592,6 +597,7 @@ spec:
         csm: <NAME>
         app: <AUTHORIZATION_REDIS_COMMANDER>
         tier: backend
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: <AUTHORIZATION_REDIS_COMMANDER>
@@ -673,6 +679,7 @@ spec:
       labels:
         csm: <NAME>
         app: <AUTHORIZATION_REDIS_SENTINEL>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       initContainers:
         - name: config

--- a/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0-alpha/nginx-ingress-controller.yaml
@@ -430,6 +430,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/authorization/v2.0.0/cert-manager.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0/cert-manager.yaml
@@ -849,6 +849,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-cainjector
       securityContext:
@@ -894,6 +895,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "controller"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -947,6 +949,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-webhook
       securityContext:

--- a/operatorconfig/moduleconfig/authorization/v2.0.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0/deployment.yaml
@@ -57,6 +57,7 @@ spec:
       labels:
         csm: <NAME>
         app: proxy-server
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: proxy-server
       containers:
@@ -141,6 +142,7 @@ spec:
       labels:
         csm: <NAME>
         app: tenant-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: tenant-service
@@ -235,6 +237,7 @@ spec:
       labels:
         csm: <NAME>
         app: role-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: role-service
       containers:
@@ -446,6 +449,7 @@ spec:
       labels:
         csm: <NAME>
         app: authorization-controller
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: authorization-controller
       containers:
@@ -513,6 +517,7 @@ spec:
       labels:
         csm: <NAME>
         app: <AUTHORIZATION_REDIS_NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       initContainers:
         - name: config
@@ -595,6 +600,7 @@ spec:
         csm: <NAME>
         app: <AUTHORIZATION_REDIS_COMMANDER>
         tier: backend
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: <AUTHORIZATION_REDIS_COMMANDER>
@@ -676,6 +682,7 @@ spec:
       labels:
         csm: <NAME>
         app: <AUTHORIZATION_REDIS_SENTINEL>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       initContainers:
         - name: config

--- a/operatorconfig/moduleconfig/authorization/v2.0.0/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.0.0/nginx-ingress-controller.yaml
@@ -430,6 +430,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/authorization/v2.1.0/cert-manager.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.1.0/cert-manager.yaml
@@ -849,6 +849,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-cainjector
       securityContext:
@@ -894,6 +895,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "controller"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -947,6 +949,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.6.1"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-webhook
       securityContext:

--- a/operatorconfig/moduleconfig/authorization/v2.1.0/deployment.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.1.0/deployment.yaml
@@ -57,6 +57,7 @@ spec:
       labels:
         csm: <NAME>
         app: proxy-server
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: proxy-server
       containers:
@@ -141,6 +142,7 @@ spec:
       labels:
         csm: <NAME>
         app: tenant-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: tenant-service
@@ -235,6 +237,7 @@ spec:
       labels:
         csm: <NAME>
         app: role-service
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: role-service
       containers:
@@ -446,6 +449,7 @@ spec:
       labels:
         csm: <NAME>
         app: authorization-controller
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: authorization-controller
       containers:
@@ -513,6 +517,7 @@ spec:
       labels:
         csm: <NAME>
         app: <AUTHORIZATION_REDIS_NAME>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       initContainers:
         - name: config
@@ -595,6 +600,7 @@ spec:
         csm: <NAME>
         app: <AUTHORIZATION_REDIS_COMMANDER>
         tier: backend
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - name: <AUTHORIZATION_REDIS_COMMANDER>
@@ -676,6 +682,7 @@ spec:
       labels:
         csm: <NAME>
         app: <AUTHORIZATION_REDIS_SENTINEL>
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       initContainers:
         - name: config

--- a/operatorconfig/moduleconfig/authorization/v2.1.0/nginx-ingress-controller.yaml
+++ b/operatorconfig/moduleconfig/authorization/v2.1.0/nginx-ingress-controller.yaml
@@ -430,6 +430,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/name: ingress-nginx
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       containers:
         - args:

--- a/operatorconfig/moduleconfig/common/cert-manager.yaml
+++ b/operatorconfig/moduleconfig/common/cert-manager.yaml
@@ -833,6 +833,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.11.0"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-cainjector
       securityContext:
@@ -887,6 +888,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "controller"
         app.kubernetes.io/version: "v1.11.0"
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -952,6 +954,7 @@ spec:
         app.kubernetes.io/instance: <NAMESPACE>
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.11.0"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: <NAMESPACE>-cert-manager-webhook
       securityContext:

--- a/operatorconfig/moduleconfig/common/cert-manager/cert-manager.yaml
+++ b/operatorconfig/moduleconfig/common/cert-manager/cert-manager.yaml
@@ -853,6 +853,7 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.11.0"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: cert-manager-cainjector
       securityContext:
@@ -907,6 +908,7 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
         app.kubernetes.io/version: "v1.11.0"
+        csmNamespace: <CSM_NAMESPACE>
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -972,6 +974,7 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.11.0"
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: cert-manager-webhook
       securityContext:

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.10.0/controller.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.10.0/controller.yaml
@@ -68,6 +68,7 @@ spec:
     metadata:
       labels:
         name: csipowermax-reverseproxy
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: csipowermax-reverseproxy
       containers:

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.11.0/controller.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.11.0/controller.yaml
@@ -68,6 +68,7 @@ spec:
     metadata:
       labels:
         name: csipowermax-reverseproxy
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: csipowermax-reverseproxy
       containers:

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.12.0/controller.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.12.0/controller.yaml
@@ -68,6 +68,7 @@ spec:
     metadata:
       labels:
         name: csipowermax-reverseproxy
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: csipowermax-reverseproxy
       containers:

--- a/operatorconfig/moduleconfig/replication/v1.10.0/controller.yaml
+++ b/operatorconfig/moduleconfig/replication/v1.10.0/controller.yaml
@@ -244,6 +244,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: dell-replication-controller-sa
       containers:

--- a/operatorconfig/moduleconfig/replication/v1.11.0/controller.yaml
+++ b/operatorconfig/moduleconfig/replication/v1.11.0/controller.yaml
@@ -244,6 +244,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: dell-replication-controller-sa
       containers:

--- a/operatorconfig/moduleconfig/replication/v1.9.0/controller.yaml
+++ b/operatorconfig/moduleconfig/replication/v1.9.0/controller.yaml
@@ -244,6 +244,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        csmNamespace: <CSM_NAMESPACE>
     spec:
       serviceAccountName: dell-replication-controller-sa
       containers:

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -58,6 +58,9 @@ const (
 
 	// CsiDebug -  Debug flag
 	CsiDebug = "<X_CSI_DEBUG>"
+
+	// PowerFlexCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	PowerFlexCSMNameSpace string = "<CSM_NAMESPACE>"
 )
 
 // PrecheckPowerFlex do input validation
@@ -306,6 +309,7 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorController)
 		yamlString = strings.ReplaceAll(yamlString, CsiPowerflexExternalAccess, powerflexExternalAccess)
 		yamlString = strings.ReplaceAll(yamlString, CsiDebug, csiDebug)
+		yamlString = strings.ReplaceAll(yamlString, PowerFlexCSMNameSpace, cr.Namespace)
 
 	case "Node":
 		if cr.Spec.Driver.Node != nil {
@@ -340,6 +344,7 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 		yamlString = strings.ReplaceAll(yamlString, CsiVxflexosMaxVolumesPerNode, maxVolumesPerNode)
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorNode)
 		yamlString = strings.ReplaceAll(yamlString, CsiDebug, csiDebug)
+		yamlString = strings.ReplaceAll(yamlString, PowerFlexCSMNameSpace, cr.Namespace)
 
 	case "CSIDriverSpec":
 		if cr.Spec.Driver.CSIDriverSpec != nil && cr.Spec.Driver.CSIDriverSpec.StorageCapacity {

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -59,6 +59,9 @@ const (
 
 	// CsiPmaxMaxVolumesPerNode - Maximum volumes that the controller can schedule on the node
 	CsiPmaxMaxVolumesPerNode = "<X_CSI_MAX_VOLUMES_PER_NODE>"
+
+	// PowerMaxCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	PowerMaxCSMNameSpace string = "<CSM_NAMESPACE>"
 )
 
 // PrecheckPowerMax do input validation
@@ -214,7 +217,7 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxChap, nodeChap)
 		yamlString = strings.ReplaceAll(yamlString, CsiPmaxMaxVolumesPerNode, maxVolumesPerNode)
 		yamlString = strings.ReplaceAll(yamlString, ReverseProxyTLSSecret, proxyTLSSecret)
-
+		yamlString = strings.ReplaceAll(yamlString, PowerMaxCSMNameSpace, cr.Namespace)
 	case "Controller":
 		if cr.Spec.Driver.Common != nil {
 			for _, env := range cr.Spec.Driver.Common.Envs {
@@ -292,7 +295,7 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxVsphereHost, vsphereHost)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxChap, nodeChap)
 		yamlString = strings.ReplaceAll(yamlString, ReverseProxyTLSSecret, proxyTLSSecret)
-
+		yamlString = strings.ReplaceAll(yamlString, PowerMaxCSMNameSpace, cr.Namespace)
 	case "CSIDriverSpec":
 		if cr.Spec.Driver.CSIDriverSpec != nil && cr.Spec.Driver.CSIDriverSpec.StorageCapacity {
 			storageCapacity = "true"

--- a/pkg/drivers/powerscale.go
+++ b/pkg/drivers/powerscale.go
@@ -36,6 +36,9 @@ const (
 
 	// PowerScaleConfigParamsVolumeMount -
 	PowerScaleConfigParamsVolumeMount = "csi-isilon-config-params" // #nosec G101
+
+	// PowerScaleCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	PowerScaleCSMNameSpace string = "<CSM_NAMESPACE>"
 )
 
 // PrecheckPowerScale do input validation
@@ -185,6 +188,7 @@ func ModifyPowerScaleCR(yamlString string, cr csmv1.ContainerStorageModule, file
 			}
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorController)
+		yamlString = strings.ReplaceAll(yamlString, PowerScaleCSMNameSpace, cr.Namespace)
 	case "Node":
 		if cr.Spec.Driver.Node != nil {
 			for _, env := range cr.Spec.Driver.Node.Envs {
@@ -194,6 +198,7 @@ func ModifyPowerScaleCR(yamlString string, cr csmv1.ContainerStorageModule, file
 			}
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorNode)
+		yamlString = strings.ReplaceAll(yamlString, PowerScaleCSMNameSpace, cr.Namespace)
 	}
 	return yamlString
 }

--- a/pkg/drivers/powerstore.go
+++ b/pkg/drivers/powerstore.go
@@ -56,6 +56,9 @@ const (
 	CsiPowerstoreExternalAccess = "<X_CSI_POWERSTORE_EXTERNAL_ACCESS>"
 	// CsiStorageCapacityEnabled - Storage capacity flag
 	CsiStorageCapacityEnabled = "false"
+
+	// PowerStoreCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	PowerStoreCSMNameSpace string = "<CSM_NAMESPACE>"
 )
 
 // PrecheckPowerStore do input validation
@@ -134,6 +137,7 @@ func ModifyPowerstoreCR(yamlString string, cr csmv1.ContainerStorageModule, file
 		yamlString = strings.ReplaceAll(yamlString, CsiPowerstoreEnableChap, chap)
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorNode)
 		yamlString = strings.ReplaceAll(yamlString, CsiPowerstoreMaxVolumesPerNode, maxVolumesPerNode)
+		yamlString = strings.ReplaceAll(yamlString, PowerStoreCSMNameSpace, cr.Namespace)
 	case "Controller":
 		if cr.Spec.Driver.Controller != nil {
 			for _, env := range cr.Spec.Driver.Controller.Envs {
@@ -151,6 +155,7 @@ func ModifyPowerstoreCR(yamlString string, cr csmv1.ContainerStorageModule, file
 		yamlString = strings.ReplaceAll(yamlString, CsiNfsAcls, nfsAcls)
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorController)
 		yamlString = strings.ReplaceAll(yamlString, CsiPowerstoreExternalAccess, powerstoreExternalAccess)
+		yamlString = strings.ReplaceAll(yamlString, PowerStoreCSMNameSpace, cr.Namespace)
 	case "CSIDriverSpec":
 		if cr.Spec.Driver.CSIDriverSpec != nil && cr.Spec.Driver.CSIDriverSpec.StorageCapacity {
 			storageCapacity = "true"

--- a/pkg/drivers/unity.go
+++ b/pkg/drivers/unity.go
@@ -53,6 +53,9 @@ const (
 
 	// AllowedNetworks - list of networks that can be used for NFS traffic
 	AllowedNetworks = "<X_CSI_ALLOWED_NETWORKS>"
+
+	// UnityCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	UnityCSMNameSpace string = "<CSM_NAMESPACE>"
 )
 
 // PrecheckUnity do input validation
@@ -133,6 +136,7 @@ func ModifyUnityCR(yamlString string, cr csmv1.ContainerStorageModule, fileType 
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorNode)
 		yamlString = strings.ReplaceAll(yamlString, AllowedNetworks, allowedNetworks)
+		yamlString = strings.ReplaceAll(yamlString, UnityCSMNameSpace, cr.Namespace)
 	case "Controller":
 		if cr.Spec.Driver.Controller != nil {
 			for _, env := range cr.Spec.Driver.Controller.Envs {
@@ -142,6 +146,7 @@ func ModifyUnityCR(yamlString string, cr csmv1.ContainerStorageModule, fileType 
 			}
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorController)
+		yamlString = strings.ReplaceAll(yamlString, UnityCSMNameSpace, cr.Namespace)
 	case "CSIDriverSpec":
 		if cr.Spec.Driver.CSIDriverSpec != nil && cr.Spec.Driver.CSIDriverSpec.StorageCapacity {
 			storageCapacity = "true"

--- a/pkg/modules/application_mobility.go
+++ b/pkg/modules/application_mobility.go
@@ -111,6 +111,9 @@ const (
 	AppMobCertManagerComponent = "cert-manager"
 	// AppMobVeleroComponent - velero component
 	AppMobVeleroComponent = "velero"
+
+	// AppMobilityCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	AppMobilityCSMNameSpace string = "<CSM_NAMESPACE>"
 )
 
 // ApplicationMobilityOldVersion - old version of application-mobility, will be filled in checkUpgrade
@@ -185,6 +188,7 @@ func getAppMobCrdDeploy(op utils.OperatorConfig, cr csmv1.ContainerStorageModule
 	yamlString = string(buf)
 
 	yamlString = strings.ReplaceAll(yamlString, AppMobNamespace, cr.Namespace)
+	yamlString = strings.ReplaceAll(yamlString, AppMobilityCSMNameSpace, cr.Namespace)
 
 	return yamlString, nil
 }
@@ -261,6 +265,7 @@ func getAppMobilityModuleDeployment(op utils.OperatorConfig, cr csmv1.ContainerS
 	yamlString = strings.ReplaceAll(yamlString, ControllerImg, controllerImage)
 	yamlString = strings.ReplaceAll(yamlString, ControllerImagePullPolicy, controllerImagePullPolicy)
 	yamlString = strings.ReplaceAll(yamlString, AppMobReplicaCount, replicaCount)
+	yamlString = strings.ReplaceAll(yamlString, AppMobilityCSMNameSpace, cr.Namespace)
 
 	return yamlString, nil
 }
@@ -490,6 +495,7 @@ func getCreateVeleroAccess(op utils.OperatorConfig, cr csmv1.ContainerStorageMod
 	yamlString = strings.ReplaceAll(yamlString, BackupStorageLocation, backupStorageLocationName)
 	yamlString = strings.ReplaceAll(yamlString, AKeyID, accessID)
 	yamlString = strings.ReplaceAll(yamlString, AKey, access)
+	yamlString = strings.ReplaceAll(yamlString, AppMobilityCSMNameSpace, cr.Namespace)
 
 	return yamlString, nil
 }
@@ -671,6 +677,7 @@ func getVelero(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (string
 	yamlString = strings.ReplaceAll(yamlString, AWSInitContainerImage, veleroAWSInitContainerImage)
 	yamlString = strings.ReplaceAll(yamlString, DELLInitContainerName, veleroDELLInitContainerName)
 	yamlString = strings.ReplaceAll(yamlString, DELLInitContainerImage, veleroDELLInitContainerImage)
+	yamlString = strings.ReplaceAll(yamlString, AppMobilityCSMNameSpace, cr.Namespace)
 
 	return yamlString, nil
 }
@@ -719,6 +726,7 @@ func getUseVolumeSnapshot(_ context.Context, op utils.OperatorConfig, cr csmv1.C
 	yamlString = strings.ReplaceAll(yamlString, VolSnapshotlocation, volSnapshotLocationName)
 	yamlString = strings.ReplaceAll(yamlString, ConfigProvider, provider)
 	yamlString = strings.ReplaceAll(yamlString, BackupStorageRegion, backupRegion)
+	yamlString = strings.ReplaceAll(yamlString, AppMobilityCSMNameSpace, cr.Namespace)
 
 	return volSnapshotLocationName, yamlString, nil
 }
@@ -782,6 +790,7 @@ func getBackupStorageLoc(_ context.Context, op utils.OperatorConfig, cr csmv1.Co
 	yamlString = strings.ReplaceAll(yamlString, ConfigProvider, provider)
 	yamlString = strings.ReplaceAll(yamlString, BackupStorageRegion, backupRegion)
 	yamlString = strings.ReplaceAll(yamlString, VeleroCaCert, bucketCacert)
+	yamlString = strings.ReplaceAll(yamlString, AppMobilityCSMNameSpace, cr.Namespace)
 
 	return backupStorageLocationName, yamlString, nil
 }
@@ -860,6 +869,7 @@ func getNodeAgent(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (str
 	yamlString = strings.ReplaceAll(yamlString, VeleroImage, veleroImg)
 	yamlString = strings.ReplaceAll(yamlString, AppMobNamespace, cr.Namespace)
 	yamlString = strings.ReplaceAll(yamlString, VeleroImagePullPolicy, veleroImgPullPolicy)
+	yamlString = strings.ReplaceAll(yamlString, AppMobilityCSMNameSpace, cr.Namespace)
 	return yamlString, nil
 }
 
@@ -898,5 +908,6 @@ func RemoveOldDaemonset(ctx context.Context, op utils.OperatorConfig, oldVersion
 	}
 	yamlString := string(buf)
 	yamlString = strings.ReplaceAll(yamlString, AppMobNamespace, cr.Namespace)
+	yamlString = strings.ReplaceAll(yamlString, AppMobilityCSMNameSpace, cr.Namespace)
 	return applyDeleteObjects(context.Background(), ctrlClient, yamlString, true)
 }

--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -143,6 +143,9 @@ const (
 
 	// AuthCrds - name of authorization crd manifest yaml
 	AuthCrds = "authorization-crds.yaml"
+
+	// AuthCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	AuthCSMNameSpace string = "<CSM_NAMESPACE>"
 )
 
 var (
@@ -292,6 +295,7 @@ func getAuthApplyCR(cr csmv1.ContainerStorageModule, op utils.OperatorConfig) (*
 	YamlString := utils.ModifyCommonCR(string(buf), cr)
 
 	YamlString = strings.ReplaceAll(YamlString, DefaultPluginIdentifier, AuthorizationSupportedDrivers[string(cr.Spec.Driver.CSIDriverType)].PluginIdentifier)
+	YamlString = strings.ReplaceAll(YamlString, AuthCSMNameSpace, cr.Namespace)
 
 	var container acorev1.ContainerApplyConfiguration
 	err = yaml.Unmarshal([]byte(YamlString), &container)
@@ -589,6 +593,7 @@ func getAuthorizationServerDeployment(op utils.OperatorConfig, cr csmv1.Containe
 			YamlString = strings.ReplaceAll(YamlString, AuthLeaderElectionEnabled, strconv.FormatBool(component.LeaderElection))
 			YamlString = strings.ReplaceAll(YamlString, AuthControllerReconcileInterval, component.ControllerReconcileInterval)
 			YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
+			YamlString = strings.ReplaceAll(YamlString, AuthCSMNameSpace, cr.Namespace)
 		}
 
 		// redis component
@@ -599,6 +604,7 @@ func getAuthorizationServerDeployment(op utils.OperatorConfig, cr csmv1.Containe
 			YamlString = strings.ReplaceAll(YamlString, AuthRedisCommander, component.RedisCommander)
 			YamlString = strings.ReplaceAll(YamlString, AuthRedisSentinel, component.Sentinel)
 			YamlString = strings.ReplaceAll(YamlString, AuthRedisReplicas, strconv.Itoa(component.RedisReplicas))
+			YamlString = strings.ReplaceAll(YamlString, AuthCSMNameSpace, cr.Namespace)
 
 			var sentinelValues []string
 			for i := 0; i < component.RedisReplicas; i++ {
@@ -618,6 +624,7 @@ func getAuthorizationServerDeployment(op utils.OperatorConfig, cr csmv1.Containe
 	YamlString = strings.ReplaceAll(YamlString, AuthNamespace, authNamespace)
 	YamlString = strings.ReplaceAll(YamlString, AuthRedisStorageClass, redisStorageClass)
 	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
+	YamlString = strings.ReplaceAll(YamlString, AuthCSMNameSpace, cr.Namespace)
 
 	return YamlString, nil
 }
@@ -1201,6 +1208,7 @@ func getNginxIngressController(op utils.OperatorConfig, cr csmv1.ContainerStorag
 	authNamespace := cr.Namespace
 	YamlString = strings.ReplaceAll(YamlString, AuthNamespace, authNamespace)
 	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
+	YamlString = strings.ReplaceAll(YamlString, AuthCSMNameSpace, cr.Namespace)
 
 	return YamlString, nil
 }
@@ -1375,6 +1383,7 @@ func getAuthCrdDeploy(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) 
 	yamlString = string(buf)
 
 	yamlString = strings.ReplaceAll(yamlString, AuthNamespace, cr.Namespace)
+	yamlString = strings.ReplaceAll(yamlString, AuthCSMNameSpace, cr.Namespace)
 
 	return yamlString, nil
 }

--- a/pkg/modules/commonconfig.go
+++ b/pkg/modules/commonconfig.go
@@ -37,6 +37,8 @@ const (
 	CommonNamespace = "<NAMESPACE>"
 	// CSMName - name
 	CSMName = "<NAME>"
+	// ComConfigCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	ComConfigCSMNameSpace string = "<CSM_NAMESPACE>"
 )
 
 // SupportedDriverParam -
@@ -100,6 +102,7 @@ func getCertManager(op utils.OperatorConfig, cr csmv1.ContainerStorageModule) (s
 	certNamespace := cr.Namespace
 	YamlString = strings.ReplaceAll(YamlString, CommonNamespace, certNamespace)
 	YamlString = strings.ReplaceAll(YamlString, CSMName, cr.Name)
+	YamlString = strings.ReplaceAll(YamlString, ComConfigCSMNameSpace, cr.Namespace)
 
 	return YamlString, nil
 }

--- a/pkg/modules/replication.go
+++ b/pkg/modules/replication.go
@@ -58,6 +58,8 @@ const (
 	DefaultRetryMax = "<RETRY_INTERVAL_MAX>"
 	// DefaultReplicaInitImage -
 	DefaultReplicaInitImage = "<REPLICATION_INIT_IMAGE>"
+	// ReplicationCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
+	ReplicationCSMNameSpace = "<CSM_NAMESPACE>"
 )
 
 var (
@@ -131,6 +133,7 @@ func getReplicaApplyCR(cr csmv1.ContainerStorageModule, op utils.OperatorConfig)
 	YamlString = strings.ReplaceAll(YamlString, DefaultReplicationPrefix, replicationPrefix)
 	YamlString = strings.ReplaceAll(YamlString, DefaultReplicationContextPrefix, replicationContextPrefix)
 	YamlString = strings.ReplaceAll(YamlString, DefaultDriverConfigParamsVolumeMount, ReplicationSupportedDrivers[string(cr.Spec.Driver.CSIDriverType)].DriverConfigParamsVolumeMount)
+	YamlString = strings.ReplaceAll(YamlString, ReplicationCSMNameSpace, cr.Namespace)
 
 	var container acorev1.ContainerApplyConfiguration
 	err = yaml.Unmarshal([]byte(YamlString), &container)
@@ -387,6 +390,7 @@ func getReplicaController(op utils.OperatorConfig, cr csmv1.ContainerStorageModu
 	YamlString = strings.ReplaceAll(YamlString, DefaultReplicaInitImage, replicaInitImage)
 	YamlString = strings.ReplaceAll(YamlString, DefaultRetryMax, retryMax)
 	YamlString = strings.ReplaceAll(YamlString, DefaultRetryMin, retryMin)
+	YamlString = strings.ReplaceAll(YamlString, ReplicationCSMNameSpace, cr.Namespace)
 
 	ctrlObjects, err := utils.GetModuleComponentObj([]byte(YamlString))
 	if err != nil {

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -45,6 +45,7 @@ const (
 	ReverseProxyTLSSecret       = "<X_CSI_REVPROXY_TLS_SECRET>" // #nosec G101
 	ReverseProxyConfigMap       = "<X_CSI_CONFIG_MAP_NAME>"
 	ReverseProxyPort            = "<X_CSI_REVPROXY_PORT>"
+	ReverseProxyCSMNameSpace    = "<CSM_NAMESPACE>"
 )
 
 // var used in deploying reverseproxy
@@ -211,6 +212,7 @@ func getReverseProxyService(op utils.OperatorConfig, cr csmv1.ContainerStorageMo
 	yamlString = strings.ReplaceAll(yamlString, utils.DefaultReleaseName, cr.Name)
 	yamlString = strings.ReplaceAll(yamlString, ReverseProxyPort, proxyPort)
 	yamlString = strings.ReplaceAll(yamlString, utils.DefaultReleaseNamespace, cr.Namespace)
+	yamlString = strings.ReplaceAll(yamlString, ReverseProxyCSMNameSpace, cr.Namespace)
 
 	return yamlString, nil
 }
@@ -260,6 +262,7 @@ func getReverseProxyDeployment(op utils.OperatorConfig, cr csmv1.ContainerStorag
 	YamlString = strings.ReplaceAll(YamlString, ReverseProxyPort, proxyPort)
 	YamlString = strings.ReplaceAll(YamlString, ReverseProxyTLSSecret, proxyTLSSecret)
 	YamlString = strings.ReplaceAll(YamlString, ReverseProxyConfigMap, proxyConfig)
+	YamlString = strings.ReplaceAll(YamlString, ReverseProxyCSMNameSpace, cr.Namespace)
 
 	return YamlString, nil
 }


### PR DESCRIPTION
# Description
Added csmNameSpace label on all the deployment/daemonset for CSM Operator in order to filter CSM related pods from the others

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1668 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
- Manually Tested the fix and also ran e2e tests for drivers 
- Manually Tested the fix for modules and also ran e2e for replication, authorization v1 authorization v2, app mobility

All details are provided in the Jira ECS01C-2
