### PR TITLE
Mount reverse proxy TLS secret within powermax driver container

### DIFF
--- a/operatorconfig/driverconfig/powermax/v2.13.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.13.0/controller.yaml
@@ -300,7 +300,7 @@ spec:
                   name: vcenter-creds
                   optional: true
             - name: X_CSI_REVPROXY_TLS_CERT_DIR
-              value: /app/tls      
+              value: /app/tls
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
@@ -312,7 +312,7 @@ spec:
             - name: powermax-array-config
               mountPath: /powermax-array-config
             - name: tls-secret
-              mountPath: /app/tls  
+              mountPath: /app/tls
       volumes:
         - name: socket-dir
           emptyDir:
@@ -330,4 +330,4 @@ spec:
           emptyDir:
         - name: tls-secret
           secret:
-            secretName: <X_CSI_REVPROXY_TLS_SECRET>   
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>

--- a/operatorconfig/driverconfig/powermax/v2.13.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.13.0/controller.yaml
@@ -299,6 +299,8 @@ spec:
                   key: password
                   name: vcenter-creds
                   optional: true
+            - name: X_CSI_REVPROXY_TLS_CERT_DIR
+              value: /app/tls      
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
@@ -309,6 +311,8 @@ spec:
               mountPath: <DriverDefaultReleaseName>-config-params
             - name: powermax-array-config
               mountPath: /powermax-array-config
+            - name: tls-secret
+              mountPath: /app/tls  
       volumes:
         - name: socket-dir
           emptyDir:
@@ -324,3 +328,6 @@ spec:
             name: powermax-array-config
         - name: cert-dir
           emptyDir:
+        - name: tls-secret
+          secret:
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>   

--- a/operatorconfig/driverconfig/powermax/v2.13.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.13.0/node.yaml
@@ -166,7 +166,7 @@ spec:
                   name: vcenter-creds
                   optional: true
             - name: X_CSI_REVPROXY_TLS_CERT_DIR
-              value: /app/tls      
+              value: /app/tls
           volumeMounts:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com
@@ -279,4 +279,4 @@ spec:
             type: Directory
         - name: tls-secret
           secret:
-            secretName: <X_CSI_REVPROXY_TLS_SECRET>    
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>

--- a/operatorconfig/driverconfig/powermax/v2.13.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.13.0/node.yaml
@@ -165,6 +165,8 @@ spec:
                   key: password
                   name: vcenter-creds
                   optional: true
+            - name: X_CSI_REVPROXY_TLS_CERT_DIR
+              value: /app/tls      
           volumeMounts:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com
@@ -191,6 +193,8 @@ spec:
               mountPath: /powermax-array-config
             - name: node-topology-config
               mountPath: /node-topology-config
+            - name: tls-secret
+              mountPath: /app/tls
         - name: registrar
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
           imagePullPolicy: IfNotPresent
@@ -273,3 +277,6 @@ spec:
           hostPath:
             path: /var/run
             type: Directory
+        - name: tls-secret
+          secret:
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>    

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -32,7 +32,9 @@ import (
 // Constant to be used for powermax deployment
 const (
 	// PowerMaxPluginIdentifier used to identify powermax plugin
-	PowerMaxPluginIdentifier = "powermax"
+	PowerMaxPluginIdentifier     = "powermax"
+	ReverseProxyServerComponent  = "csipowermax-reverseproxy" // #nosec G101
+	RevProxyTLSSecretDefaultName = "csirevproxy-tls-secret"   // #nosec G101
 
 	// PowerMaxConfigParamsVolumeMount used to identify config param volume mount
 	PowerMaxConfigParamsVolumeMount = "powermax-config-params"
@@ -53,6 +55,7 @@ const (
 	CSIPmaxVsphereHostname = "<X_CSI_VSPHERE_HOSTNAME>"
 	CSIPmaxVsphereHost     = "<X_CSI_VCENTER_HOST>"
 	CSIPmaxChap            = "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
+	ReverseProxyTLSSecret  = "<X_CSI_REVPROXY_TLS_SECRET>" // #nosec G101
 
 	// CsiPmaxMaxVolumesPerNode - Maximum volumes that the controller can schedule on the node
 	CsiPmaxMaxVolumesPerNode = "<X_CSI_MAX_VOLUMES_PER_NODE>"
@@ -182,6 +185,17 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 				}
 			}
 		}
