### PR TITLE
[Bug Fix]: Minimal manifest image pull issue

### DIFF
--- a/operatorconfig/moduleconfig/common/version-values.yaml
+++ b/operatorconfig/moduleconfig/common/version-values.yaml
@@ -56,7 +56,7 @@ powermax:
     observability: "v1.10.0"
     resiliency: "v1.11.0"
   v2.13.0:
-    csireverseproxy: "v2.12go .0"
+    csireverseproxy: "v2.12.0"
     authorization: "v2.1.0"
     replication: "v1.11.0"
     observability: "v1.11.0"

--- a/operatorconfig/moduleconfig/common/version-values.yaml
+++ b/operatorconfig/moduleconfig/common/version-values.yaml
@@ -56,6 +56,7 @@ powermax:
     observability: "v1.10.0"
     resiliency: "v1.11.0"
   v2.13.0:
+    csireverseproxy: "v2.12go .0"
     authorization: "v2.1.0"
     replication: "v1.11.0"
     observability: "v1.11.0"

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.12.0/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.12.0/container.yaml
@@ -1,5 +1,5 @@
 name: reverseproxy
-image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:v2.12.0
+image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
 imagePullPolicy: Always
 env:
   - name: X_CSI_REVPROXY_CONFIG_DIR

--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -100,13 +100,15 @@ func GetController(ctx context.Context, cr csmv1.ContainerStorageModule, operato
 	for i, c := range containers {
 		if c.Name != nil && string(*c.Name) == "driver" {
 			// Check if Common is not nil before accessing Envs
-			if cr.Spec.Driver.Common != nil && cr.Spec.Driver.Controller != nil {
-				containers[i].Env = utils.ReplaceAllApplyCustomEnvs(c.Env, cr.Spec.Driver.Common.Envs, cr.Spec.Driver.Controller.Envs)
-				c.Env = containers[i].Env
-				if string(cr.Spec.Driver.Common.Image) != "" {
+			if cr.Spec.Driver.Common != nil {
+				if cr.Spec.Driver.Common.Image != "" {
 					image := string(cr.Spec.Driver.Common.Image)
 					c.Image = &image
 				}
+			}
+			if cr.Spec.Driver.Controller != nil {
+				containers[i].Env = utils.ReplaceAllApplyCustomEnvs(c.Env, cr.Spec.Driver.Common.Envs, cr.Spec.Driver.Controller.Envs)
+				c.Env = containers[i].Env
 			}
 		}
 


### PR DESCRIPTION
# Description
The CSM deployment minimal file was encountering issues while pulling the specified image from the registry,
caused by this change: https://github.com/dell/csm-operator/blob/0d79b9f1e2824d9a2b1501ed10eb79a3ba3b0bea/pkg/drivers/commonconfig.go#L103
Small fix in code is added to resolve it

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1633|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Deployed Powermax, powerstore, unity and powerscale with the minimal sample
- [ ] Test B
