### PR TITLE
Add PowerMax Mount Credentials Support

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -228,10 +228,6 @@ type Driver struct {
 	// ForceRemoveDriver is the boolean flag used to remove driver deployment when CR is deleted
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Force Remove Driver"
 	ForceRemoveDriver *bool `json:"forceRemoveDriver,omitempty" yaml:"forceRemoveDriver"`
-
-	// ReverseProxySecret is the name of the reverse proxy credentials secret
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Reverse Proxy Secret"
-	ReverseProxySecret string `json:"reverseProxySecret,omitempty" yaml:"reverseProxySecret"`
 }
 
 // ContainerTemplate template

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -228,6 +228,10 @@ type Driver struct {
 	// ForceRemoveDriver is the boolean flag used to remove driver deployment when CR is deleted
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Force Remove Driver"
 	ForceRemoveDriver *bool `json:"forceRemoveDriver,omitempty" yaml:"forceRemoveDriver"`
+
+	// ReverseProxySecret is the name of the reverse proxy credentials secret
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Reverse Proxy Secret"
+	ReverseProxySecret string `json:"reverseProxySecret,omitempty" yaml:"reverseProxySecret"`
 }
 
 // ContainerTemplate template

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -769,6 +769,9 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 			log.Infof("DeployAsSidar is false...csi-reverseproxy should be present as deployement\n")
 			log.Infof("adding proxy service name...\n")
 			modules.AddReverseProxyServiceName(&controller.Deployment)
+
+			// Set the secret mount for powermax controller.
+			drivers.SetPowerMaxSecretMount(&controller.Deployment, cr)
 		} else {
 			log.Info("Starting CSI ReverseProxy Service")
 			if err := modules.ReverseProxyStartService(ctx, false, operatorConfig, cr, ctrlClient); err != nil {
@@ -785,9 +788,6 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 
 		// Set the secret mount for powermax node.
 		drivers.SetPowerMaxSecretMount(&node.DaemonSetApplyConfig, cr)
-
-		// Set the secret mount for powermax controller.
-		drivers.SetPowerMaxSecretMount(&controller.Deployment, cr)
 	}
 
 	replicationEnabled, clusterClients, err := utils.GetDefaultClusters(ctx, cr, r)

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -1,4 +1,4 @@
-//  Copyright © 2021 - 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+//  Copyright © 2021 - 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -779,6 +779,9 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 			if err != nil {
 				return fmt.Errorf("injecting replication into deployment: %v", err)
 			}
+
+			drivers.SetNodeSecretMounts(&node.DaemonSetApplyConfig, cr)
+
 			controller.Deployment = *dp
 		}
 	}

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -780,10 +780,14 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 				return fmt.Errorf("injecting replication into deployment: %v", err)
 			}
 
-			drivers.SetNodeSecretMounts(&node.DaemonSetApplyConfig, cr)
-
 			controller.Deployment = *dp
 		}
+
+		// Set the secret mount for powermax node.
+		drivers.SetPowerMaxSecretMount(&node.DaemonSetApplyConfig, cr)
+
+		// Set the secret mount for powermax controller.
+		drivers.SetPowerMaxSecretMount(&controller.Deployment, cr)
 	}
 
 	replicationEnabled, clusterClients, err := utils.GetDefaultClusters(ctx, cr, r)

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -771,7 +771,10 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 			modules.AddReverseProxyServiceName(&controller.Deployment)
 
 			// Set the secret mount for powermax controller.