+		proxyTLSSecret := RevProxyTLSSecretDefaultName
+		revProxy := cr.GetModule(csmv1.ReverseProxy)
+		for _, component := range revProxy.Components {
+			if component.Name == ReverseProxyServerComponent {
+				for _, env := range component.Envs {
+					if env.Name == "X_CSI_REVPROXY_TLS_SECRET" {
+						proxyTLSSecret = env.Value
+					}
+				}
+			}
+		}
 
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxManagedArray, managedArray)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxEndpoint, endpoint)
@@ -199,6 +213,8 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxVsphereHost, vsphereHost)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxChap, nodeChap)
 		yamlString = strings.ReplaceAll(yamlString, CsiPmaxMaxVolumesPerNode, maxVolumesPerNode)
+		yamlString = strings.ReplaceAll(yamlString, ReverseProxyTLSSecret, proxyTLSSecret)
+
 	case "Controller":
 		if cr.Spec.Driver.Common != nil {
 			for _, env := range cr.Spec.Driver.Common.Envs {
@@ -247,6 +263,19 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 				}
 			}
 		}
+
+		proxyTLSSecret := RevProxyTLSSecretDefaultName
+		revProxy := cr.GetModule(csmv1.ReverseProxy)
+		for _, component := range revProxy.Components {
+			if component.Name == ReverseProxyServerComponent {
+				for _, env := range component.Envs {
+					if env.Name == "X_CSI_REVPROXY_TLS_SECRET" {
+						proxyTLSSecret = env.Value
+					}
+				}
+			}
+		}
+
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxManagedArray, managedArray)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxEndpoint, endpoint)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxClusterPrefix, clusterPrefix)
@@ -262,6 +291,8 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxVsphereHostname, vsphereHostname)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxVsphereHost, vsphereHost)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxChap, nodeChap)
+		yamlString = strings.ReplaceAll(yamlString, ReverseProxyTLSSecret, proxyTLSSecret)
+
 	case "CSIDriverSpec":
 		if cr.Spec.Driver.CSIDriverSpec != nil && cr.Spec.Driver.CSIDriverSpec.StorageCapacity {
 			storageCapacity = "true"

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -314,12 +314,15 @@ func getRevProxyPort(revProxyModule csmv1.Module) string {
 }
 
 func getRevProxyVolumeComp(revProxyModule csmv1.Module) []acorev1.VolumeApplyConfiguration {
-	revProxyConfigMap := RevProxyConfigMapDeafultName
+	revProxyConfigMap, revProxyTLSSecret := RevProxyConfigMapDeafultName, RevProxyTLSSecretDefaultName
 	for _, component := range revProxyModule.Components {
 		if component.Name == ReverseProxyServerComponent {
 			for _, env := range component.Envs {
 				if env.Name == "X_CSI_CONFIG_MAP_NAME" {
 					revProxyConfigMap = env.Value
+				}
+				if env.Name == "X_CSI_REVPROXY_TLS_SECRET" {
+					revProxyTLSSecret = env.Value
 				}
 			}
 		}
@@ -335,8 +338,15 @@ func getRevProxyVolumeComp(revProxyModule csmv1.Module) []acorev1.VolumeApplyCon
 				},
 			},
 		},
+		{
+			Name: &RevProxyTLSSecretVolName,
+			VolumeSourceApplyConfiguration: acorev1.VolumeSourceApplyConfiguration{
+				Secret: &acorev1.SecretVolumeSourceApplyConfiguration{
+					SecretName: &revProxyTLSSecret,
+				},
+			},
+		},
 	}
