### PR TITLE
Add prefix for SRDF Metro to work after CSI driver installation

### DIFF
--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -40,22 +40,24 @@ const (
 	PowerMaxConfigParamsVolumeMount = "powermax-config-params"
 
 	// CSIPmaxManagedArray and following  used for replacing user values in config files
-	CSIPmaxManagedArray    = "<X_CSI_MANAGED_ARRAY>"
-	CSIPmaxEndpoint        = "<X_CSI_POWERMAX_ENDPOINT>"
-	CSIPmaxClusterPrefix   = "<X_CSI_K8S_CLUSTER_PREFIX>"
-	CSIPmaxDebug           = "<X_CSI_POWERMAX_DEBUG>"
-	CSIPmaxPortGroup       = "<X_CSI_POWERMAX_PORTGROUPS>"
-	CSIPmaxProtocol        = "<X_CSI_TRANSPORT_PROTOCOL>"
-	CSIPmaxNodeTemplate    = "<X_CSI_IG_NODENAME_TEMPLATE>"
-	CSIPmaxModifyHostname  = "<X_CSI_IG_MODIFY_HOSTNAME>"
-	CSIPmaxHealthMonitor   = "<X_CSI_HEALTH_MONITOR_ENABLED>"
-	CSIPmaxTopology        = "<X_CSI_TOPOLOGY_CONTROL_ENABLED>"
-	CSIPmaxVsphere         = "<X_CSI_VSPHERE_ENABLED>"
-	CSIPmaxVspherePG       = "<X_CSI_VSPHERE_PORTGROUP>"
-	CSIPmaxVsphereHostname = "<X_CSI_VSPHERE_HOSTNAME>"
-	CSIPmaxVsphereHost     = "<X_CSI_VCENTER_HOST>"
-	CSIPmaxChap            = "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
-	ReverseProxyTLSSecret  = "<X_CSI_REVPROXY_TLS_SECRET>" // #nosec G101
+	CSIPmaxManagedArray             = "<X_CSI_MANAGED_ARRAY>"
+	CSIPmaxEndpoint                 = "<X_CSI_POWERMAX_ENDPOINT>"
+	CSIPmaxClusterPrefix            = "<X_CSI_K8S_CLUSTER_PREFIX>"
+	CSIPmaxDebug                    = "<X_CSI_POWERMAX_DEBUG>"
+	CSIPmaxPortGroup                = "<X_CSI_POWERMAX_PORTGROUPS>"
+	CSIPmaxProtocol                 = "<X_CSI_TRANSPORT_PROTOCOL>"
+	CSIPmaxNodeTemplate             = "<X_CSI_IG_NODENAME_TEMPLATE>"
+	CSIPmaxModifyHostname           = "<X_CSI_IG_MODIFY_HOSTNAME>"
+	CSIPmaxReplicationContextPrefix = "<X_CSI_REPLICATION_CONTEXT_PREFIX>"
+	CSIPmaxReplicationPrefix        = "<X_CSI_REPLICATION_PREFIX>"
+	CSIPmaxHealthMonitor            = "<X_CSI_HEALTH_MONITOR_ENABLED>"
+	CSIPmaxTopology                 = "<X_CSI_TOPOLOGY_CONTROL_ENABLED>"
+	CSIPmaxVsphere                  = "<X_CSI_VSPHERE_ENABLED>"
+	CSIPmaxVspherePG                = "<X_CSI_VSPHERE_PORTGROUP>"
+	CSIPmaxVsphereHostname          = "<X_CSI_VSPHERE_HOSTNAME>"
+	CSIPmaxVsphereHost              = "<X_CSI_VCENTER_HOST>"
+	CSIPmaxChap                     = "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
+	ReverseProxyTLSSecret           = "<X_CSI_REVPROXY_TLS_SECRET>" // #nosec G101
 
 	// CsiPmaxMaxVolumesPerNode - Maximum volumes that the controller can schedule on the node
 	CsiPmaxMaxVolumesPerNode = "<X_CSI_MAX_VOLUMES_PER_NODE>"
@@ -115,6 +117,8 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 	protocol := ""
 	nodeTemplate := ""
 	modifyHostname := "false"
+	replicationContextPrefix := "powermax"
+	replicationPrefix := "replication.storage.dell.com"
 	nodeTopology := "false"
 	vsphereEnabled := "false"
 	vspherePG := ""
@@ -254,6 +258,12 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 				if env.Name == "X_CSI_IG_MODIFY_HOSTNAME" {
 					modifyHostname = env.Value
 				}
+				if env.Name == "X_CSI_REPLICATION_CONTEXT_PREFIX" {
+					replicationContextPrefix = env.Value
+				}
+				if env.Name == "X_CSI_REPLICATION_PREFIX" {
+					replicationContextPrefix = env.Value
+				}
 				if env.Name == "X_CSI_IG_NODENAME_TEMPLATE" {
 					nodeTemplate = env.Value
 				}
@@ -287,6 +297,8 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxProtocol, protocol)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxNodeTemplate, nodeTemplate)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxModifyHostname, modifyHostname)
+		yamlString = strings.ReplaceAll(yamlString, CSIPmaxReplicationContextPrefix, replicationContextPrefix)
+		yamlString = strings.ReplaceAll(yamlString, CSIPmaxReplicationPrefix, replicationPrefix)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxHealthMonitor, ctrlHealthMonitor)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxTopology, nodeTopology)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxVsphere, vsphereEnabled)


### PR DESCRIPTION
# Description
By default, when deployed with the CSM Operator PowerMax Metro fails.

This is something enabled by default in the helm deployment : https://github.com/dell/helm-charts/blob/main/charts/csi-powermax/templates/controller.yaml#L452

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|  ECS01D-4 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
I have not build the Docker image for the Operator and try a complete functional testing.
Please reach out to me on Slack so I can understand the process and do that test as well