-			drivers.SetPowerMaxSecretMount(&controller.Deployment, cr)
+			_, err := drivers.SetPowerMaxSecretMount(&controller.Deployment, cr)
+			if err != nil {
+				return err
+			}
 		} else {
 			log.Info("Starting CSI ReverseProxy Service")
 			if err := modules.ReverseProxyStartService(ctx, false, operatorConfig, cr, ctrlClient); err != nil {
@@ -787,7 +790,10 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 		}
 
 		// Set the secret mount for powermax node.
-		drivers.SetPowerMaxSecretMount(&node.DaemonSetApplyConfig, cr)
+		_, err := drivers.SetPowerMaxSecretMount(&node.DaemonSetApplyConfig, cr)
+		if err != nil {
+			return err
+		}
 	}
 
 	replicationEnabled, clusterClients, err := utils.GetDefaultClusters(ctx, cr, r)

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -1,4 +1,4 @@
-//  Copyright © 2022 - 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+//  Copyright © 2022 - 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -274,7 +274,6 @@ func (suite *CSMControllerTestSuite) TestReverseProxyReconcile() {
 }
 
 func (suite *CSMControllerTestSuite) TestReverseProxyWithSecretReconcile() {
-	// suite.makeFakeRevProxyCSM(csmName, suite.namespace, true, getReverseProxyModuleWithSecret(), string(v1.PowerMax))
 	csm := suite.buildFakeRevProxyCSM(csmName, suite.namespace, true, getReverseProxyModuleWithSecret(), string(v1.PowerMax))
 	csm.Spec.Driver.Common.Envs = append(csm.Spec.Driver.Common.Envs, corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 	err := suite.fakeClient.Create(ctx, &csm)

--- a/operatorconfig/driverconfig/powerflex/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.12.0/node.yaml
@@ -43,6 +43,9 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch", "update"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operatorconfig/driverconfig/powerflex/v2.12.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.12.0/node.yaml
@@ -43,9 +43,6 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
-    verbs: ["get", "list", "watch", "update"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
@@ -1,0 +1,337 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch", "update"]
+    # below for snapshotter
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots", "volumesnapshots/status"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+    # below for resizer
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+    # Permissions for CSIStorageCapacity
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  # Permissions for ReplicationReplicator
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-controller
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-controller
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  selector:
+    matchLabels:
+      app: <DriverDefaultReleaseName>-controller
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: <DriverDefaultReleaseName>-controller
+        csmNamespace: <CSM_NAMESPACE>
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
+    spec:
+      serviceAccount: <DriverDefaultReleaseName>-controller
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - <DriverDefaultReleaseName>-controller
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--timeout=180s"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+            - "--timeout=180s"
+            - "--worker-threads=6"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: external-health-monitor
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--leader-election"
+            - "--enable-node-watcher=true"
+            - "--monitor-interval=60s"
+            - "--timeout=180s"
+            - "--http-endpoint=:8080"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--volume-name-prefix=csivol"
+            - "--volume-name-uuid-length=10"
+            - "--worker-threads=6"
+            - "--timeout=120s"
+            - "--v=5"
+            - "--feature-gates=Topology=true"
+            - "--leader-election"
+            - "--extra-create-metadata"
+            - "--default-fstype=ext4"
+            - "--enable-capacity=true"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval=5m"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: snapshotter
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=180s"
+            - "--v=5"
+            - "--snapshot-name-prefix=pmsn"
+            - "--leader-election"
+            - "--snapshot-name-uuid-length=10"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        - name: driver
+          image: quay.io/dell/container-storage-modules/csi-powermax:nightly
+          imagePullPolicy: Always
+          command: ["/csi-powermax.sh"]
+          env:
+            - name: X_CSI_POWERMAX_DRIVER_NAME
+              value: csi-powermax.dellemc.com
+            - name: CSI_ENDPOINT
+              value: /var/run/csi/csi.sock
+            - name: X_CSI_K8S_CLUSTER_PREFIX
+              value: "CSM"
+            - name: X_CSI_MODE
+              value: controller
+            - name: X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
+            - name: X_CSI_POWERMAX_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: powermax-creds
+            - name: X_CSI_POWERMAX_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: powermax-creds
+            - name: X_CSI_POWERMAX_DEBUG
+              value: "<X_CSI_POWERMAX_DEBUG>"
+            - name: X_CSI_GRPC_MAX_THREADS
+              value: "50"
+            - name: X_CSI_ENABLE_BLOCK
+              value: "true"
+            - name: SSL_CERT_DIR
+              value: /certs
+            - name: X_CSI_IG_NODENAME_TEMPLATE
+              value: "<X_CSI_IG_NODENAME_TEMPLATE>"
+            - name: X_CSI_IG_MODIFY_HOSTNAME
+              value: "<X_CSI_IG_MODIFY_HOSTNAME>"
+            - name: X_CSI_UNISPHERE_TIMEOUT
+              value: 5m
+            - name: X_CSI_POWERMAX_CONFIG_PATH
+              value: /powermax-config-params/driver-config-params.yaml
+            - name: X_CSI_POWERMAX_ARRAY_CONFIG_PATH
+              value: /powermax-array-config/powermax-array-config.yaml
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_VSPHERE_ENABLED
+              value: "<X_CSI_VSPHERE_ENABLED>"
+            - name: X_CSI_VSPHERE_PORTGROUP
+              value: "<X_CSI_VSPHERE_PORTGROUP>"
+            - name: X_CSI_VSPHERE_HOSTNAME
+              value: "<X_CSI_VSPHERE_HOSTNAME>"
+            - name: X_CSI_VCENTER_HOST
+              value: "<X_CSI_VCENTER_HOST>"
+            - name: X_CSI_VCENTER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: vcenter-creds
+                  optional: true
+            - name: X_CSI_VCENTER_PWD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: vcenter-creds
+                  optional: true
+            - name: X_CSI_REVPROXY_TLS_CERT_DIR
+              value: /app/tls
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: powermax-config-params
+              mountPath: <DriverDefaultReleaseName>-config-params
+            - name: powermax-array-config
+              mountPath: /powermax-array-config
+            - name: tls-secret
+              mountPath: /app/tls
+            - name: powermax-config
+              mountPath: /powermax-config
+      volumes:
+        - name: socket-dir
+          emptyDir:
+        - name: certs
+          secret:
+            secretName: <DriverDefaultReleaseName>-certs
+            optional: true
+        - name: powermax-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+        - name: powermax-array-config
+          configMap:
+            name: powermax-array-config
+        - name: cert-dir
+          emptyDir:
+        - name: tls-secret
+          secret:
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>
+

--- a/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
@@ -314,8 +314,6 @@ spec:
               mountPath: /powermax-array-config
             - name: tls-secret
               mountPath: /app/tls
-            - name: powermax-config
-              mountPath: /powermax-config
       volumes:
         - name: socket-dir
           emptyDir:

--- a/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
@@ -332,4 +332,3 @@ spec:
         - name: tls-secret
           secret:
             secretName: <X_CSI_REVPROXY_TLS_SECRET>
-

--- a/operatorconfig/driverconfig/powermax/v2.14.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/csidriver.yaml
@@ -1,0 +1,23 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi-powermax.dellemc.com
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+  storageCapacity: true
+  fsGroupPolicy: ReadWriteOnceWithFSType
+  volumeLifecycleModes:
+    - Persistent

--- a/operatorconfig/driverconfig/powermax/v2.14.0/csidriver.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/csidriver.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operatorconfig/driverconfig/powermax/v2.14.0/driver-config-params.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/driver-config-params.yaml
@@ -1,0 +1,21 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: <DriverDefaultReleaseNamespace>
+data:
+  driver-config-params.yaml: |-
+    CSI_LOG_LEVEL: "info"
+    CSI_LOG_FORMAT: "TEXT"

--- a/operatorconfig/driverconfig/powermax/v2.14.0/driver-config-params.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/driver-config-params.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operatorconfig/driverconfig/powermax/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/node.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operatorconfig/driverconfig/powermax/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/node.yaml
@@ -1,0 +1,286 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["create", "delete", "get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["privileged"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+subjects:
+  - kind: ServiceAccount
+    name: <DriverDefaultReleaseName>-node
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: ClusterRole
+  name: <DriverDefaultReleaseName>-node
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: <DriverDefaultReleaseName>-node
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  selector:
+    matchLabels:
+      app: <DriverDefaultReleaseName>-node
+  template:
+    metadata:
+      labels:
+        app: <DriverDefaultReleaseName>-node
+        csmNamespace: <CSM_NAMESPACE>
+      annotations:
+        kubectl.kubernetes.io/default-container: driver
+    spec:
+      serviceAccount: <DriverDefaultReleaseName>-node
+      # nodeSelector:
+      # tolerations:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: driver
+          command: ["/csi-powermax.sh"]
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: quay.io/dell/container-storage-modules/csi-powermax:nightly
+          imagePullPolicy: Always
+          env:
+            - name: X_CSI_POWERMAX_DRIVER_NAME
+              value: csi-powermax.dellemc.com
+            - name: CSI_ENDPOINT
+              value: unix://<KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com/csi_sock
+            - name: X_CSI_K8S_CLUSTER_PREFIX
+              value: "CSM"
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_PRIVATE_MOUNT_DIR
+              value: "<KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com/disks"
+            - name: X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
+            - name: X_CSI_POWERMAX_USER
+              valueFrom:
+                secretKeyRef:
+                  name: powermax-creds
+                  key: username
+            - name: X_CSI_POWERMAX_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: powermax-creds
+                  key: password
+            - name: X_CSI_POWERMAX_NODENAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
+              value: "<X_CSI_POWERMAX_ISCSI_ENABLE_CHAP>"
+            - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
+              value: "csipowermax-reverseproxy"
+            - name: X_CSI_NODE_CHROOT
+              value: noderoot
+            - name: X_CSI_GRPC_MAX_THREADS
+              value: "50"
+            - name: SSL_CERT_DIR
+              value: /certs
+            - name: X_CSI_POWERMAX_CONFIG_PATH
+              value: /powermax-config-params/driver-config-params.yaml
+            - name: X_CSI_POWERMAX_ARRAY_CONFIG_PATH
+              value: /powermax-array-config/powermax-array-config.yaml
+            - name: X_CSI_POWERMAX_TOPOLOGY_CONFIG_PATH
+              value: /node-topology-config/topologyConfig.yaml
+            - name: X_CSI_IG_NODENAME_TEMPLATE
+              value: "<X_CSI_IG_NODENAME_TEMPLATE>"
+            - name: X_CSI_IG_MODIFY_HOSTNAME
+              value: "<X_CSI_IG_MODIFY_HOSTNAME>"
+            - name: X_CSI_HEALTH_MONITOR_ENABLED
+              value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
+            - name: X_CSI_MAX_VOLUMES_PER_NODE
+              value: "<X_CSI_MAX_VOLUMES_PER_NODE>"
+            - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+              value: "<X_CSI_TOPOLOGY_CONTROL_ENABLED>"
+            - name: X_CSI_VSPHERE_ENABLED
+              value: "<X_CSI_VSPHERE_ENABLED>"
+            - name: X_CSI_VSPHERE_PORTGROUP
+              value: "<X_CSI_VSPHERE_PORTGROUP>"
+            - name: X_CSI_VCENTER_HOST
+              value: "<X_CSI_VCENTER_HOST>"
+            - name: X_CSI_VSPHERE_HOSTNAME
+              value: "<X_CSI_VSPHERE_HOSTNAME>"
+            - name: X_CSI_VCENTER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: vcenter-creds
+                  optional: true
+            - name: X_CSI_VCENTER_PWD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: vcenter-creds
+                  optional: true
+            - name: X_CSI_REVPROXY_TLS_CERT_DIR
+              value: /app/tls
+          volumeMounts:
+            - name: driver-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com
+            - name: volumedevices-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices
+              mountPropagation: "Bidirectional"
+            - name: pods-path
+              mountPath: <KUBELET_CONFIG_DIR>/pods
+              mountPropagation: "Bidirectional"
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+            - name: noderoot
+              mountPath: /noderoot
+            - name: dbus-socket
+              mountPath: /run/dbus/system_bus_socket
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: powermax-config-params
+              mountPath: /powermax-config-params
+            - name: powermax-array-config
+              mountPath: /powermax-array-config
+            - name: node-topology-config
+              mountPath: /node-topology-config
+            - name: tls-secret
+              mountPath: /app/tls
+        - name: registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - --kubelet-registration-path=<KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com/csi_sock
+          env:
+            - name: ADDRESS
+              value: /csi/csi_sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: registration-dir
+              mountPath: /registration
+            - name: driver-path
+              mountPath: /csi
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins_registry/
+            type: DirectoryOrCreate
+        - name: driver-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com
+            type: DirectoryOrCreate
+        - name: volumedevices-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices
+            type: DirectoryOrCreate
+        - name: csi-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi
+        - name: pods-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/pods
+            type: Directory
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: noderoot
+          hostPath:
+            path: /
+            type: Directory
+        - name: dbus-socket
+          hostPath:
+            path: /run/dbus/system_bus_socket
+            type: Socket
+        - name: certs
+          secret:
+            secretName: <DriverDefaultReleaseName>-certs
+            optional: true
+        - name: powermax-config
+          secret:
+            secretName: <DriverDefaultReleaseName>-config
+        - name: powermax-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+        - name: powermax-array-config
+          configMap:
+            name: powermax-array-config
+        - name: node-topology-config
+          configMap:
+            name: node-topology-config
+            optional: true
+        - name: kubelet-pods
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: usr-bin
+          hostPath:
+            path: /usr/bin
+            type: Directory
+        - name: var-run
+          hostPath:
+            path: /var/run
+            type: Directory
+        - name: tls-secret
+          secret:
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>

--- a/operatorconfig/driverconfig/powermax/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/node.yaml
@@ -256,9 +256,6 @@ spec:
           secret:
             secretName: <DriverDefaultReleaseName>-certs
             optional: true
-        - name: powermax-config
-          secret:
-            secretName: <DriverDefaultReleaseName>-config
         - name: powermax-config-params
           configMap:
             name: <DriverDefaultReleaseName>-config-params

--- a/operatorconfig/driverconfig/powermax/v2.14.0/upgrade-path.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/upgrade-path.yaml
@@ -1,0 +1,1 @@
+minUpgradePath: v2.13.0

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/container.yaml
@@ -15,8 +15,6 @@ env:
   - name: X_CSI_REVPROXY_USE_SECRET
     value: <X_CSI_REVPROXY_USE_SECRET>
 volumeMounts:
-  - name: configmap-volume
-    mountPath: /etc/config/configmap
   - name: tls-secret
     mountPath: /app/tls
   - name: cert-dir

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/container.yaml
@@ -1,3 +1,15 @@
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name: reverseproxy
 image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
 imagePullPolicy: Always

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/container.yaml
@@ -12,8 +12,6 @@ env:
     value: /app/tls
   - name: X_CSI_REVPROXY_WATCH_NAMESPACE
     value: <DriverDefaultReleaseNamespace>
-  - name: X_CSI_REVPROXY_USE_SECRET
-    value: <X_CSI_REVPROXY_USE_SECRET>
 volumeMounts:
   - name: tls-secret
     mountPath: /app/tls

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/container.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/container.yaml
@@ -1,0 +1,23 @@
+name: reverseproxy
+image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
+imagePullPolicy: Always
+env:
+  - name: X_CSI_REVPROXY_CONFIG_DIR
+    value: /etc/config/configmap
+  - name: X_CSI_REVPROXY_CONFIG_FILE_NAME
+    value: config.yaml
+  - name: X_CSI_REVRPOXY_IN_CLUSTER
+    value: "true"
+  - name: X_CSI_REVPROXY_TLS_CERT_DIR
+    value: /app/tls
+  - name: X_CSI_REVPROXY_WATCH_NAMESPACE
+    value: <DriverDefaultReleaseNamespace>
+  - name: X_CSI_REVPROXY_USE_SECRET
+    value: <X_CSI_REVPROXY_USE_SECRET>
+volumeMounts:
+  - name: configmap-volume
+    mountPath: /etc/config/configmap
+  - name: tls-secret
+    mountPath: /app/tls
+  - name: cert-dir
+    mountPath: /app/certs

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/controller.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/controller.yaml
@@ -87,8 +87,6 @@ spec:
               value: /app/tls
             - name: X_CSI_REVPROXY_WATCH_NAMESPACE
               value: <DriverDefaultReleaseNamespace>  # Change this to the namespace where proxy will be installed
-            - name: X_CSI_REVPROXY_USE_SECRET
-              value: <X_CSI_REVPROXY_USE_SECRET>
           volumeMounts:
             - name: tls-secret
               mountPath: /app/tls

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/controller.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/controller.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/controller.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/controller.yaml
@@ -1,0 +1,108 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["list", "watch", "get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+subjects:
+  - kind: ServiceAccount
+    name: csipowermax-reverseproxy
+    namespace: <DriverDefaultReleaseNamespace>
+roleRef:
+  kind: Role
+  name: csipowermax-reverseproxy
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  ports:
+    - port: <X_CSI_REVPROXY_PORT>
+      protocol: TCP
+      targetPort: 2222
+  selector:
+    name: csipowermax-reverseproxy
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: csipowermax-reverseproxy
+  template:
+    metadata:
+      labels:
+        name: csipowermax-reverseproxy
+        csmNamespace: <CSM_NAMESPACE>
+    spec:
+      serviceAccountName: csipowermax-reverseproxy
+      containers:
+        - name: csipowermax-reverseproxy
+          # Replace this with the built image name
+          image: <REVERSEPROXY_PROXY_SERVER_IMAGE>
+          imagePullPolicy: Always
+          env:
+            - name: X_CSI_REVPROXY_CONFIG_DIR
+              value: /etc/config/configmap
+            - name: X_CSI_REVPROXY_CONFIG_FILE_NAME
+              value: config.yaml
+            - name: X_CSI_REVRPOXY_IN_CLUSTER
+              value: "true"
+            - name: X_CSI_REVPROXY_TLS_CERT_DIR
+              value: /app/tls
+            - name: X_CSI_REVPROXY_WATCH_NAMESPACE
+              value: <DriverDefaultReleaseNamespace>  # Change this to the namespace where proxy will be installed
+            - name: X_CSI_REVPROXY_USE_SECRET
+              value: <X_CSI_REVPROXY_USE_SECRET>
+          volumeMounts:
+            - name: configmap-volume
+              mountPath: /etc/config/configmap
+            - name: tls-secret
+              mountPath: /app/tls
+            - name: cert-dir
+              mountPath: /app/certs
+      volumes:
+        - name: configmap-volume
+          configMap:
+            name: <X_CSI_CONFIG_MAP_NAME>
+            optional: true
+        - name: tls-secret
+          secret:
+            secretName: <X_CSI_REVPROXY_TLS_SECRET>
+        - name: cert-dir
+          emptyDir:

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/controller.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/controller.yaml
@@ -90,17 +90,11 @@ spec:
             - name: X_CSI_REVPROXY_USE_SECRET
               value: <X_CSI_REVPROXY_USE_SECRET>
           volumeMounts:
-            - name: configmap-volume
-              mountPath: /etc/config/configmap
             - name: tls-secret
               mountPath: /app/tls
             - name: cert-dir
               mountPath: /app/certs
       volumes:
-        - name: configmap-volume
-          configMap:
-            name: <X_CSI_CONFIG_MAP_NAME>
-            optional: true
         - name: tls-secret
           secret:
             secretName: <X_CSI_REVPROXY_TLS_SECRET>

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/service.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csipowermax-reverseproxy
+  namespace: <DriverDefaultReleaseNamespace>
+spec:
+  ports:
+    - port: <X_CSI_REVPROXY_PORT>
+      protocol: TCP
+      targetPort: 2222
+  selector:
+    app: <DriverDefaultReleaseName>-controller
+  type: ClusterIP

--- a/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/service.yaml
+++ b/operatorconfig/moduleconfig/csireverseproxy/v2.13.0/service.yaml
@@ -1,3 +1,15 @@
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 apiVersion: v1
 kind: Service
 metadata:

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -67,11 +67,11 @@ const (
 	// PowerMaxCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
 	PowerMaxCSMNameSpace string = "<CSM_NAMESPACE>"
 
-	CSIPowerMaxUseSecret       string = "X_CSI_REVPROXY_USE_SECRET"
-	CSIPowerMaxSecretMountPath string = "/etc/powermax/"
+	CSIPowerMaxUseSecret       string = "X_CSI_REVPROXY_USE_SECRET" // #nosec G101
+	CSIPowerMaxSecretMountPath string = "/etc/powermax/"            // #nosec G101
 
 	// To be used.
-	CSIPowerMaxSecretName string = "powermax-config"
+	CSIPowerMaxSecretName string = "powermax-config" // #nosec G101
 )
 
 // PrecheckPowerMax do input validation

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -101,7 +101,7 @@ func PrecheckPowerMax(ctx context.Context, cr *csmv1.ContainerStorageModule, ope
 	found := &corev1.Secret{}
 	err := ct.Get(ctx, types.NamespacedName{Name: secretName, Namespace: cr.GetNamespace()}, found)
 	if err != nil {
-		log.Error(err, "Failed query for secret ", secretName)
+		log.Error(err, "Failed query for secret", secretName)
 		if errors.IsNotFound(err) {
 			return fmt.Errorf("failed to find secret %s", secretName)
 		}

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -403,8 +403,10 @@ func SetPowerMaxSecretMount(configuration interface{}, cr csmv1.ContainerStorage
 
 		// Adding volume
 		podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes,
-			acorev1.VolumeApplyConfiguration{Name: &secretName,
-				VolumeSourceApplyConfiguration: acorev1.VolumeSourceApplyConfiguration{Secret: &acorev1.SecretVolumeSourceApplyConfiguration{SecretName: &secretName, Optional: &optional}}})
+			acorev1.VolumeApplyConfiguration{
+				Name:                           &secretName,
+				VolumeSourceApplyConfiguration: acorev1.VolumeSourceApplyConfiguration{Secret: &acorev1.SecretVolumeSourceApplyConfiguration{SecretName: &secretName, Optional: &optional}},
+			})
 
 		// Adding volume mount for both the reverseproxy and driver
 		for i, cnt := range podTemplate.Spec.Containers {

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -1,4 +1,4 @@
-//  Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+//  Copyright © 2023-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/pkg/drivers/powermax_test.go
+++ b/pkg/drivers/powermax_test.go
@@ -113,7 +113,7 @@ func csmWithReverseProxySecret() csmv1.ContainerStorageModule {
 	res.Spec.Driver.Common.Envs = []corev1.EnvVar{
 		{Name: "X_CSI_POWERMAX_PORTGROUPS", Value: "csi_pg"},
 		{Name: "X_CSI_TRANSPORT_PROTOCOL", Value: "FC"},
-		{Name: "X_CSI_USE_REVPROXY_SECRET", Value: "true"},
+		{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"},
 	}
 	res.Spec.Driver.AuthSecret = "csm-creds"
 
@@ -122,7 +122,7 @@ func csmWithReverseProxySecret() csmv1.ContainerStorageModule {
 	res.Spec.Driver.CSIDriverType = csmv1.PowerMax
 
 	revproxy := shared.MakeReverseProxyModule(shared.ConfigVersion)
-	revproxy.Components[0].Envs = append(revproxy.Components[0].Envs, corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "false"})
+	revproxy.Components[0].Envs = append(revproxy.Components[0].Envs, corev1.EnvVar{Name: CSIPowerMaxUseSecret, Value: "false"})
 	res.Spec.Modules = append(res.Spec.Modules, revproxy)
 
 	return res
@@ -134,7 +134,7 @@ func csmWithBadReverseProxySecret() csmv1.ContainerStorageModule {
 	res.Spec.Driver.Common.Envs = []corev1.EnvVar{
 		{Name: "X_CSI_POWERMAX_PORTGROUPS", Value: "csi_pg"},
 		{Name: "X_CSI_TRANSPORT_PROTOCOL", Value: "FC"},
-		{Name: "X_CSI_USE_REVPROXY_SECRET", Value: "invalid"},
+		{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "invalid"},
 	}
 	res.Spec.Driver.AuthSecret = "csm-creds"
 

--- a/pkg/drivers/powermax_test.go
+++ b/pkg/drivers/powermax_test.go
@@ -1,4 +1,4 @@
-//  Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+//  Copyright © 2023-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -49,7 +49,7 @@ const (
 	ReverseProxyConfigMap       = "<X_CSI_CONFIG_MAP_NAME>"
 	ReverseProxyPort            = "<X_CSI_REVPROXY_PORT>"
 	ReverseProxyCSMNameSpace    = "<CSM_NAMESPACE>"
-	ReverseProxyUseSecret       = "<X_CSI_REVPROXY_USE_SECRET>"
+	ReverseProxyUseSecret       = "<X_CSI_REVPROXY_USE_SECRET>" // #nosec G101
 )
 
 // var used in deploying reverseproxy

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -353,10 +353,12 @@ func setReverseProxySecretMounts(dp *v1.DeploymentApplyConfiguration, secretName
 
 	// Adding volume
 	dp.Spec.Template.Spec.Volumes = append(dp.Spec.Template.Spec.Volumes,
-		acorev1.VolumeApplyConfiguration{Name: &secretName,
+		acorev1.VolumeApplyConfiguration{
+			Name: &secretName,
 			VolumeSourceApplyConfiguration: acorev1.VolumeSourceApplyConfiguration{
 				Secret: &acorev1.SecretVolumeSourceApplyConfiguration{
-					SecretName: &secretName, Optional: &optional},
+					SecretName: &secretName, Optional: &optional,
+				},
 			},
 		})
 
@@ -375,8 +377,10 @@ func deploymentSetReverseProxySecretMounts(dp *appsv1.Deployment, secretName str
 
 	// Adding volume
 	dp.Spec.Template.Spec.Volumes = append(dp.Spec.Template.Spec.Volumes,
-		corev1.Volume{Name: secretName,
-			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: secretName, Optional: &optional}}})
+		corev1.Volume{
+			Name:         secretName,
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: secretName, Optional: &optional}},
+		})
 
 	mountPath := drivers.CSIPowerMaxSecretMountPath + secretName
 	// Adding volume mount for both the reverseproxy and driver
@@ -409,12 +413,15 @@ func setReverseProxyConfigMapMounts(dp *v1.DeploymentApplyConfiguration, revProx
 
 func deploymentSetReverseProxyConfigMapMounts(dp *appsv1.Deployment, cmName string) {
 	optional := true
-	volume := corev1.Volume{Name: RevProxyConfigMapVolName,
+	volume := corev1.Volume{
+		Name: RevProxyConfigMapVolName,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: cmName},
-				Optional: &optional},
+					Name: cmName,
+				},
+				Optional: &optional,
+			},
 		},
 	}
 	volumeMount := corev1.VolumeMount{Name: RevProxyConfigMapVolName, MountPath: RevProxyConfigMapMountPath}

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -357,6 +357,16 @@ func deploymentSetReverseProxySecretMounts(dp *appsv1.Deployment, secretName str
 		if cnt.Name == RevProxyServiceName {
 			dp.Spec.Template.Spec.Containers[i].VolumeMounts = append(dp.Spec.Template.Spec.Containers[i].VolumeMounts,
 				corev1.VolumeMount{Name: secretName, MountPath: mountPath})
+
+			dp.Spec.Template.Spec.Containers[i].Env = append(dp.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{
+				Name:  drivers.CSIPowerMaxSecretFilePath,
+				Value: drivers.CSIPowerMaxSecretMountPath + "/" + drivers.CSIPowerMaxSecretName,
+			})
+			dp.Spec.Template.Spec.Containers[i].Env = append(dp.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{
+				Name:  drivers.CSIPowerMaxUseSecret,
+				Value: "true",
+			})
+			break
 		}
 	}
 }

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -1,4 +1,4 @@
-//  Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+//  Copyright © 2023-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -328,7 +328,10 @@ func ReverseProxyInjectDeployment(dp v1.DeploymentApplyConfiguration, cr csmv1.C
 	secretSupported, _ := utils.MinVersionCheck("v2.13.0", revProxyModule.ConfigVersion)
 	useSecret := getRevProxyUseSecret(*revProxyModule)
 	if secretSupported && useSecret == "true" {
-		drivers.SetPowerMaxSecretMount(&dp, cr)
+		_, err = drivers.SetPowerMaxSecretMount(&dp, cr)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if useSecret == "false" {

--- a/pkg/modules/reverseproxy_test.go
+++ b/pkg/modules/reverseproxy_test.go
@@ -190,9 +190,8 @@ func TestReverseProxyPrecheck(t *testing.T) {
 				panic(err)
 			}
 
-			customResource.Spec.Modules[0].Components[0].Envs =
-				append(customResource.Spec.Modules[0].Components[0].Envs,
-					corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
+			customResource.Spec.Modules[0].Components[0].Envs = append(customResource.Spec.Modules[0].Components[0].Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 
 			proxySecret := getSecret(customResource.Namespace, "csirevproxy-tls-secret")
 
@@ -301,9 +300,8 @@ func TestReverseProxyServer(t *testing.T) {
 				panic(err)
 			}
 
-			tmpCR.Spec.Modules[0].Components[0].Envs =
-				append(tmpCR.Spec.Modules[0].Components[0].Envs,
-					corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
+			tmpCR.Spec.Modules[0].Components[0].Envs = append(tmpCR.Spec.Modules[0].Components[0].Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 
 			deployAsSidecar = true
 			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
@@ -315,9 +313,8 @@ func TestReverseProxyServer(t *testing.T) {
 				panic(err)
 			}
 
-			tmpCR.Spec.Modules[0].Components[0].Envs =
-				append(tmpCR.Spec.Modules[0].Components[0].Envs,
-					corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "false"})
+			tmpCR.Spec.Modules[0].Components[0].Envs = append(tmpCR.Spec.Modules[0].Components[0].Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "false"})
 
 			deployAsSidecar = true
 			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
@@ -368,9 +365,8 @@ func TestReverseProxyInjectDeployment(t *testing.T) {
 				panic(err)
 			}
 
-			customResource.Spec.Modules[0].Components[0].Envs =
-				append(customResource.Spec.Modules[0].Components[0].Envs,
-					corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
+			customResource.Spec.Modules[0].Components[0].Envs = append(customResource.Spec.Modules[0].Components[0].Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 
 			controllerYAML, err := drivers.GetController(ctx, customResource, operatorConfig, csmv1.PowerMax)
 			if err != nil {
@@ -386,9 +382,8 @@ func TestReverseProxyInjectDeployment(t *testing.T) {
 				panic(err)
 			}
 
-			customResource.Spec.Modules[0].Components[0].Envs =
-				append(customResource.Spec.Modules[0].Components[0].Envs,
-					corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "false"})
+			customResource.Spec.Modules[0].Components[0].Envs = append(customResource.Spec.Modules[0].Components[0].Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "false"})
 
 			controllerYAML, err := drivers.GetController(ctx, customResource, operatorConfig, csmv1.PowerMax)
 			if err != nil {

--- a/pkg/modules/reverseproxy_test.go
+++ b/pkg/modules/reverseproxy_test.go
@@ -18,13 +18,13 @@ import (
 	"testing"
 
 	"github.com/dell/csm-operator/pkg/drivers"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	applyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 
 	csmv1 "github.com/dell/csm-operator/api/v1"
 	"github.com/dell/csm-operator/pkg/utils"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -184,6 +184,25 @@ func TestReverseProxyPrecheck(t *testing.T) {
 
 			return true, reverseProxy, tmpCR, sourceClient, fakeControllerRuntimeClient
 		},
+		"success - use reverse proxy secret": func(*testing.T) (bool, csmv1.Module, csmv1.ContainerStorageModule, ctrlClient.Client, fakeControllerRuntimeClientWrapper) {
+			customResource, err := getCustomResource("./testdata/cr_powermax_reverseproxy_use_secret.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			proxySecret := getSecret(customResource.Namespace, "csirevproxy-tls-secret")
+
+			tmpCR := customResource
+			reverseProxy := tmpCR.Spec.Modules[0]
+
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects(proxySecret).Build()
+			fakeControllerRuntimeClient := func(_ []byte) (ctrlClient.Client, error) {
+				clusterClient := ctrlClientFake.NewClientBuilder().WithObjects(proxySecret).Build()
+				return clusterClient, nil
+			}
+
+			return true, reverseProxy, tmpCR, sourceClient, fakeControllerRuntimeClient
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -272,6 +291,15 @@ func TestReverseProxyServer(t *testing.T) {
 			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
 			return false, false, tmpCR, sourceClient, operatorConfig
 		},
+		"success - use reverse proxy secret": func(*testing.T) (bool, bool, csmv1.ContainerStorageModule, ctrlClient.Client, utils.OperatorConfig) {
+			tmpCR, err := getCustomResource("./testdata/cr_powermax_reverseproxy_use_secret.yaml")
+			if err != nil {
+				panic(err)
+			}
+			deployAsSidecar = true
+			sourceClient := ctrlClientFake.NewClientBuilder().WithObjects().Build()
+			return true, false, tmpCR, sourceClient, operatorConfig
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -309,6 +337,20 @@ func TestReverseProxyInjectDeployment(t *testing.T) {
 				panic(err)
 			}
 			deployAsSidecar = true
+			return true, controllerYAML.Deployment, operatorConfig, customResource
+		},
+		"success - use reverse proxy secret": func(*testing.T) (bool, applyv1.DeploymentApplyConfiguration, utils.OperatorConfig, csmv1.ContainerStorageModule) {
+			customResource, err := getCustomResource("./testdata/cr_powermax_reverseproxy_use_secret.yaml")
+			if err != nil {
+				panic(err)
+			}
+
+			controllerYAML, err := drivers.GetController(ctx, customResource, operatorConfig, csmv1.PowerMax)
+			if err != nil {
+				panic(err)
+			}
+			deployAsSidecar = true
+
 			return true, controllerYAML.Deployment, operatorConfig, customResource
 		},
 	}

--- a/pkg/modules/reverseproxy_test.go
+++ b/pkg/modules/reverseproxy_test.go
@@ -1,4 +1,4 @@
-//  Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+//  Copyright © 2023-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/pkg/modules/testdata/cr_powermax_reverseproxy_use_secret.yaml
+++ b/pkg/modules/testdata/cr_powermax_reverseproxy_use_secret.yaml
@@ -1,0 +1,52 @@
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: test-powermax
+  namespace: powermax
+spec:
+  driver:
+    csiDriverType: "powermax"
+    configVersion: v2.13.0
+    authSecret: powermax-creds
+    replicas: 1
+    common:
+      image: "quay.io/dell/container-storage-modules/csi-powermax:v2.14.0"
+      imagePullPolicy: IfNotPresent
+  modules:
+    # CSI Powermax Reverseproxy is a mandatory module
+    - name: "csireverseproxy"
+      # enabled: Always set to true
+      enabled: true
+      configVersion: v2.13.0
+      components:
+        - name: csipowermax-reverseproxy
+          # image: Define the container images used for the reverse proxy
+          # Default value: None
+          image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:v2.13.0
+          envs:
+            # "tlsSecret" defines the TLS secret that is created with certificate
+            # and its associated key
+            # Default value: None
+            # Example: "tls-secret"
+            - name: X_CSI_REVPROXY_TLS_SECRET
+              value: "csirevproxy-tls-secret"
+            - name: X_CSI_REVPROXY_PORT
+              value: "2222"
+            - name: X_CSI_CONFIG_MAP_NAME
+              value: "powermax-reverseproxy-config"
+            - name: "DeployAsSidecar"
+              value: "true"
+            - name: "X_CSI_REVPROXY_USE_SECRET"
+              value: "true"

--- a/pkg/modules/testdata/cr_powermax_reverseproxy_use_secret.yaml
+++ b/pkg/modules/testdata/cr_powermax_reverseproxy_use_secret.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   driver:
     csiDriverType: "powermax"
-    configVersion: v2.13.0
+    configVersion: v2.14.0
     authSecret: powermax-creds
     replicas: 1
     common:
@@ -47,6 +47,4 @@ spec:
             - name: X_CSI_CONFIG_MAP_NAME
               value: "powermax-reverseproxy-config"
             - name: "DeployAsSidecar"
-              value: "true"
-            - name: "X_CSI_REVPROXY_USE_SECRET"
               value: "true"

--- a/tests/e2e/steps/steps_def.go
+++ b/tests/e2e/steps/steps_def.go
@@ -1,4 +1,4 @@
-//  Copyright © 2022-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+//  Copyright © 2022-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/e2e/steps/steps_def.go
+++ b/tests/e2e/steps/steps_def.go
@@ -15,6 +15,7 @@ package steps
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -25,8 +26,6 @@ import (
 	"time"
 
 	csmv1 "github.com/dell/csm-operator/api/v1"
-
-	"encoding/json"
 
 	"github.com/dell/csm-operator/pkg/constants"
 	"github.com/dell/csm-operator/pkg/modules"
@@ -55,8 +54,10 @@ var (
 	authString        = "karavi-authorization-proxy"
 	operatorNamespace = "dell-csm-operator"
 	quotaLimit        = "100000000"
-	pflexSecretMap    = map[string]string{"REPLACE_USER": "PFLEX_USER", "REPLACE_PASS": "PFLEX_PASS", "REPLACE_SYSTEMID": "PFLEX_SYSTEMID", "REPLACE_ENDPOINT": "PFLEX_ENDPOINT", "REPLACE_MDM": "PFLEX_MDM", "REPLACE_POOL": "PFLEX_POOL", "REPLACE_NAS": "PFLEX_NAS",
-		"REPLACE_ZONING_USER": "PFLEX_ZONING_USER", "REPLACE_ZONING_PASS": "PFLEX_ZONING_PASS", "REPLACE_ZONING_SYSTEMID": "PFLEX_ZONING_SYSTEMID", "REPLACE_ZONING_ENDPOINT": "PFLEX_ZONING_ENDPOINT", "REPLACE_ZONING_MDM": "PFLEX_ZONING_MDM", "REPLACE_ZONING_POOL": "PFLEX_ZONING_POOL", "REPLACE_ZONING_NAS": "PFLEX_ZONING_NAS"}
+	pflexSecretMap    = map[string]string{
+		"REPLACE_USER": "PFLEX_USER", "REPLACE_PASS": "PFLEX_PASS", "REPLACE_SYSTEMID": "PFLEX_SYSTEMID", "REPLACE_ENDPOINT": "PFLEX_ENDPOINT", "REPLACE_MDM": "PFLEX_MDM", "REPLACE_POOL": "PFLEX_POOL", "REPLACE_NAS": "PFLEX_NAS",
+		"REPLACE_ZONING_USER": "PFLEX_ZONING_USER", "REPLACE_ZONING_PASS": "PFLEX_ZONING_PASS", "REPLACE_ZONING_SYSTEMID": "PFLEX_ZONING_SYSTEMID", "REPLACE_ZONING_ENDPOINT": "PFLEX_ZONING_ENDPOINT", "REPLACE_ZONING_MDM": "PFLEX_ZONING_MDM", "REPLACE_ZONING_POOL": "PFLEX_ZONING_POOL", "REPLACE_ZONING_NAS": "PFLEX_ZONING_NAS",
+	}
 	pflexAuthSecretMap       = map[string]string{"REPLACE_USER": "PFLEX_USER", "REPLACE_SYSTEMID": "PFLEX_SYSTEMID", "REPLACE_ENDPOINT": "PFLEX_AUTH_ENDPOINT", "REPLACE_MDM": "PFLEX_MDM"}
 	pscaleSecretMap          = map[string]string{"REPLACE_CLUSTERNAME": "PSCALE_CLUSTER", "REPLACE_USER": "PSCALE_USER", "REPLACE_PASS": "PSCALE_PASS", "REPLACE_ENDPOINT": "PSCALE_ENDPOINT", "REPLACE_PORT": "PSCALE_PORT"}
 	pscaleAuthSecretMap      = map[string]string{"REPLACE_CLUSTERNAME": "PSCALE_CLUSTER", "REPLACE_USER": "PSCALE_USER", "REPLACE_PASS": "PSCALE_PASS", "REPLACE_AUTH_ENDPOINT": "PSCALE_AUTH_ENDPOINT", "REPLACE_AUTH_PORT": "PSCALE_AUTH_PORT", "REPLACE_ENDPOINT": "PSCALE_ENDPOINT", "REPLACE_PORT": "PSCALE_PORT"}
@@ -1012,7 +1013,6 @@ func (step *Step) runCustomTestSelector(res Resource, testName string) error {
 	}
 
 	return nil
-
 }
 
 func (step *Step) setupEphemeralVolumeProperties(res Resource, templateFile string, crType string) error {
@@ -1561,7 +1561,7 @@ func (step *Step) AuthorizationV1Resources(storageType, driver, port, proxyHost,
 		"--insecure", "--addr", fmt.Sprintf("%s:%s", proxyHost, port),
 	)
 
-	//by default, assume we will create storage
+	// by default, assume we will create storage
 	skipStorage := false
 
 	fmt.Println("=== Checking Storage === \n", cmd.String())
@@ -1621,7 +1621,7 @@ func (step *Step) AuthorizationV1Resources(storageType, driver, port, proxyHost,
 		return fmt.Errorf("failed to create tenant %s: %v\nErrMessage:\n%s", tenantName, err, string(b))
 	}
 
-	//By default, assume a role will be created
+	// By default, assume a role will be created
 	skipCreateRole := false
 	cmd = exec.Command("karavictl",
 		"--admin-token", "/tmp/adminToken.yaml",
@@ -1932,7 +1932,6 @@ func (step *Step) configureAMInstall(res Resource, templateFile string) error {
 // Normally, this service account is created by Operator, but we create it here
 // in advance to set imagePullSecrets.
 func setupAMImagePullSecret() error {
-
 	if os.Getenv("RH_REGISTRY_USERNAME") == "" || os.Getenv("RH_REGISTRY_PASSWORD") == "" {
 		return fmt.Errorf("env variable RH_REGISTRY_USERNAME or RH_REGISTRY_PASSWORD is not set," +
 			" set it in array-info.sh before continuing")

--- a/tests/e2e/steps/steps_def.go
+++ b/tests/e2e/steps/steps_def.go
@@ -65,6 +65,7 @@ var (
 	pflexEphemeralVolumeMap  = map[string]string{"REPLACE_SYSTEMID": "PFLEX_SYSTEMID", "REPLACE_POOL": "PFLEX_POOL", "REPLACE_VOLUME": "PFLEX_VOLUME"}
 	pflexAuthSidecarMap      = map[string]string{"REPLACE_USER": "PFLEX_USER", "REPLACE_PASS": "PFLEX_PASS", "REPLACE_SYSTEMID": "PFLEX_SYSTEMID", "REPLACE_ENDPOINT": "PFLEX_ENDPOINT", "REPLACE_AUTH_ENDPOINT": "PFLEX_AUTH_ENDPOINT"}
 	pmaxCredMap              = map[string]string{"REPLACE_USER": "PMAX_USER_ENCODED", "REPLACE_PASS": "PMAX_PASS_ENCODED"}
+	pmaxSecretMap            = map[string]string{"REPLACE_USERNAME": "PMAX_USER", "REPLACE_PASSWORD": "PMAX_USER", "REPLACE_SYSTEMID": "PMAX_SYSTEMID", "REPLACE_ENDPOINT": "PMAX_ENDPOINT"}
 	pmaxAuthSidecarMap       = map[string]string{"REPLACE_SYSTEMID": "PMAX_SYSTEMID", "REPLACE_ENDPOINT": "PMAX_ENDPOINT", "REPLACE_AUTH_ENDPOINT": "PMAX_AUTH_ENDPOINT"}
 	pmaxStorageMap           = map[string]string{"REPLACE_SYSTEMID": "PMAX_SYSTEMID", "REPLACE_RESOURCE_POOL": "PMAX_POOL_V1", "REPLACE_SERVICE_LEVEL": "PMAX_SERVICE_LEVEL"}
 	pmaxReverseProxyMap      = map[string]string{"REPLACE_SYSTEMID": "PMAX_SYSTEMID", "REPLACE_AUTH_ENDPOINT": "PMAX_AUTH_ENDPOINT"}
@@ -888,6 +889,8 @@ func determineMap(crType string) (map[string]string, error) {
 		mapValues = pmaxAuthSidecarMap
 	} else if crType == "pmaxCreds" {
 		mapValues = pmaxCredMap
+	} else if crType == "pmaxUseSecret" {
+		mapValues = pmaxSecretMap
 	} else if crType == "pmaxReverseProxy" {
 		mapValues = pmaxReverseProxyMap
 	} else if crType == "pmaxArrayConfig" {

--- a/tests/e2e/testfiles/powermax-templates/powermax-use-secret-template.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax-use-secret-template.yaml
@@ -1,6 +1,7 @@
 storageArrays:
   - storageArrayId: "REPLACE_SYSTEMID"
     primaryEndpoint: "https://REPLACE_ENDPOINT"
+    backupEndpoint: "https://REPLACE_ENDPOINT"
 managementServers:
   - endpoint: "https://REPLACE_ENDPOINT"
     username: REPLACE_USERNAME

--- a/tests/e2e/testfiles/powermax-templates/powermax-use-secret-template.yaml
+++ b/tests/e2e/testfiles/powermax-templates/powermax-use-secret-template.yaml
@@ -1,0 +1,8 @@
+storageArrays:
+  - storageArrayId: "REPLACE_SYSTEMID"
+    primaryEndpoint: "https://REPLACE_ENDPOINT"
+managementServers:
+  - endpoint: "https://REPLACE_ENDPOINT"
+    username: REPLACE_USERNAME
+    password: REPLACE_PASSWORD
+    skipCertificateValidation: true

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1819,6 +1819,32 @@
       run:
         - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
+- scenario: "Install PowerMax Driver with secret"
+  paths:
+    - "testfiles/storage_csm_powermax_secret.yaml"
+  tags:
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up reverse proxy tls secret namespace [powermax]"
+    - "Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Run custom test"
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret]"
+    - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
+
 - scenario: "Install PowerMax Driver with TLS (Standalone)"
   paths:
     - "testfiles/storage_csm_powermax_tls.yaml"

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1819,9 +1819,35 @@
       run:
         - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
-- scenario: "Install PowerMax Driver with secret"
+- scenario: "Install PowerMax Driver with Mount Credentials"
   paths:
     - "testfiles/storage_csm_powermax_secret.yaml"
+  tags:
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up reverse proxy tls secret namespace [powermax]"
+    - "Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Run custom test"
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret]"
+    - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
+
+- scenario: "Install PowerMax Driver with Mount Credentials (Sidecar)"
+  paths:
+    - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
   tags:
     - "powermax"
   steps:

--- a/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_observability.yaml
@@ -205,7 +205,7 @@ spec:
   modules:
     # CSI Powermax Reverseproxy is a mandatory module for Powermax
     - name: csireverseproxy
-      configVersion: v2.11.0
+      configVersion: v2.12.0
       components:
         - name: csipowermax-reverseproxy
           # image: Define the container images used for the reverse proxy

--- a/tests/e2e/testfiles/storage_csm_powermax_observability_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_observability_authorization.yaml
@@ -214,7 +214,7 @@ spec:
   modules:
     # CSI Powermax Reverseproxy is a mandatory module for Powermax
     - name: csireverseproxy
-      configVersion: v2.11.0
+      configVersion: v2.12.0
       components:
         - name: csipowermax-reverseproxy
           # image: Define the container images used for the reverse proxy

--- a/tests/e2e/testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_reverseproxy_authorization.yaml
@@ -205,7 +205,7 @@ spec:
   modules:
     # CSI Powermax Reverseproxy is a mandatory module for Powermax
     - name: csireverseproxy
-      configVersion: v2.11.0
+      configVersion: v2.12.0
       components:
         - name: csipowermax-reverseproxy
           # image: Define the container images used for the reverse proxy

--- a/tests/e2e/testfiles/storage_csm_powermax_secret.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_secret.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/e2e/testfiles/storage_csm_powermax_secret.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_secret.yaml
@@ -22,6 +22,7 @@ spec:
   driver:
     csiDriverType: "powermax"
     csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
       # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
       # Allowed values: ReadWriteOnceWithFSType, File , None
       # Default value: ReadWriteOnceWithFSType
@@ -31,19 +32,18 @@ spec:
       #   true: enable storage capacity tracking
       #   false: disable storage capacity tracking
       storageCapacity: true
-    # Config version for CSI PowerMax v2.13.0 driver
-    configVersion: v2.13.0
+    configVersion: v2.14.0
     # replica: Define the number of PowerMax controller nodes
     # to deploy to the Kubernetes release
+    # Controller count
     # Allowed values: n, where n > 0
-    # Default value: None
+    # Default value: 2
     replicas: 2
     # Default credential secret for Powermax, if not set it to ""
-    authSecret: powermax-creds
+    authSecret: powermax-config
     dnsPolicy: ClusterFirstWithHostNet
     forceRemoveDriver: true
     common:
-      # Image for CSI PowerMax driver v2.12.0
       image: quay.io/dell/container-storage-modules/csi-powermax:nightly
       # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
       # Allowed values:
@@ -92,6 +92,34 @@ spec:
         # Default value: "" <empty>
         - name: "X_CSI_VCENTER_HOST"
           value: ""
+        # CSI driver log level
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "debug"
+        - name: "CSI_LOG_LEVEL"
+          value: "info"
+        # X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION: It determines if driver is going to skip verification
+        # of TLS certificates while connecting to Unisphere RESTAPI interface
+        # If it is set to false,
+        # then a secret powermax-certs has to be created with a X.509 certificate of CA
+        # which signed the Unisphere certificate
+        # Allowed values:
+        #   "true"  - TLS certificates verification will be skipped
+        #   "false" - TLS certificates will be verified
+        # Default value: "true"
+        - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
+          value: "true"
+        # CSI driver log format
+        # Allowed values: "TEXT" or "JSON"
+        # Default value: "TEXT"
+        - name: "CSI_LOG_FORMAT"
+          value: "TEXT"
+        # X_CSI_REVPROXY_USE_SECRET: Define whether or not to use the new secret format for the reverse proxy.
+        # Allowed values:
+        #   "true" - Use secret format for the reverse proxy
+        #   "false" - Use configmap format for the reverse proxy
+        # Default value: "false"
+        - name: "X_CSI_REVPROXY_USE_SECRET"
+          value: "true"
     controller:
       envs:
         # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition
@@ -181,7 +209,7 @@ spec:
       # 'csivol' represents a string prepended to each volume created by the CSI driver
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-        args: [ "--volume-name-prefix=csivol" ]
+        args: ["--volume-name-prefix=csivol"]
       - name: attacher
         image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
       - name: registrar
@@ -193,9 +221,10 @@ spec:
       - name: csi-metadata-retriever
         image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
       # health monitor is disabled by default, refer to driver documentation before enabling it
+      # Default monitor-interval: 60s
       - name: external-health-monitor
         enabled: false
-        args: [ "--monitor-interval=60s" ]
+        args: ["--monitor-interval=60s"]
         image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.14.0
         # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
         # Configure only when the storageCapacity is set as "true"
@@ -205,12 +234,11 @@ spec:
   modules:
     # CSI Powermax Reverseproxy is a mandatory module for Powermax
     - name: csireverseproxy
-      configVersion: v2.12.0
+      configVersion: v2.13.0
       components:
         - name: csipowermax-reverseproxy
           # image: Define the container images used for the reverse proxy
           # Default value: None
-          # Example: "csipowermax-reverseproxy:v2.9.1"
           image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
           imagePullPolicy: Always
           envs:
@@ -235,7 +263,7 @@ spec:
       #   true: enable Resiliency feature(deploy podmon sidecar)
       #   false: disable Resiliency feature(do not deploy podmon sidecar)
       # Default value: false
-      enabled: true
+      enabled: false
       configVersion: v1.12.0
       components:
         - name: podmon-controller

--- a/tests/e2e/testfiles/storage_csm_powermax_secret_sidecar.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_secret_sidecar.yaml
@@ -256,7 +256,7 @@ spec:
             # set it true, if csm-auth is enabled / you want it as a sidecar container
             # set it false, if you want it as a deployment
             - name: "DeployAsSidecar"
-              value: "false"
+              value: "true"
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature
       # Allowed values:

--- a/tests/e2e/testfiles/storage_csm_powermax_secret_sidecar.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_secret_sidecar.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description
Add mount credentials support to PowerMax. This introduces the ability to create a create a secret that will be mounted as a volume instead of the usage of a ConfigMap for communication to the backend array.

Both ConfigMap and Secret approaches are supported for backwards compatibility. Depending on the the `X_CSI_REVPROXY_USE_SECRET` environment variable, either the secret or configMap will be dynamically mounted for the PowerMax `controller`, `nodes`, and `reverseProxy`.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1614 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Manually deploy PowerMax with `X_CSI_REVPROXY_USE_SECRET` set to **true** with Reverse Proxy as a sidecar.

<details>
<summary>controller/driver:</summary>

```
      X_CSI_REVPROXY_SECRET_FILEPATH:              /etc/powermax/config
      X_CSI_REVPROXY_USE_SECRET:                   true
    Mounts:
      /app/tls from tls-secret (rw)
      /certs from certs (ro)
      /etc/powermax from powermax-reverseproxy-secret (rw)
```
</details>

<details>
<summary>controller/reverseproxy:</summary>

```
      X_CSI_REVPROXY_SECRET_FILEPATH:   /etc/powermax/config
      X_CSI_REVPROXY_USE_SECRET:        true
    Mounts:
      /app/certs from cert-dir (rw)
      /app/tls from tls-secret (rw)
      /etc/powermax from powermax-reverseproxy-secret (rw)
```
</details>

<details>
<summary>node/driver:</summary>

```
      X_CSI_REVPROXY_SECRET_FILEPATH:              /etc/powermax/config
      X_CSI_REVPROXY_USE_SECRET:                   true
    Mounts:
      /app/tls from tls-secret (rw)
      /certs from certs (ro)
      /dev from dev (rw)
      /etc/powermax from powermax-reverseproxy-secret (rw)
```
</details>

- [x] Manually deploy PowerMax with `X_CSI_REVPROXY_USE_SECRET` set to **true** with Reverse Proxy NOT as a sidecar.
- [x] Manually deploy PowerMax with `X_CSI_REVPROXY_USE_SECRET` set to **false** with Reverse Proxy as a sidecar.
- [x] Manually deploy PowerMax with `X_CSI_REVPROXY_USE_SECRET` set to **false** with Reverse Proxy NOT as a sidecar.
- [x] Add unit tests to cover the different scenarios for the use of the Reverse Proxy Secret.

<details>

```
$ make module-unit-test
go clean -cache && go test -v -coverprofile=c.out github.com/dell/csm-operator/pkg/modules
...
PASS
coverage: 90.3% of statements
ok      github.com/dell/csm-operator/pkg/modules        0.656s  coverage: 90.3% of statements
```
```
$ make driver-unit-test
go clean -cache && go test -v -coverprofile=c.out github.com/dell/csm-operator/pkg/drivers
...
PASS
coverage: 96.8% of statements
ok      github.com/dell/csm-operator/pkg/drivers        0.084s  coverage: 96.8% of statements
```
</details>

- [x] Add E2E to cover the different scenarios for the use of the Reverse Proxy Secret.
<details>

```
/root/git/public/dell/csm-operator/tests/e2e
  W0121 15:21:44.811874   11432 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0121 15:21:44.812187 11432 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/git/public/dell/csm-operator/tests/e2e
===========================================================================================
Random Seed: 1737472876

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 01/21/25 15:21:44.812
  STEP: [powermax] @ 01/21/25 15:21:44.812
  STEP: Reading values file @ 01/21/25 15:21:44.812
  STEP: Getting a k8s client @ 01/21/25 15:21:44.824
[BeforeSuite] PASSED [0.025 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver with Mount Credentials  @ 01/21/25 15:21:44.837
  STEP: Returning false here @ 01/21/25 15:21:44.837
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/21/25 15:21:44.837
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/21/25 15:21:44.925
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/21/25 15:21:47.193
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret] @ 01/21/25 15:21:47.828
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/21/25 15:21:48.905
  STEP:      Executing  Apply custom resource [1] @ 01/21/25 15:21:49.798
  I0121 15:21:49.800463 11432 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0121 15:21:50.532146 11432 builder.go:146] stderr: ""
  I0121 15:21:50.532203 11432 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/21/25 15:21:50.532
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/21/25 15:22:10.616
  STEP:      Executing  Run custom test @ 01/21/25 15:22:30.693
  I0121 15:22:30.693682 11432 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-21 15:22:31]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-21 15:22:31]  INFO Using EVENT observer type
[2025-01-21 15:22:31]  INFO Using config from /root/.kube/config
[2025-01-21 15:22:31]  INFO Successfully loaded config. Host: https://10.227.248.175:6443
[2025-01-21 15:22:31]  INFO Created new KubeClient
[2025-01-21 15:22:31]  INFO Running 1 iteration(s)
[2025-01-21 15:22:31]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-21 15:22:31]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-21 15:22:31]  INFO Successfully created namespace volumeio-test-c233c0a6
[2025-01-21 15:22:31]  INFO Using default number of volumes
[2025-01-21 15:22:31]  INFO Using default image: docker.io/centos:latest
[2025-01-21 15:22:31]  INFO Creating IO pod
[2025-01-21 15:22:31]  INFO Waiting for pod iowriter-test-67rvw to be READY
[2025-01-21 15:23:29]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-21 15:23:30]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-21 15:23:33]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-21 15:23:33]  INFO VolumeAttachment deleted
[2025-01-21 15:23:33]  INFO Deleting all resources in namespace volumeio-test-c233c0a6
[2025-01-21 15:23:45]  INFO Namespace volumeio-test-c233c0a6 was deleted in 12.092289185s
[2025-01-21 15:23:46]  INFO SUCCESS: VolumeIoSuite in 1m15.166714073s
[2025-01-21 15:23:46]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-21 15:23:46]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-21 15:23:46]  WARN No ResourceUsageMetrics provided
[2025-01-21 15:23:46] ERROR no ResourceUsageMetrics provided
report-test-run-1c13803e:
Name: test-run-1c13803e
Host: https://10.227.248.175:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-1c13803e/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-1c13803e/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-1c13803e/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-1c13803e/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-1c13803e/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-21 15:22:31.315358743 +0000 UTC
            Ended:     2025-01-21 15:23:46.503137294 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 2.600753942s
                        Min: 2.600753942s
                        Max: 2.600753942s
                        Histogram:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 17.44620011s
                        Min: 17.44620011s
                        Max: 17.44620011s
                        Histogram:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 20.522269081s
                        Min: 20.522269081s
                        Max: 20.522269081s
                        Histogram:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 75.434866ms
                        Min: 75.434866ms
                        Max: 75.434866ms
                        Histogram:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.759170122s
                        Min: 1.759170122s
                        Max: 1.759170122s
                        Histogram:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 56.15873065s
                        Min: 56.15873065s
                        Max: 56.15873065s
                        Histogram:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.36920982s
                        Min: 1.36920982s
                        Max: 1.36920982s
                        Histogram:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-1c13803e/VolumeIoSuite4/EntityNumberOverTime.png

[2025-01-21 15:23:47]  INFO Avg time of a run:   62.06s
[2025-01-21 15:23:47]  INFO Avg time of a del:   12.09s
[2025-01-21 15:23:47]  INFO Avg time of all:     75.16s
[2025-01-21 15:23:47]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/21/25 15:23:47.032
  STEP:      Executing  Delete custom resource [1] @ 01/21/25 15:23:47.123
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/21/25 15:23:47.177

err: found the following pods: csipowermax-reverseproxy-649599b7f9-4wx6d,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/21/25 15:24:37.26
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 01/21/25 15:24:37.321
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/21/25 15:24:37.409
  STEP: Ending: Install PowerMax Driver with Mount Credentials
   @ 01/21/25 15:24:37.486
  STEP: Starting: Install PowerMax Driver with Mount Credentials (Sidecar)  @ 01/21/25 15:24:42.488
  STEP: Returning false here @ 01/21/25 15:24:42.488
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/21/25 15:24:42.488
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/21/25 15:24:42.511
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/21/25 15:24:43.202
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret] @ 01/21/25 15:24:43.471
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/21/25 15:24:43.98
  STEP:      Executing  Apply custom resource [1] @ 01/21/25 15:24:44.413
  I0121 15:24:44.413654 11432 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0121 15:24:44.809993 11432 builder.go:146] stderr: ""
  I0121 15:24:44.810068 11432 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/21/25 15:24:44.81

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/21/25 15:25:34.931
  STEP:      Executing  Run custom test @ 01/21/25 15:25:55.011
  I0121 15:25:55.011382 11432 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-21 15:25:55]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-21 15:25:55]  INFO Using EVENT observer type
[2025-01-21 15:25:55]  INFO Using config from /root/.kube/config
[2025-01-21 15:25:55]  INFO Successfully loaded config. Host: https://10.227.248.175:6443
[2025-01-21 15:25:55]  INFO Created new KubeClient
[2025-01-21 15:25:55]  INFO Running 1 iteration(s)
[2025-01-21 15:25:55]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-21 15:25:55]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-21 15:25:55]  INFO Successfully created namespace volumeio-test-2e03270d
[2025-01-21 15:25:55]  INFO Using default number of volumes
[2025-01-21 15:25:55]  INFO Using default image: docker.io/centos:latest
[2025-01-21 15:25:55]  INFO Creating IO pod
[2025-01-21 15:25:55]  INFO Waiting for pod iowriter-test-t2bpl to be READY
[2025-01-21 15:26:33]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-21 15:26:34]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-21 15:26:37]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-21 15:26:37]  INFO VolumeAttachment deleted
[2025-01-21 15:26:37]  INFO Deleting all resources in namespace volumeio-test-2e03270d
[2025-01-21 15:26:49]  INFO Namespace volumeio-test-2e03270d was deleted in 12.086828769s
[2025-01-21 15:26:50]  INFO SUCCESS: VolumeIoSuite in 55.21040117s
[2025-01-21 15:26:50]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-21 15:26:50]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->] 100.00% ? p/s1 / 1 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 83 p/s[2025-01-21 15:26:50]  WARN No ResourceUsageMetrics provided
[2025-01-21 15:26:50] ERROR no ResourceUsageMetrics provided
report-test-run-daea632f:
Name: test-run-daea632f
Host: https://10.227.248.175:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-daea632f/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-daea632f/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-daea632f/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-daea632f/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-daea632f/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-21 15:25:55.208652908 +0000 UTC
            Ended:     2025-01-21 15:26:50.461444101 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 2.481335143s
                        Min: 2.481335143s
                        Max: 2.481335143s
                        Histogram:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.718097695s
                        Min: 2.718097695s
                        Max: 2.718097695s
                        Histogram:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 5.557758356s
                        Min: 5.557758356s
                        Max: 5.557758356s
                        Histogram:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 40.547396ms
                        Min: 40.547396ms
                        Max: 40.547396ms
                        Histogram:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.796436304s
                        Min: 1.796436304s
                        Max: 1.796436304s
                        Histogram:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 36.936139862s
                        Min: 36.936139862s
                        Max: 36.936139862s
                        Histogram:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.313157544s
                        Min: 1.313157544s
                        Max: 1.313157544s
                        Histogram:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-daea632f/VolumeIoSuite5/EntityNumberOverTime.png

[2025-01-21 15:26:50]  INFO Avg time of a run:   41.87s
[2025-01-21 15:26:50]  INFO Avg time of a del:   12.09s
[2025-01-21 15:26:50]  INFO Avg time of all:     55.21s
[2025-01-21 15:26:50]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/21/25 15:26:50.964
  STEP:      Executing  Delete custom resource [1] @ 01/21/25 15:26:51.058
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/21/25 15:26:51.112

err: found the following pods: powermax-controller-74649f448c-27bmc,powermax-controller-74649f448c-cgkhg,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/21/25 15:27:41.213
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 01/21/25 15:27:41.266
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/21/25 15:27:41.349
  STEP: Ending: Install PowerMax Driver with Mount Credentials (Sidecar)
   @ 01/21/25 15:27:41.425
• [361.589 seconds]
------------------------------

Ran 1 of 1 Specs in 361.614 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 6m29.84763694s
Test Suite Passed
```
</details>