-
 	return revProxyVolumes
 }
 

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -314,15 +314,12 @@ func getRevProxyPort(revProxyModule csmv1.Module) string {
 }
 
 func getRevProxyVolumeComp(revProxyModule csmv1.Module) []acorev1.VolumeApplyConfiguration {
-	revProxyConfigMap, revProxyTLSSecret := RevProxyConfigMapDeafultName, RevProxyTLSSecretDefaultName
+	revProxyConfigMap := RevProxyConfigMapDeafultName
 	for _, component := range revProxyModule.Components {
 		if component.Name == ReverseProxyServerComponent {
 			for _, env := range component.Envs {
 				if env.Name == "X_CSI_CONFIG_MAP_NAME" {
 					revProxyConfigMap = env.Value
-				}
-				if env.Name == "X_CSI_REVPROXY_TLS_SECRET" {
-					revProxyTLSSecret = env.Value
 				}
 			}
 		}
@@ -335,14 +332,6 @@ func getRevProxyVolumeComp(revProxyModule csmv1.Module) []acorev1.VolumeApplyCon
 				ConfigMap: &acorev1.ConfigMapVolumeSourceApplyConfiguration{
 					LocalObjectReferenceApplyConfiguration: acorev1.LocalObjectReferenceApplyConfiguration{Name: &revProxyConfigMap},
 					Optional:                               &optional,
-				},
-			},
-		},
-		{
-			Name: &RevProxyTLSSecretVolName,
-			VolumeSourceApplyConfiguration: acorev1.VolumeSourceApplyConfiguration{
-				Secret: &acorev1.SecretVolumeSourceApplyConfiguration{
-					SecretName: &revProxyTLSSecret,
 				},
 			},
 		},

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -338,15 +338,23 @@ func getRevProxyVolumeComp(revProxyModule csmv1.Module) []acorev1.VolumeApplyCon
 				},
 			},
 		},
-		{
-			Name: &RevProxyTLSSecretVolName,
-			VolumeSourceApplyConfiguration: acorev1.VolumeSourceApplyConfiguration{
-				Secret: &acorev1.SecretVolumeSourceApplyConfiguration{
-					SecretName: &revProxyTLSSecret,
+	}
+
+	// Volume tls-secret should be added only of version is older than 2.12.0
+	isNewReverProxy, _ := utils.MinVersionCheck("v2.12.0", revProxyModule.ConfigVersion)
+	if revProxyModule.ConfigVersion != "" && !isNewReverProxy {
+		revProxyVolumes = append(revProxyVolumes, []acorev1.VolumeApplyConfiguration{
+			{
+				Name: &RevProxyTLSSecretVolName,
+				VolumeSourceApplyConfiguration: acorev1.VolumeSourceApplyConfiguration{
+					Secret: &acorev1.SecretVolumeSourceApplyConfiguration{
+						SecretName: &revProxyTLSSecret,
+					},
 				},
 			},
-		},
+		}...)
 	}
+
 	return revProxyVolumes
 }
 

--- a/samples/storage_csm_powermax_v2130.yaml
+++ b/samples/storage_csm_powermax_v2130.yaml
@@ -107,7 +107,7 @@ spec:
         #   "false" - TLS certificates will be verified
         # Default value: "true"
         - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
-          value: "true"  
+          value: "true"
         # CSI driver log format
         # Allowed values: "TEXT" or "JSON"
         # Default value: "TEXT"

--- a/samples/storage_csm_powermax_v2130.yaml
+++ b/samples/storage_csm_powermax_v2130.yaml
@@ -97,6 +97,17 @@ spec:
         # Default value: "debug"
         - name: "CSI_LOG_LEVEL"
           value: "info"
+        # "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION" determines if driver is going to skip verification
+        # of TLS certificates while connecting to Unisphere RESTAPI interface
+        # If it is set to false,
+        # then a secret powermax-certs has to be created with a X.509 certificate of CA
+        # which signed the Unisphere certificate
+        # Allowed values:
+        #   "true"  - TLS certificates verification will be skipped
+        #   "false" - TLS certificates will be verified
+        # Default value: "true"
+        - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
+          value: "true"  
         # CSI driver log format
         # Allowed values: "TEXT" or "JSON"
         # Default value: "TEXT"

--- a/samples/storage_csm_powermax_v2130.yaml
+++ b/samples/storage_csm_powermax_v2130.yaml
@@ -97,7 +97,7 @@ spec:
         # Default value: "debug"
         - name: "CSI_LOG_LEVEL"
           value: "info"
-        # "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION" determines if driver is going to skip verification
+        # X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION: It determines if driver is going to skip verification
         # of TLS certificates while connecting to Unisphere RESTAPI interface
         # If it is set to false,
         # then a secret powermax-certs has to be created with a X.509 certificate of CA

--- a/tests/config/driverconfig/powermax/v2.13.0/controller.yaml
+++ b/tests/config/driverconfig/powermax/v2.13.0/controller.yaml
@@ -90,6 +90,10 @@ rules:
   - apiGroups: ["apps"]
     resources: ["replicasets"]
     verbs: ["get"]
+  # Permissions for ReplicationReplicator
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -122,6 +126,8 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-controller
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccount: <DriverDefaultReleaseName>-controller
       affinity:
@@ -238,7 +244,7 @@ spec:
             - name: CSI_ENDPOINT
               value: /var/run/csi/csi.sock
             - name: X_CSI_K8S_CLUSTER_PREFIX
-              value: "<X_CSI_K8S_CLUSTER_PREFIX>"
+              value: "CSM"
             - name: X_CSI_MODE
               value: controller
             - name: X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION
@@ -265,14 +271,12 @@ spec:
               value: "<X_CSI_IG_NODENAME_TEMPLATE>"
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
-            - name: X_CSI_REPLICATION_CONTEXT_PREFIX
-              value: powermax/
-            - name: X_CSI_REPLICATION_PREFIX
-              value: replication.storage.dell.com/
             - name: X_CSI_UNISPHERE_TIMEOUT
               value: 5m
             - name: X_CSI_POWERMAX_CONFIG_PATH
               value: /powermax-config-params/driver-config-params.yaml
+            - name: X_CSI_POWERMAX_ARRAY_CONFIG_PATH
+              value: /powermax-array-config/powermax-array-config.yaml
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
             - name: X_CSI_VSPHERE_ENABLED
@@ -295,6 +299,8 @@ spec:
                   key: password
                   name: vcenter-creds
                   optional: true
+            - name: X_CSI_REVPROXY_TLS_CERT_DIR
+              value: /app/tls      
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
@@ -302,7 +308,11 @@ spec:
               mountPath: /certs
               readOnly: true
             - name: powermax-config-params
-              mountPath: /csi-powermax-config-params
+              mountPath: <DriverDefaultReleaseName>-config-params
+            - name: powermax-array-config
+              mountPath: /powermax-array-config
+            - name: tls-secret
+              mountPath: /app/tls  
       volumes:
         - name: socket-dir
           emptyDir:
@@ -313,5 +323,11 @@ spec:
         - name: powermax-config-params
           configMap:
             name: <DriverDefaultReleaseName>-config-params
+        - name: powermax-array-config
+          configMap:
+            name: powermax-array-config
         - name: cert-dir
           emptyDir:
+        - name: tls-secret
+          secret:
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>   

--- a/tests/config/driverconfig/powermax/v2.13.0/controller.yaml
+++ b/tests/config/driverconfig/powermax/v2.13.0/controller.yaml
@@ -300,7 +300,7 @@ spec:
                   name: vcenter-creds
                   optional: true
             - name: X_CSI_REVPROXY_TLS_CERT_DIR
-              value: /app/tls      
+              value: /app/tls
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
@@ -312,7 +312,7 @@ spec:
             - name: powermax-array-config
               mountPath: /powermax-array-config
             - name: tls-secret
-              mountPath: /app/tls  
+              mountPath: /app/tls
       volumes:
         - name: socket-dir
           emptyDir:
@@ -330,4 +330,4 @@ spec:
           emptyDir:
         - name: tls-secret
           secret:
-            secretName: <X_CSI_REVPROXY_TLS_SECRET>   
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>

--- a/tests/config/driverconfig/powermax/v2.13.0/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.13.0/node.yaml
@@ -166,7 +166,7 @@ spec:
                   name: vcenter-creds
                   optional: true
             - name: X_CSI_REVPROXY_TLS_CERT_DIR
-              value: /app/tls      
+              value: /app/tls
           volumeMounts:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com
@@ -279,4 +279,4 @@ spec:
             type: Directory
         - name: tls-secret
           secret:
-            secretName: <X_CSI_REVPROXY_TLS_SECRET>    
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>

--- a/tests/config/driverconfig/powermax/v2.13.0/node.yaml
+++ b/tests/config/driverconfig/powermax/v2.13.0/node.yaml
@@ -73,6 +73,8 @@ spec:
     metadata:
       labels:
         app: <DriverDefaultReleaseName>-node
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
     spec:
       serviceAccount: <DriverDefaultReleaseName>-node
       # nodeSelector:
@@ -95,7 +97,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://<KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com/csi_sock
             - name: X_CSI_K8S_CLUSTER_PREFIX
-              value: "<X_CSI_K8S_CLUSTER_PREFIX>"
+              value: "CSM"
             - name: X_CSI_MODE
               value: node
             - name: X_CSI_PRIVATE_MOUNT_DIR
@@ -129,6 +131,8 @@ spec:
               value: /certs
             - name: X_CSI_POWERMAX_CONFIG_PATH
               value: /powermax-config-params/driver-config-params.yaml
+            - name: X_CSI_POWERMAX_ARRAY_CONFIG_PATH
+              value: /powermax-array-config/powermax-array-config.yaml
             - name: X_CSI_POWERMAX_TOPOLOGY_CONFIG_PATH
               value: /node-topology-config/topologyConfig.yaml
             - name: X_CSI_IG_NODENAME_TEMPLATE
@@ -137,6 +141,8 @@ spec:
               value: "<X_CSI_IG_MODIFY_HOSTNAME>"
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_MAX_VOLUMES_PER_NODE
+              value: "<X_CSI_MAX_VOLUMES_PER_NODE>"
             - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
               value: "<X_CSI_TOPOLOGY_CONTROL_ENABLED>"
             - name: X_CSI_VSPHERE_ENABLED
@@ -145,6 +151,8 @@ spec:
               value: "<X_CSI_VSPHERE_PORTGROUP>"
             - name: X_CSI_VCENTER_HOST
               value: "<X_CSI_VCENTER_HOST>"
+            - name: X_CSI_VSPHERE_HOSTNAME
+              value: "<X_CSI_VSPHERE_HOSTNAME>"
             - name: X_CSI_VCENTER_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -157,11 +165,14 @@ spec:
                   key: password
                   name: vcenter-creds
                   optional: true
+            - name: X_CSI_REVPROXY_TLS_CERT_DIR
+              value: /app/tls      
           volumeMounts:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com
             - name: volumedevices-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices
+              mountPropagation: "Bidirectional"
             - name: pods-path
               mountPath: <KUBELET_CONFIG_DIR>/pods
               mountPropagation: "Bidirectional"
@@ -178,8 +189,12 @@ spec:
               readOnly: true
             - name: powermax-config-params
               mountPath: /powermax-config-params
+            - name: powermax-array-config
+              mountPath: /powermax-array-config
             - name: node-topology-config
               mountPath: /node-topology-config
+            - name: tls-secret
+              mountPath: /app/tls
         - name: registrar
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
           imagePullPolicy: IfNotPresent
@@ -213,6 +228,9 @@ spec:
           hostPath:
             path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices
             type: DirectoryOrCreate
+        - name: csi-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
         - name: pods-path
           hostPath:
             path: <KUBELET_CONFIG_DIR>/pods
@@ -240,7 +258,25 @@ spec:
         - name: powermax-config-params
           configMap:
             name: <DriverDefaultReleaseName>-config-params
+        - name: powermax-array-config
+          configMap:
+            name: powermax-array-config
         - name: node-topology-config
           configMap:
             name: node-topology-config
             optional: true
+        - name: kubelet-pods
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: usr-bin
+          hostPath:
+            path: /usr/bin
+            type: Directory
+        - name: var-run
+          hostPath:
+            path: /var/run
+            type: Directory
+        - name: tls-secret
+          secret:
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>    

--- a/tests/e2e/steps/steps_runner.go
+++ b/tests/e2e/steps/steps_runner.go
@@ -88,6 +88,7 @@ func StepRunnerInit(runner *Runner, ctrlClient client.Client, clientSet *kuberne
 	runner.addStep(`^Delete Authorization CRDs \[(\d+)\]$`, step.deleteCustomResourceDefinition)
 	runner.addStep(`^Set up application mobility CR \[([^"]*)\]$`, step.configureAMInstall)
 	runner.addStep(`^Set up reverse proxy tls secret namespace \[([^"]*)\]`, step.setUpReverseProxy)
+	runner.addStep(`^Set up reverse proxy tls secret with SAN namespace \[([^"]*)\]`, step.setUpTLSSecretWithSAN)
 }
 
 func (runner *Runner) addStep(expr string, stepFunc interface{}) {

--- a/tests/e2e/testfiles/powermax-templates/san.cnf
+++ b/tests/e2e/testfiles/powermax-templates/san.cnf
@@ -1,0 +1,17 @@
+[ req ]
+default_bits       = 2048
+distinguished_name = req_distinguished_name
+req_extensions     = v3_req
+prompt             = no
+
+[ req_distinguished_name ]
+C  = XX
+L  = Default City
+O  = Default Company Ltd
+
+[ v3_req ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = "csipowermax-reverseproxy"
+IP.1 = "0.0.0.0"

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1816,6 +1816,34 @@
       run:
         - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
+- scenario: "Install PowerMax Driver with TLS (Standalone)"
+  paths:
+    - "testfiles/storage_csm_powermax_tls.yaml"
+  tags:
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up reverse proxy tls secret with SAN namespace [powermax]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Run custom test"
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar]"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
+    - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
+
 - scenario: "Install PowerMax Driver(Sidecar)"
   paths:
     - "testfiles/storage_csm_powermax_sidecar.yaml"
@@ -1825,6 +1853,35 @@
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
     - "Set up reverse proxy tls secret namespace [powermax]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
+    - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Run custom test"
+    # Last two steps perform Clean Up
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar]"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
+    - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
+
+- scenario: "Install PowerMax Driver with TLS (Sidecar)"
+  paths:
+    - "testfiles/storage_csm_powermax_sidecar_tls.yaml"
+  tags:
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up reverse proxy tls secret with SAN namespace [powermax]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds]"
     - "Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar]"
     - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"

--- a/tests/e2e/testfiles/storage_csm_powermax.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax.yaml
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powermax"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -31,19 +32,18 @@ spec:
       #   true: enable storage capacity tracking
       #   false: disable storage capacity tracking
       storageCapacity: true
-    # Config version for CSI PowerMax v2.13.0 driver
     configVersion: v2.13.0
     # replica: Define the number of PowerMax controller nodes
     # to deploy to the Kubernetes release
+    # Controller count
     # Allowed values: n, where n > 0
-    # Default value: None
+    # Default value: 2
     replicas: 2
     # Default credential secret for Powermax, if not set it to ""
     authSecret: powermax-creds
     dnsPolicy: ClusterFirstWithHostNet
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerMax driver v2.12.0
       image: quay.io/dell/container-storage-modules/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
@@ -92,6 +92,27 @@ spec:
         # Default value: "" <empty>
         - name: "X_CSI_VCENTER_HOST"
           value: ""
+        # CSI driver log level
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "debug"
+        - name: "CSI_LOG_LEVEL"
+          value: "info"
+        # X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION: It determines if driver is going to skip verification
+        # of TLS certificates while connecting to Unisphere RESTAPI interface
+        # If it is set to false,
+        # then a secret powermax-certs has to be created with a X.509 certificate of CA
+        # which signed the Unisphere certificate
+        # Allowed values:
+        #   "true"  - TLS certificates verification will be skipped
+        #   "false" - TLS certificates will be verified
+        # Default value: "true"
+        - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
+          value: "true"  
+        # CSI driver log format
+        # Allowed values: "TEXT" or "JSON"
+        # Default value: "TEXT"
+        - name: "CSI_LOG_FORMAT"
+          value: "TEXT"
     controller:
       envs:
         # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition
@@ -193,6 +214,7 @@ spec:
       - name: csi-metadata-retriever
         image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
       # health monitor is disabled by default, refer to driver documentation before enabling it
+      # Default monitor-interval: 60s
       - name: external-health-monitor
         enabled: false
         args: ["--monitor-interval=60s"]
@@ -205,12 +227,11 @@ spec:
   modules:
     # CSI Powermax Reverseproxy is a mandatory module for Powermax
     - name: csireverseproxy
-      configVersion: v2.11.0
+      configVersion: v2.12.0
       components:
         - name: csipowermax-reverseproxy
           # image: Define the container images used for the reverse proxy
           # Default value: None
-          # Example: "csipowermax-reverseproxy:v2.9.1"
           image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
           imagePullPolicy: Always
           envs:

--- a/tests/e2e/testfiles/storage_csm_powermax.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax.yaml
@@ -107,7 +107,7 @@ spec:
         #   "false" - TLS certificates will be verified
         # Default value: "true"
         - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
-          value: "true"  
+          value: "true"
         # CSI driver log format
         # Allowed values: "TEXT" or "JSON"
         # Default value: "TEXT"

--- a/tests/e2e/testfiles/storage_csm_powermax_sidecar_tls.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_sidecar_tls.yaml
@@ -107,7 +107,7 @@ spec:
         #   "false" - TLS certificates will be verified
         # Default value: "true"
         - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
-          value: "false"  
+          value: "false"
         # CSI driver log format
         # Allowed values: "TEXT" or "JSON"
         # Default value: "TEXT"

--- a/tests/e2e/testfiles/storage_csm_powermax_sidecar_tls.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_sidecar_tls.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powermax"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -31,10 +32,10 @@ spec:
       #   true: enable storage capacity tracking
       #   false: disable storage capacity tracking
       storageCapacity: true
-    # Config version for CSI PowerMax v2.13.0 driver
     configVersion: v2.13.0
     # replica: Define the number of PowerMax controller nodes
     # to deploy to the Kubernetes release
+    # Controller count
     # Allowed values: n, where n > 0
     # Default value: 2
     replicas: 2
@@ -43,7 +44,6 @@ spec:
     dnsPolicy: ClusterFirstWithHostNet
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerMax driver v2.12.0
       image: quay.io/dell/container-storage-modules/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
@@ -107,7 +107,7 @@ spec:
         #   "false" - TLS certificates will be verified
         # Default value: "true"
         - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
-          value: "true"
+          value: "false"  
         # CSI driver log format
         # Allowed values: "TEXT" or "JSON"
         # Default value: "TEXT"
@@ -202,7 +202,7 @@ spec:
       # 'csivol' represents a string prepended to each volume created by the CSI driver
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-        args: [ "--volume-name-prefix=csivol" ]
+        args: ["--volume-name-prefix=csivol"]
       - name: attacher
         image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
       - name: registrar
@@ -214,9 +214,10 @@ spec:
       - name: csi-metadata-retriever
         image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
       # health monitor is disabled by default, refer to driver documentation before enabling it
+      # Default monitor-interval: 60s
       - name: external-health-monitor
         enabled: false
-        args: [ "--monitor-interval=60s" ]
+        args: ["--monitor-interval=60s"]
         image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
         # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
         # Configure only when the storageCapacity is set as "true"
@@ -231,7 +232,6 @@ spec:
         - name: csipowermax-reverseproxy
           # image: Define the container images used for the reverse proxy
           # Default value: None
-          # Example: "csipowermax-reverseproxy:v2.9.1"
           image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
           imagePullPolicy: Always
           envs:

--- a/tests/e2e/testfiles/storage_csm_powermax_tls.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_tls.yaml
@@ -107,7 +107,7 @@ spec:
         #   "false" - TLS certificates will be verified
         # Default value: "true"
         - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
-          value: "false"  
+          value: "false"
         # CSI driver log format
         # Allowed values: "TEXT" or "JSON"
         # Default value: "TEXT"

--- a/tests/e2e/testfiles/storage_csm_powermax_tls.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_tls.yaml
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powermax"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -31,10 +32,10 @@ spec:
       #   true: enable storage capacity tracking
       #   false: disable storage capacity tracking
       storageCapacity: true
-    # Config version for CSI PowerMax v2.13.0 driver
     configVersion: v2.13.0
     # replica: Define the number of PowerMax controller nodes
     # to deploy to the Kubernetes release
+    # Controller count
     # Allowed values: n, where n > 0
     # Default value: 2
     replicas: 2
@@ -43,7 +44,6 @@ spec:
     dnsPolicy: ClusterFirstWithHostNet
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerMax driver v2.12.0
       image: quay.io/dell/container-storage-modules/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
@@ -107,7 +107,7 @@ spec:
         #   "false" - TLS certificates will be verified
         # Default value: "true"
         - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
-          value: "true"
+          value: "false"  
         # CSI driver log format
         # Allowed values: "TEXT" or "JSON"
         # Default value: "TEXT"
@@ -202,7 +202,7 @@ spec:
       # 'csivol' represents a string prepended to each volume created by the CSI driver
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-        args: [ "--volume-name-prefix=csivol" ]
+        args: ["--volume-name-prefix=csivol"]
       - name: attacher
         image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
       - name: registrar
@@ -214,9 +214,10 @@ spec:
       - name: csi-metadata-retriever
         image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
       # health monitor is disabled by default, refer to driver documentation before enabling it
+      # Default monitor-interval: 60s
       - name: external-health-monitor
         enabled: false
-        args: [ "--monitor-interval=60s" ]
+        args: ["--monitor-interval=60s"]
         image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
         # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
         # Configure only when the storageCapacity is set as "true"
@@ -231,7 +232,6 @@ spec:
         - name: csipowermax-reverseproxy
           # image: Define the container images used for the reverse proxy
           # Default value: None
-          # Example: "csipowermax-reverseproxy:v2.9.1"
           image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
           imagePullPolicy: Always
           envs:
@@ -249,4 +249,48 @@ spec:
             # set it true, if csm-auth is enabled / you want it as a sidecar container
             # set it false, if you want it as a deployment
             - name: "DeployAsSidecar"
-              value: "true"
+              value: "false"
+    - name: resiliency
+      # enabled: Enable/Disable Resiliency feature
+      # Allowed values:
+      #   true: enable Resiliency feature(deploy podmon sidecar)
+      #   false: disable Resiliency feature(do not deploy podmon sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.12.0
+      components:
+        - name: podmon-controller
+          image: quay.io/dell/container-storage-modules/podmon:nightly
+          imagePullPolicy: Always
+          args:
+            - "--labelvalue=csi-powermax"
+            - "--arrayConnectivityPollRate=60"
+            - "--skipArrayConnectionValidation=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityConnectionLossThreshold=3"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/run/csi/csi.sock"
+            - "--mode=controller"
+            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
+            - "--driverPath=csi-powermax.dellemc.com"
+        - name: podmon-node
+          image: quay.io/dell/container-storage-modules/podmon:nightly
+          imagePullPolicy: Always
+          envs:
+            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
+            # Allowed values: Any valid and free port (string)
+            # Default value: 8083
+            - name: "X_CSI_PODMON_API_PORT"
+              value: "8083"
+          args:
+            - "--labelvalue=csi-powermax"
+            - "--arrayConnectivityPollRate=60"
+            - "--leaderelection=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/lib/kubelet/plugins/powermax.emc.dell.com/csi_sock"
+            - "--mode=node"
+            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
+            - "--driverPath=csi-powermax.dellemc.com"


### PR DESCRIPTION
# Description
Update operator to mount the reverse proxy TLS secret within the powermax driver container. This PR resolves the `cannot validate certificate for 0.0.0.0 because it doesn't contain any IP SANs` error when `skipCertificateValidation` is set to `false`.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#1571 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Deployed the driver with reverse proxy configured as a sidecar and skip certificate validation set to false, then successfully executed the cert-csi scale test.
- [x] Deployed the driver with reverse proxy configured as a sidecar and skip certificate validation set to true, then successfully executed the cert-csi scale test.
- [x] Deployed the driver with reverse proxy configured as a deployment and skip certificate validation set to false, then successfully executed the cert-csi scale test.
- [x] Deployed the driver with reverse proxy configured as a deployment and skip certificate validation set to true, then successfully executed the cert-csi scale test.
- [x] Successful run of Operator E2E on PowerMax without modules
![image](https://github.com/user-attachments/assets/76e82bc8-8399-49a3-905a-f61cba479b37)


