### PR TITLE
Update Powermax to handle Minimal Manifests with Mount Credentials

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -783,7 +783,7 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 			log.Info("Injecting CSI ReverseProxy")
 			dp, err := modules.ReverseProxyInjectDeployment(controller.Deployment, cr, operatorConfig)
 			if err != nil {
-				return fmt.Errorf("injecting replication into deployment: %v", err)
+				return fmt.Errorf("unable to inject ReverseProxy into deployment: %v", err)
 			}
 
 			controller.Deployment = *dp
@@ -1383,6 +1383,10 @@ func (r *ContainerStorageModuleReconciler) PreChecks(ctx context.Context, cr *cs
 		if err != nil {
 			return fmt.Errorf("failed powermax validation: %v", err)
 		}
+
+		// To ensure that we are handling minimal manifests correctly and consistent, we must reset DeployAsSidecar to the original value.
+		// This variable will be set correctly if the reverseproxy is found in the manifests.
+		modules.ResetDeployAsSidecar()
 	default:
 		// Go to checkUpgrade if it is standalone module i.e. app mobility or authorizatio proxy server
 		if cr.HasModule(csmv1.ApplicationMobility) || cr.HasModule(csmv1.AuthorizationServer) {

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -771,7 +771,7 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 			modules.AddReverseProxyServiceName(&controller.Deployment)
 
 			// Set the secret mount for powermax controller.
-			_, err := drivers.SetPowerMaxSecretMount(&controller.Deployment, cr)
+			_, err := drivers.DynamicallyMountPowermaxContent(&controller.Deployment, cr)
 			if err != nil {
 				return err
 			}
@@ -790,7 +790,7 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 		}
 
 		// Set the secret mount for powermax node.
-		_, err := drivers.SetPowerMaxSecretMount(&node.DaemonSetApplyConfig, cr)
+		_, err := drivers.DynamicallyMountPowermaxContent(&node.DaemonSetApplyConfig, cr)
 		if err != nil {
 			return err
 		}

--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -771,7 +771,7 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 			modules.AddReverseProxyServiceName(&controller.Deployment)
 
 			// Set the secret mount for powermax controller.
-			_, err := drivers.DynamicallyMountPowermaxContent(&controller.Deployment, cr)
+			err := drivers.DynamicallyMountPowermaxContent(&controller.Deployment, cr)
 			if err != nil {
 				return err
 			}
@@ -790,7 +790,7 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 		}
 
 		// Set the secret mount for powermax node.
-		_, err := drivers.DynamicallyMountPowermaxContent(&node.DaemonSetApplyConfig, cr)
+		err := drivers.DynamicallyMountPowermaxContent(&node.DaemonSetApplyConfig, cr)
 		if err != nil {
 			return err
 		}

--- a/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/controller.yaml
@@ -250,16 +250,6 @@ spec:
               value: controller
             - name: X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION
               value: "true"
-            - name: X_CSI_POWERMAX_USER
-              valueFrom:
-                secretKeyRef:
-                  key: username
-                  name: powermax-creds
-            - name: X_CSI_POWERMAX_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: password
-                  name: powermax-creds
             - name: X_CSI_POWERMAX_DEBUG
               value: "<X_CSI_POWERMAX_DEBUG>"
             - name: X_CSI_GRPC_MAX_THREADS

--- a/operatorconfig/driverconfig/powermax/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powermax/v2.14.0/node.yaml
@@ -105,16 +105,6 @@ spec:
               value: "<KUBELET_CONFIG_DIR>/plugins/powermax.emc.dell.com/disks"
             - name: X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION
               value: "true"
-            - name: X_CSI_POWERMAX_USER
-              valueFrom:
-                secretKeyRef:
-                  name: powermax-creds
-                  key: username
-            - name: X_CSI_POWERMAX_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: powermax-creds
-                  key: password
             - name: X_CSI_POWERMAX_NODENAME
               valueFrom:
                 fieldRef:

--- a/operatorconfig/moduleconfig/common/version-values.yaml
+++ b/operatorconfig/moduleconfig/common/version-values.yaml
@@ -61,3 +61,9 @@ powermax:
     replication: "v1.11.0"
     observability: "v1.11.0"
     resiliency: "v1.12.0"
+  v2.14.0:
+    csireverseproxy: "v2.13.0"
+    authorization: "v2.1.0"
+    replication: "v1.11.0"
+    observability: "v1.11.0"
+    resiliency: "v1.12.0"

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -91,7 +92,7 @@ func PrecheckPowerMax(ctx context.Context, cr *csmv1.ContainerStorageModule, ope
 		secretName = cr.Spec.Driver.AuthSecret
 	}
 
-	useReverseProxySecret := useReverseProxySecret(cr)
+	useReverseProxySecret := UseReverseProxySecret(cr)
 	if useReverseProxySecret {
 		log.Infof("[PrecheckPowerMax] Using Secret: %s", secretName)
 	} else {
@@ -121,7 +122,7 @@ func PrecheckPowerMax(ctx context.Context, cr *csmv1.ContainerStorageModule, ope
 	return nil
 }
 
-func useReverseProxySecret(cr *csmv1.ContainerStorageModule) bool {
+func UseReverseProxySecret(cr *csmv1.ContainerStorageModule) bool {
 	useSecret := false
 
 	if cr.Spec.Driver.Common == nil {
@@ -382,26 +383,32 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 	return yamlString
 }
 
-func SetPowerMaxSecretMount(configuration interface{}, cr csmv1.ContainerStorageModule) (bool, error) {
-	if useReverseProxySecret(&cr) {
-		secretName := cr.Spec.Driver.AuthSecret
+func DynamicallyMountPowermaxContent(configuration interface{}, cr csmv1.ContainerStorageModule) (bool, error) {
+	var podTemplate *acorev1.PodTemplateSpecApplyConfiguration
+	switch configuration := configuration.(type) {
+	case *v1.DeploymentApplyConfiguration:
+		dp := configuration
+		podTemplate = dp.Spec.Template
+	case *v1.DaemonSetApplyConfiguration:
+		ds := configuration
+		podTemplate = ds.Spec.Template
+	}
+
+	if podTemplate == nil {
+		return false, fmt.Errorf("invalid type passed through")
+	}
+
+	secretName := cr.Name + "-creds"
+	if cr.Spec.Driver.AuthSecret != "" {
+		secretName = cr.Spec.Driver.AuthSecret
+	}
+
+	if UseReverseProxySecret(&cr) {
 		volumeName := CSIPowerMaxSecretVolumeName
 		optional := false
 		mountPath := CSIPowerMaxSecretMountPath
 
-		var podTemplate *acorev1.PodTemplateSpecApplyConfiguration
-		switch configuration := configuration.(type) {
-		case *v1.DeploymentApplyConfiguration:
-			dp := configuration
-			podTemplate = dp.Spec.Template
-		case *v1.DaemonSetApplyConfiguration:
-			ds := configuration
-			podTemplate = ds.Spec.Template
-		}
-
-		if podTemplate == nil {
-			return false, fmt.Errorf("invalid type passed through")
-		}
+		log.Printf("[FERNADO] Adding secret volume and volume mount for secret %s", secretName)
 
 		// Adding volume
 		podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes,
@@ -413,17 +420,28 @@ func SetPowerMaxSecretMount(configuration interface{}, cr csmv1.ContainerStorage
 		// Adding volume mount for both the reverseproxy and driver
 		for i, cnt := range podTemplate.Spec.Containers {
 			if *cnt.Name == "driver" || *cnt.Name == "reverseproxy" {
-				SetPowerMaxSecretVariables(&podTemplate.Spec.Containers[i], volumeName, mountPath)
+				setPowermaxMountCredentialContent(&podTemplate.Spec.Containers[i], volumeName, mountPath)
 			}
 		}
 
 		return true, nil
+	} else {
+		// Adding volume mount for both the reverseproxy and driver
+
+		log.Printf("[FERNANDO] Using configMap solution for %+v", podTemplate.Spec.Containers)
+
+		for i, cnt := range podTemplate.Spec.Containers {
+			if *cnt.Name == "driver" {
+				SetPowermaxConfigContent(&podTemplate.Spec.Containers[i], secretName)
+				break
+			}
+		}
 	}
 
 	return false, nil
 }
 
-func SetPowerMaxSecretVariables(ct *acorev1.ContainerApplyConfiguration, mN, mP string) {
+func setPowermaxMountCredentialContent(ct *acorev1.ContainerApplyConfiguration, mN, mP string) {
 	ct.VolumeMounts = append(ct.VolumeMounts, acorev1.VolumeMountApplyConfiguration{Name: &mN, MountPath: &mP})
 
 	volumeName := CSIPowerMaxSecretFilePath
@@ -434,6 +452,46 @@ func SetPowerMaxSecretVariables(ct *acorev1.ContainerApplyConfiguration, mN, mP 
 	ct.Env = append(ct.Env,
 		acorev1.EnvVarApplyConfiguration{Name: &volumeName, Value: &mountPath},
 		acorev1.EnvVarApplyConfiguration{Name: &useSecretEnv, Value: &useSecretValue})
+}
+
+func SetPowermaxConfigContent(ct *acorev1.ContainerApplyConfiguration, secretName string) {
+	userNameVariable := "X_CSI_POWERMAX_USER"
+	userNameKey := "username"
+	userPasswordVariable := "X_CSI_POWERMAX_PASSWORD"
+	userPasswordKey := "password"
+	dynamicallyAddEnvironmentVariable(ct, acorev1.EnvVarApplyConfiguration{
+		Name: &userNameVariable,
+		ValueFrom: &acorev1.EnvVarSourceApplyConfiguration{
+			SecretKeyRef: &acorev1.SecretKeySelectorApplyConfiguration{
+				Key: &userNameKey,
+				LocalObjectReferenceApplyConfiguration: acorev1.LocalObjectReferenceApplyConfiguration{
+					Name: &secretName,
+				},
+			},
+		},
+	})
+
+	dynamicallyAddEnvironmentVariable(ct, acorev1.EnvVarApplyConfiguration{
+		Name: &userPasswordVariable,
+		ValueFrom: &acorev1.EnvVarSourceApplyConfiguration{
+			SecretKeyRef: &acorev1.SecretKeySelectorApplyConfiguration{
+				Key: &userPasswordKey,
+				LocalObjectReferenceApplyConfiguration: acorev1.LocalObjectReferenceApplyConfiguration{
+					Name: &secretName,
+				},
+			},
+		},
+	})
+}
+
+func dynamicallyAddEnvironmentVariable(ct *acorev1.ContainerApplyConfiguration, envVar acorev1.EnvVarApplyConfiguration) {
+	contains := slices.ContainsFunc(ct.Env,
+		func(v acorev1.EnvVarApplyConfiguration) bool { return *(v.Name) == *(envVar.Name) },
+	)
+
+	if !contains {
+		ct.Env = append(ct.Env, envVar)
+	}
 }
 
 func getApplyCertVolumePowermax(cr csmv1.ContainerStorageModule) (*acorev1.VolumeApplyConfiguration, error) {

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -408,8 +408,6 @@ func DynamicallyMountPowermaxContent(configuration interface{}, cr csmv1.Contain
 		optional := false
 		mountPath := CSIPowerMaxSecretMountPath
 
-		log.Printf("[FERNADO] Adding secret volume and volume mount for secret %s", secretName)
-
 		// Adding volume
 		podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes,
 			acorev1.VolumeApplyConfiguration{
@@ -426,10 +424,6 @@ func DynamicallyMountPowermaxContent(configuration interface{}, cr csmv1.Contain
 
 		return true, nil
 	} else {
-		// Adding volume mount for both the reverseproxy and driver
-
-		log.Printf("[FERNANDO] Using configMap solution for %+v", podTemplate.Spec.Containers)
-
 		for i, cnt := range podTemplate.Spec.Containers {
 			if *cnt.Name == "driver" {
 				SetPowermaxConfigContent(&podTemplate.Spec.Containers[i], secretName)

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -383,7 +383,7 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 	return yamlString
 }
 
-func DynamicallyMountPowermaxContent(configuration interface{}, cr csmv1.ContainerStorageModule) (bool, error) {
+func DynamicallyMountPowermaxContent(configuration interface{}, cr csmv1.ContainerStorageModule) error {
 	var podTemplate *acorev1.PodTemplateSpecApplyConfiguration
 	switch configuration := configuration.(type) {
 	case *v1.DeploymentApplyConfiguration:
@@ -395,7 +395,7 @@ func DynamicallyMountPowermaxContent(configuration interface{}, cr csmv1.Contain
 	}
 
 	if podTemplate == nil {
-		return false, fmt.Errorf("invalid type passed through")
+		return fmt.Errorf("invalid type passed through")
 	}
 
 	secretName := cr.Name + "-creds"
@@ -422,17 +422,17 @@ func DynamicallyMountPowermaxContent(configuration interface{}, cr csmv1.Contain
 			}
 		}
 
-		return true, nil
-	} else {
-		for i, cnt := range podTemplate.Spec.Containers {
-			if *cnt.Name == "driver" {
-				SetPowermaxConfigContent(&podTemplate.Spec.Containers[i], secretName)
-				break
-			}
+		return nil
+	}
+
+	for i, cnt := range podTemplate.Spec.Containers {
+		if *cnt.Name == "driver" {
+			SetPowermaxConfigContent(&podTemplate.Spec.Containers[i], secretName)
+			break
 		}
 	}
 
-	return false, nil
+	return nil
 }
 
 func setPowermaxMountCredentialContent(ct *acorev1.ContainerApplyConfiguration, mN, mP string) {
@@ -451,7 +451,7 @@ func setPowermaxMountCredentialContent(ct *acorev1.ContainerApplyConfiguration, 
 func SetPowermaxConfigContent(ct *acorev1.ContainerApplyConfiguration, secretName string) {
 	userNameVariable := "X_CSI_POWERMAX_USER"
 	userNameKey := "username"
-	userPasswordVariable := "X_CSI_POWERMAX_PASSWORD"
+	userPasswordVariable := "X_CSI_POWERMAX_PASSWORD" // #nosec G101
 	userPasswordKey := "password"
 	dynamicallyAddEnvironmentVariable(ct, acorev1.EnvVarApplyConfiguration{
 		Name: &userNameVariable,

--- a/pkg/drivers/powermax_test.go
+++ b/pkg/drivers/powermax_test.go
@@ -195,7 +195,7 @@ func TestSetPowerMaxSecretMount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := SetPowerMaxSecretMount(tt.configuration, tt.cr)
+			_, err := DynamicallyMountPowermaxContent(tt.configuration, tt.cr)
 			if tt.expectedErr == nil {
 				assert.Nil(t, err)
 			} else {

--- a/pkg/drivers/powermax_test.go
+++ b/pkg/drivers/powermax_test.go
@@ -232,7 +232,7 @@ func TestDynamicallyMountPowermaxContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := DynamicallyMountPowermaxContent(tt.configuration, tt.cr)
+			err := DynamicallyMountPowermaxContent(tt.configuration, tt.cr)
 			if tt.expectedErr == nil {
 				assert.Nil(t, err)
 			} else {

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -15,7 +15,6 @@ package modules
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"slices"
@@ -101,7 +100,13 @@ func ReverseProxyPrecheck(ctx context.Context, op utils.OperatorConfig, revproxy
 				proxyConfigMap = env.Value
 			}
 			if env.Name == "DeployAsSidecar" {
-				deployAsSidecar, _ = strconv.ParseBool(env.Value)
+				das, err := strconv.ParseBool(env.Value)
+				if err != nil {
+					log.Infof("Error parsing %s, %s. Using default value", env.Name, err.Error())
+					das = true
+				}
+
+				deployAsSidecar = das
 			}
 		}
 	}
@@ -113,8 +118,7 @@ func ReverseProxyPrecheck(ctx context.Context, op utils.OperatorConfig, revproxy
 		}
 	}
 
-	useSecret := getRevProxyUseSecret(revproxy)
-	if useSecret == "false" {
+	if !drivers.UseReverseProxySecret(&cr) {
 		log.Infof("[ReverseProxyPrecheck] using configmap %s", proxyConfigMap)
 		err = r.GetClient().Get(ctx, types.NamespacedName{Name: proxyConfigMap, Namespace: cr.GetNamespace()}, &corev1.ConfigMap{})
 		if err != nil {
@@ -147,7 +151,7 @@ func ReverseProxyServer(ctx context.Context, isDeleting bool, op utils.OperatorC
 			revProxyModule, _, _ := getRevproxyApplyCR(cr, op)
 			secretSupported, _ := utils.MinVersionCheck("v2.13.0", revProxyModule.ConfigVersion)
 			if secretSupported {
-				if getRevProxyUseSecret(*revProxyModule) == "true" {
+				if drivers.UseReverseProxySecret(&cr) {
 					secretName := cr.Spec.Driver.AuthSecret
 					deploymentSetReverseProxySecretMounts(dp, secretName)
 				} else {
@@ -303,9 +307,6 @@ func ReverseProxyInjectDeployment(dp v1.DeploymentApplyConfiguration, cr csmv1.C
 		return nil, err
 	}
 
-	log.Printf("[ReverseProxyInjectDeployment] Injecting reverseProxy into driver deployment %+v", revProxyModule)
-	log.Printf("[ReverseProxyInjectDeployment] Container: %+v", *containerPtr)
-
 	container := *containerPtr
 	// update the image
 	for _, side := range revProxyModule.Components {
@@ -327,21 +328,15 @@ func ReverseProxyInjectDeployment(dp v1.DeploymentApplyConfiguration, cr csmv1.C
 		}
 	}
 
-	// powerMaxVersion := cr.Spec.Driver.ConfigVersion
-
-	// Dynamic secret/configMap mounting is only supported in v2.13.0 and above
+	// Dynamic secret/configMap mounting is only supported in v2.14.0 and above
 	secretSupported, _ := utils.MinVersionCheck("v2.14.0", cr.Spec.Driver.ConfigVersion)
 	useSecret := drivers.UseReverseProxySecret(&cr)
-
-	log.Printf("[ReverseProxyInjectDeployment] Using secret: %t, supported: %t, version: %s", useSecret, secretSupported, cr.Spec.Driver.ConfigVersion)
 	if secretSupported && useSecret {
 		_, err = drivers.DynamicallyMountPowermaxContent(&dp, cr)
 		if err != nil {
 			return nil, err
 		}
 	}
-
-	log.Println("[FERNANDO] ReverseProxyInjectDeployment using secret, version: " + revProxyModule.ConfigVersion)
 
 	if !useSecret {
 		setReverseProxyConfigMapMounts(&dp, *revProxyModule, cr)
@@ -402,7 +397,6 @@ func setReverseProxyConfigMapMounts(dp *v1.DeploymentApplyConfiguration, revProx
 			)
 
 			if !contains {
-				log.Printf("[setReverseProxyConfigMapMounts] Mounting volume: %s", RevProxyConfigMapMountPath)
 				dp.Spec.Template.Spec.Containers[i].VolumeMounts = append(dp.Spec.Template.Spec.Containers[i].VolumeMounts,
 					acorev1.VolumeMountApplyConfiguration{Name: &RevProxyConfigMapVolName, MountPath: &RevProxyConfigMapMountPath})
 			}
@@ -459,20 +453,6 @@ func getRevProxyPort(revProxyModule csmv1.Module) string {
 		}
 	}
 	return revProxyPort
-}
-
-func getRevProxyUseSecret(revProxyModule csmv1.Module) string {
-	useSecret := "false"
-	for _, component := range revProxyModule.Components {
-		if component.Name == ReverseProxyServerComponent {
-			for _, env := range component.Envs {
-				if env.Name == drivers.CSIPowerMaxUseSecret {
-					useSecret = env.Value
-				}
-			}
-		}
-	}
-	return useSecret
 }
 
 func getRevProxyEnvVariable(revProxyModule csmv1.Module, envVar string) string {
@@ -538,6 +518,7 @@ func getRevProxyVolumeComp(revProxyModule csmv1.Module) []acorev1.VolumeApplyCon
 func getRevproxyApplyCR(cr csmv1.ContainerStorageModule, op utils.OperatorConfig) (*csmv1.Module, *acorev1.ContainerApplyConfiguration, error) {
 	var err error
 	revProxyModule := cr.GetModule(csmv1.ReverseProxy)
+
 	// This is necessary for the minimal manifest, where the reverse proxy will not be included in the CSM CR.
 	if len(revProxyModule.Name) == 0 {
 		revProxyModule.Name = csmv1.ReverseProxy
@@ -570,4 +551,8 @@ func AddReverseProxyServiceName(dp *v1.DeploymentApplyConfiguration) {
 
 var IsReverseProxySidecar = func() bool {
 	return deployAsSidecar
+}
+
+func ResetDeployAsSidecar() {
+	deployAsSidecar = true
 }

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -332,7 +332,7 @@ func ReverseProxyInjectDeployment(dp v1.DeploymentApplyConfiguration, cr csmv1.C
 	secretSupported, _ := utils.MinVersionCheck("v2.14.0", cr.Spec.Driver.ConfigVersion)
 	useSecret := drivers.UseReverseProxySecret(&cr)
 	if secretSupported && useSecret {
-		_, err = drivers.DynamicallyMountPowermaxContent(&dp, cr)
+		err = drivers.DynamicallyMountPowermaxContent(&dp, cr)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -102,7 +102,7 @@ func ReverseProxyPrecheck(ctx context.Context, op utils.OperatorConfig, revproxy
 			if env.Name == "DeployAsSidecar" {
 				das, err := strconv.ParseBool(env.Value)
 				if err != nil {
-					log.Infof("Error parsing %s, %s. Using default value", env.Name, err.Error())
+					log.Warnf("Error parsing %s, %s. Deploying reverseproxy as sidecar.", env.Name, err.Error())
 					das = true
 				}
 

--- a/pkg/modules/reverseproxy_test.go
+++ b/pkg/modules/reverseproxy_test.go
@@ -190,6 +190,8 @@ func TestReverseProxyPrecheck(t *testing.T) {
 				panic(err)
 			}
 
+			customResource.Spec.Driver.Common.Envs = append(customResource.Spec.Driver.Common.Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 			customResource.Spec.Modules[0].Components[0].Envs = append(customResource.Spec.Modules[0].Components[0].Envs,
 				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 
@@ -300,6 +302,8 @@ func TestReverseProxyServer(t *testing.T) {
 				panic(err)
 			}
 
+			tmpCR.Spec.Driver.Common.Envs = append(tmpCR.Spec.Driver.Common.Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 			tmpCR.Spec.Modules[0].Components[0].Envs = append(tmpCR.Spec.Modules[0].Components[0].Envs,
 				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 
@@ -312,6 +316,9 @@ func TestReverseProxyServer(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
+
+			tmpCR.Spec.Driver.Common.Envs = append(tmpCR.Spec.Driver.Common.Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "false"})
 
 			tmpCR.Spec.Modules[0].Components[0].Envs = append(tmpCR.Spec.Modules[0].Components[0].Envs,
 				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "false"})
@@ -365,6 +372,8 @@ func TestReverseProxyInjectDeployment(t *testing.T) {
 				panic(err)
 			}
 
+			customResource.Spec.Driver.Common.Envs = append(customResource.Spec.Driver.Common.Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 			customResource.Spec.Modules[0].Components[0].Envs = append(customResource.Spec.Modules[0].Components[0].Envs,
 				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "true"})
 
@@ -382,6 +391,8 @@ func TestReverseProxyInjectDeployment(t *testing.T) {
 				panic(err)
 			}
 
+			customResource.Spec.Driver.Common.Envs = append(customResource.Spec.Driver.Common.Envs,
+				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "false"})
 			customResource.Spec.Modules[0].Components[0].Envs = append(customResource.Spec.Modules[0].Components[0].Envs,
 				corev1.EnvVar{Name: "X_CSI_REVPROXY_USE_SECRET", Value: "false"})
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -838,8 +837,6 @@ func GetModuleDefaultVersion(driverConfigVersion string, driverType csmv1.Driver
 	if driverType == "isilon" {
 		dType = "powerscale"
 	}
-
-	log.Printf("driverConfigVersion: %s, driverType: %s, moduleType: %s, configMapPath: %s", driverConfigVersion, dType, moduleType, configMapPath)
 
 	if driver, ok := support[dType]; ok {
 		if modules, ok := driver[driverConfigVersion]; ok {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -837,6 +838,8 @@ func GetModuleDefaultVersion(driverConfigVersion string, driverType csmv1.Driver
 	if driverType == "isilon" {
 		dType = "powerscale"
 	}
+
+	log.Printf("driverConfigVersion: %s, driverType: %s, moduleType: %s, configMapPath: %s", driverConfigVersion, dType, moduleType, configMapPath)
 
 	if driver, ok := support[dType]; ok {
 		if modules, ok := driver[driverConfigVersion]; ok {

--- a/tests/e2e/steps/steps_def.go
+++ b/tests/e2e/steps/steps_def.go
@@ -348,7 +348,10 @@ func (step *Step) validateMinimalCSMDriverSpec(res Resource, driverName string, 
 	if driver.CSIDriverType == "" {
 		return fmt.Errorf("csiDriverType is missing")
 	}
-	if driver.Replicas == 0 {
+
+	// Ensure that the expected number of controller pods are running.
+	status := found.Status
+	if status.ControllerStatus.Failed > "0" {
 		return fmt.Errorf("replicas should have a non-zero value")
 	}
 
@@ -360,7 +363,6 @@ func (step *Step) validateMinimalCSMDriverSpec(res Resource, driverName string, 
 		driver.Node != nil ||
 		driver.CSIDriverSpec != nil ||
 		driver.DNSPolicy != "" ||
-		driver.Common != nil ||
 		driver.AuthSecret != "" ||
 		driver.TLSCertSecret != "" {
 		return fmt.Errorf("unexpected fields found in Driver spec: %+v", driver)

--- a/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
@@ -887,6 +887,32 @@
       run:
         - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
+- scenario: "Install PowerMax Driver with Mount Credentials (Minimal)"
+  paths:
+    - "testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml"
+  tags:
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-creds] in namespace [powermax] for [pmaxUseSecret]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Validate [powermax] driver spec from CR [1]"
+    - "Run custom test"
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret]"
+    - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
+
 - scenario: "Install PowerMax Driver (Minimal, With no forceRemoveDriver)"
   paths:
     - "testfiles/minimal-testfiles/storage_csm_powermax_with_no_forceRemoveDriver.yaml"

--- a/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: powermax
+  namespace: powermax
+spec:
+  driver:
+    csiDriverType: "powermax"
+    configVersion: v2.14.0
+    forceRemoveDriver: true
+    common:
+      envs:
+        - name: "X_CSI_REVPROXY_USE_SECRET"
+          value: "true"
+  modules:
+    - name: authorization
+      enabled: false
+    - name: resiliency
+      enabled: false
+    - name: replication
+      enabled: false
+    - name: observability
+      enabled: false


### PR DESCRIPTION
# Description
Fix dynamically adding parameters for the config map and mount credentials approach for Powermax. Also, fix the processing of the minimal manifest installation for Powermax to work with the mount credentials.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1614 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensure that unit tests are still passing as expected
<details>

```
-> # make test
test -s /root/git/public/dell/csm-operator/bin/controller-gen && /root/git/public/dell/csm-operator/bin/controller-gen --version | grep -q v0.16.5 || \
GOBIN=/root/git/public/dell/csm-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5
/root/git/public/dell/csm-operator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/root/git/public/dell/csm-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
(cd core; rm -f core_generated.go; go generate)
go run core/semver/semver.go -f mk > semver.mk
go fmt ./...
core/core_generated.go
go vet ./...
KUBEBUILDER_ASSETS="/root/.local/share/kubebuilder-envtest/k8s/1.31.0-linux-amd64" go test ./... -coverprofile cover.out
        github.com/dell/csm-operator            coverage: 0.0% of statements
        github.com/dell/csm-operator/api/v1             coverage: 0.0% of statements
        github.com/dell/csm-operator/core/semver                coverage: 0.0% of statements
        github.com/dell/csm-operator/core               coverage: 0.0% of statements
?       github.com/dell/csm-operator/pkg/constants      [no test files]
        github.com/dell/csm-operator/pkg/logger         coverage: 0.0% of statements
        github.com/dell/csm-operator/tests/shared/clientgoclient                coverage: 0.0% of statements
        github.com/dell/csm-operator/tests/shared               coverage: 0.0% of statements
        github.com/dell/csm-operator/tests/shared/crclient              coverage: 0.0% of statements
ok      github.com/dell/csm-operator/controllers        57.151s coverage: 86.4% of statements
ok      github.com/dell/csm-operator/k8s        0.228s  coverage: 90.3% of statements
ok      github.com/dell/csm-operator/pkg/drivers        1.558s  coverage: 96.9% of statements
ok      github.com/dell/csm-operator/pkg/modules        4.351s  coverage: 90.2% of statements
ok      github.com/dell/csm-operator/pkg/resources/configmap    0.074s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/csidriver    0.105s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/daemonset    0.190s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/deployment   0.117s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/rbac 0.100s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/resources/serviceaccount       0.148s  coverage: 100.0% of statements
ok      github.com/dell/csm-operator/pkg/utils  3.172s  coverage: 82.0% of statements
```
</details>

- [x] Ensure Powermax E2E tests run successfully
<details>

```
-> # bash run-e2e-test.sh --pmax
/root/git/public/dell/csm-operator/tests/e2e
  W0122 20:38:26.872454    2727 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0122 20:38:26.880340 2727 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/git/public/dell/csm-operator/tests/e2e
===========================================================================================
Random Seed: 1737578296

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 01/22/25 20:38:26.885
  STEP: [powermax] @ 01/22/25 20:38:26.885
  STEP: Reading values file @ 01/22/25 20:38:26.885
  STEP: Getting a k8s client @ 01/22/25 20:38:27.453
[BeforeSuite] PASSED [0.573 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver(Standalone)  @ 01/22/25 20:38:27.457
  STEP: Returning false here @ 01/22/25 20:38:27.457
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/22/25 20:38:27.457
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:38:27.548
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/22/25 20:38:28.755
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:38:29.234
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar] @ 01/22/25 20:38:29.947
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/22/25 20:38:30.88
  STEP:      Executing  Apply custom resource [1] @ 01/22/25 20:38:31.733
  I0122 20:38:31.734538 2727 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0122 20:38:32.425762 2727 builder.go:146] stderr: ""
  I0122 20:38:32.425821 2727 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/22/25 20:38:32.425
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/22/25 20:38:52.51
  STEP:      Executing  Run custom test @ 01/22/25 20:39:12.586
  I0122 20:39:12.586888 2727 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-22 20:39:12]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-22 20:39:12]  INFO Using EVENT observer type
[2025-01-22 20:39:12]  INFO Using config from /root/.kube/config
[2025-01-22 20:39:12]  INFO Successfully loaded config. Host: https://10.227.248.175:6443
[2025-01-22 20:39:12]  INFO Created new KubeClient
[2025-01-22 20:39:12]  INFO Running 1 iteration(s)
[2025-01-22 20:39:12]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-22 20:39:12]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-22 20:39:12]  INFO Successfully created namespace volumeio-test-91a7f60d
[2025-01-22 20:39:12]  INFO Using default number of volumes
[2025-01-22 20:39:12]  INFO Using default image: docker.io/centos:latest
[2025-01-22 20:39:12]  INFO Creating IO pod
[2025-01-22 20:39:12]  INFO Waiting for pod iowriter-test-89m9w to be READY
[2025-01-22 20:39:57]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-22 20:39:58]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-22 20:40:00]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-22 20:40:00]  INFO VolumeAttachment deleted
[2025-01-22 20:40:00]  INFO Deleting all resources in namespace volumeio-test-91a7f60d
[2025-01-22 20:40:12]  INFO Namespace volumeio-test-91a7f60d was deleted in 12.089312999s
[2025-01-22 20:40:13]  INFO SUCCESS: VolumeIoSuite in 1m0.204405026s
[2025-01-22 20:40:13]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-22 20:40:13]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-22 20:40:13]  WARN No ResourceUsageMetrics provided
[2025-01-22 20:40:13] ERROR no ResourceUsageMetrics provided
report-test-run-b9aa15a5:
Name: test-run-b9aa15a5
Host: https://10.227.248.175:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-b9aa15a5/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-b9aa15a5/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-b9aa15a5/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-b9aa15a5/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-b9aa15a5/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-22 20:39:12.780916685 +0000 UTC
            Ended:     2025-01-22 20:40:13.029299577 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 4.472952705s
                        Min: 4.472952705s
                        Max: 4.472952705s
                        Histogram:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.93622335s
                        Min: 2.93622335s
                        Max: 2.93622335s
                        Histogram:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 7.610314378s
                        Min: 7.610314378s
                        Max: 7.610314378s
                        Histogram:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 99.913218ms
                        Min: 99.913218ms
                        Max: 99.913218ms
                        Histogram:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.744060156s
                        Min: 1.744060156s
                        Max: 1.744060156s
                        Histogram:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 43.223200866s
                        Min: 43.223200866s
                        Max: 43.223200866s
                        Histogram:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 863.474757ms
                        Min: 863.474757ms
                        Max: 863.474757ms
                        Histogram:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-b9aa15a5/VolumeIoSuite9/EntityNumberOverTime.png

[2025-01-22 20:40:13]  INFO Avg time of a run:   47.93s
[2025-01-22 20:40:13]  INFO Avg time of a del:   12.09s
[2025-01-22 20:40:13]  INFO Avg time of all:     60.20s
[2025-01-22 20:40:13]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/22/25 20:40:13.508
  STEP:      Executing  Delete custom resource [1] @ 01/22/25 20:40:13.599
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/22/25 20:40:13.65

err: found the following pods: csipowermax-reverseproxy-bbbc6c6b7-szk8r,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar] @ 01/22/25 20:41:03.714
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:41:03.759
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:41:03.828
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/22/25 20:41:03.868
  STEP: Ending: Install PowerMax Driver(Standalone)
   @ 01/22/25 20:41:03.956
  STEP: Starting: Install PowerMax Driver with TLS (Standalone)  @ 01/22/25 20:41:08.96
  STEP: Returning false here @ 01/22/25 20:41:08.96
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/22/25 20:41:08.96
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:41:08.983
  STEP:      Executing  Set up reverse proxy tls secret with SAN namespace [powermax] @ 01/22/25 20:41:09.653
Temporary directory created at: /tmp/tls-setup1828511958
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:41:10.742
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar] @ 01/22/25 20:41:11.101
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/22/25 20:41:11.573
  STEP:      Executing  Apply custom resource [1] @ 01/22/25 20:41:12.021
  I0122 20:41:12.022372 2727 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0122 20:41:12.385201 2727 builder.go:146] stderr: ""
  I0122 20:41:12.385293 2727 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/22/25 20:41:12.385
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/22/25 20:41:32.447
  STEP:      Executing  Run custom test @ 01/22/25 20:41:52.523
  I0122 20:41:52.523844 2727 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-22 20:41:52]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-22 20:41:52]  INFO Using EVENT observer type
[2025-01-22 20:41:52]  INFO Using config from /root/.kube/config
[2025-01-22 20:41:52]  INFO Successfully loaded config. Host: https://10.227.248.175:6443
[2025-01-22 20:41:52]  INFO Created new KubeClient
[2025-01-22 20:41:52]  INFO Running 1 iteration(s)
[2025-01-22 20:41:52]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-22 20:41:52]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-22 20:41:52]  INFO Successfully created namespace volumeio-test-9bb2e2b5
[2025-01-22 20:41:52]  INFO Using default number of volumes
[2025-01-22 20:41:52]  INFO Using default image: docker.io/centos:latest
[2025-01-22 20:41:52]  INFO Creating IO pod
[2025-01-22 20:41:52]  INFO Waiting for pod iowriter-test-pkpht to be READY
[2025-01-22 20:42:32]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-22 20:42:33]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-22 20:42:36]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-22 20:42:36]  INFO VolumeAttachment deleted
[2025-01-22 20:42:36]  INFO Deleting all resources in namespace volumeio-test-9bb2e2b5
[2025-01-22 20:42:48]  INFO Namespace volumeio-test-9bb2e2b5 was deleted in 12.084658229s
[2025-01-22 20:42:52]  INFO SUCCESS: VolumeIoSuite in 1m0.158279806s
[2025-01-22 20:42:52]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-22 20:42:52]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-22 20:42:53]  WARN No ResourceUsageMetrics provided
[2025-01-22 20:42:53] ERROR no ResourceUsageMetrics provided
report-test-run-ec3d1714:
Name: test-run-ec3d1714
Host: https://10.227.248.175:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-ec3d1714/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-ec3d1714/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-ec3d1714/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-ec3d1714/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-ec3d1714/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-22 20:41:52.703725569 +0000 UTC
            Ended:     2025-01-22 20:42:52.861715435 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 2.681673159s
                        Min: 2.681673159s
                        Max: 2.681673159s
                        Histogram:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 3.217595162s
                        Min: 3.217595162s
                        Max: 3.217595162s
                        Histogram:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 6.783956211s
                        Min: 6.783956211s
                        Max: 6.783956211s
                        Histogram:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 69.164719ms
                        Min: 69.164719ms
                        Max: 69.164719ms
                        Histogram:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.890881925s
                        Min: 1.890881925s
                        Max: 1.890881925s
                        Histogram:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 38.752454643s
                        Min: 38.752454643s
                        Max: 38.752454643s
                        Histogram:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.05350824s
                        Min: 1.05350824s
                        Max: 1.05350824s
                        Histogram:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-ec3d1714/VolumeIoSuite10/EntityNumberOverTime.png

[2025-01-22 20:42:53]  INFO Avg time of a run:   43.94s
[2025-01-22 20:42:53]  INFO Avg time of a del:   12.09s
[2025-01-22 20:42:53]  INFO Avg time of all:     60.15s
[2025-01-22 20:42:53]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/22/25 20:42:53.351
  STEP:      Executing  Delete custom resource [1] @ 01/22/25 20:42:53.444
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/22/25 20:42:53.498

err: found the following pods: csipowermax-reverseproxy-bbbc6c6b7-s5zh8,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar] @ 01/22/25 20:43:43.579
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:43:43.634
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:43:43.683
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/22/25 20:43:43.71
  STEP: Ending: Install PowerMax Driver with TLS (Standalone)
   @ 01/22/25 20:43:43.8
  STEP: Starting: Install PowerMax Driver(Sidecar)  @ 01/22/25 20:43:48.804
  STEP: Returning false here @ 01/22/25 20:43:48.804
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/22/25 20:43:48.804
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:43:48.827
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/22/25 20:43:49.492
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:43:49.763
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar] @ 01/22/25 20:43:50.153
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/22/25 20:43:50.637
  STEP:      Executing  Apply custom resource [1] @ 01/22/25 20:43:51.126
  I0122 20:43:51.127449 2727 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0122 20:43:51.484529 2727 builder.go:146] stderr: ""
  I0122 20:43:51.484584 2727 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/22/25 20:43:51.484

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/22/25 20:44:41.583

err:
The container(registrar) in pod(powermax-node-57lxq) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2025-01-22 20:44:26 +0000 UTC,FinishedAt:2025-01-22 20:44:56 +0000 UTC,ContainerID:containerd://dbbfe383b3deeb46d03c22690f62de87f9c474fa1283c0e5a89857f27e522732,}}
The container(registrar) in pod(powermax-node-7495z) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2025-01-22 20:44:27 +0000 UTC,FinishedAt:2025-01-22 20:44:57 +0000 UTC,ContainerID:containerd://facf847e66767621184a45fc77ac578306c33e0edb3097294786c4a1824a40f8,}}
  STEP:      Executing  Run custom test @ 01/22/25 20:45:31.732
  I0122 20:45:31.733145 2727 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-22 20:45:31]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-22 20:45:31]  INFO Using EVENT observer type
[2025-01-22 20:45:31]  INFO Using config from /root/.kube/config
[2025-01-22 20:45:31]  INFO Successfully loaded config. Host: https://10.227.248.175:6443
[2025-01-22 20:45:31]  INFO Created new KubeClient
[2025-01-22 20:45:31]  INFO Running 1 iteration(s)
[2025-01-22 20:45:31]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-22 20:45:31]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-22 20:45:32]  INFO Successfully created namespace volumeio-test-465a8a65
[2025-01-22 20:45:32]  INFO Using default number of volumes
[2025-01-22 20:45:32]  INFO Using default image: docker.io/centos:latest
[2025-01-22 20:45:32]  INFO Creating IO pod
[2025-01-22 20:45:32]  INFO Waiting for pod iowriter-test-tzkn9 to be READY
[2025-01-22 20:46:16]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-22 20:46:17]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-22 20:46:19]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-22 20:46:19]  INFO VolumeAttachment deleted
[2025-01-22 20:46:19]  INFO Deleting all resources in namespace volumeio-test-465a8a65
[2025-01-22 20:46:32]  INFO Namespace volumeio-test-465a8a65 was deleted in 12.096190004s
[2025-01-22 20:46:32]  INFO SUCCESS: VolumeIoSuite in 1m0.320028452s
[2025-01-22 20:46:32]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-22 20:46:32]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->] 100.00% ? p/s1 / 1 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 35 p/s[2025-01-22 20:46:32]  WARN No ResourceUsageMetrics provided
[2025-01-22 20:46:32] ERROR no ResourceUsageMetrics provided
report-test-run-ef2e29bf:
Name: test-run-ef2e29bf
Host: https://10.227.248.175:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-ef2e29bf/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-ef2e29bf/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-ef2e29bf/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-ef2e29bf/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-ef2e29bf/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-22 20:45:31.937437275 +0000 UTC
            Ended:     2025-01-22 20:46:32.293758739 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 2.440633537s
                        Min: 2.440633537s
                        Max: 2.440633537s
                        Histogram:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.797723763s
                        Min: 2.797723763s
                        Max: 2.797723763s
                        Histogram:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 5.493833726s
                        Min: 5.493833726s
                        Max: 5.493833726s
                        Histogram:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 26.296747ms
                        Min: 26.296747ms
                        Max: 26.296747ms
                        Histogram:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.769776514s
                        Min: 1.769776514s
                        Max: 1.769776514s
                        Histogram:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 42.146426581s
                        Min: 42.146426581s
                        Max: 42.146426581s
                        Histogram:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.471637297s
                        Min: 1.471637297s
                        Max: 1.471637297s
                        Histogram:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-ef2e29bf/VolumeIoSuite11/EntityNumberOverTime.png

[2025-01-22 20:46:32]  INFO Avg time of a run:   47.98s
[2025-01-22 20:46:32]  INFO Avg time of a del:   12.10s
[2025-01-22 20:46:32]  INFO Avg time of all:     60.31s
[2025-01-22 20:46:32]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/22/25 20:46:32.812
  STEP:      Executing  Delete custom resource [1] @ 01/22/25 20:46:32.886
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/22/25 20:46:32.938

err: found the following pods: powermax-controller-6b78ff6667-9kb7z,powermax-controller-6b78ff6667-f4kkq,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar] @ 01/22/25 20:47:23.022
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:47:23.112
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:47:23.185
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/22/25 20:47:23.213
  STEP: Ending: Install PowerMax Driver(Sidecar)
   @ 01/22/25 20:47:23.292
  STEP: Starting: Install PowerMax Driver with TLS (Sidecar)  @ 01/22/25 20:47:28.296
  STEP: Returning false here @ 01/22/25 20:47:28.296
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/22/25 20:47:28.296
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:47:28.319
  STEP:      Executing  Set up reverse proxy tls secret with SAN namespace [powermax] @ 01/22/25 20:47:28.984
Temporary directory created at: /tmp/tls-setup3027028339
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:47:30.06
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar] @ 01/22/25 20:47:30.419
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/22/25 20:47:30.927
  STEP:      Executing  Apply custom resource [1] @ 01/22/25 20:47:31.367
  I0122 20:47:31.367862 2727 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0122 20:47:31.724045 2727 builder.go:146] stderr: ""
  I0122 20:47:31.724115 2727 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/22/25 20:47:31.724

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/22/25 20:48:21.807

err:
The container(registrar) in pod(powermax-node-dlv87) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2025-01-22 20:48:07 +0000 UTC,FinishedAt:2025-01-22 20:48:37 +0000 UTC,ContainerID:containerd://a7f8eebdd4076a47b4552c3fe95eaf6d3b31829f38cbf15b5fbd0e4bb4d6957c,}}
  STEP:      Executing  Run custom test @ 01/22/25 20:49:11.948
  I0122 20:49:11.948991 2727 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-22 20:49:11]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-22 20:49:11]  INFO Using EVENT observer type
[2025-01-22 20:49:11]  INFO Using config from /root/.kube/config
[2025-01-22 20:49:11]  INFO Successfully loaded config. Host: https://10.227.248.175:6443
[2025-01-22 20:49:12]  INFO Created new KubeClient
[2025-01-22 20:49:12]  INFO Running 1 iteration(s)
[2025-01-22 20:49:12]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-22 20:49:12]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-22 20:49:12]  INFO Successfully created namespace volumeio-test-76d0fc31
[2025-01-22 20:49:12]  INFO Using default number of volumes
[2025-01-22 20:49:12]  INFO Using default image: docker.io/centos:latest
[2025-01-22 20:49:12]  INFO Creating IO pod
[2025-01-22 20:49:12]  INFO Waiting for pod iowriter-test-qhlkp to be READY
[2025-01-22 20:49:50]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-22 20:49:51]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-22 20:49:54]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-22 20:49:54]  INFO VolumeAttachment deleted
[2025-01-22 20:49:54]  INFO Deleting all resources in namespace volumeio-test-76d0fc31
[2025-01-22 20:50:06]  INFO Namespace volumeio-test-76d0fc31 was deleted in 12.085933253s
[2025-01-22 20:50:07]  INFO SUCCESS: VolumeIoSuite in 55.153460372s
[2025-01-22 20:50:07]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-22 20:50:07]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->] 100.00% ? p/s1 / 1 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 49 p/s[2025-01-22 20:50:07]  WARN No ResourceUsageMetrics provided
[2025-01-22 20:50:07] ERROR no ResourceUsageMetrics provided
report-test-run-57ab943a:
Name: test-run-57ab943a
Host: https://10.227.248.175:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-57ab943a/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-57ab943a/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-57ab943a/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-57ab943a/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-57ab943a/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-22 20:49:12.147109701 +0000 UTC
            Ended:     2025-01-22 20:50:07.343350411 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 2.491559641s
                        Min: 2.491559641s
                        Max: 2.491559641s
                        Histogram:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.362051615s
                        Min: 2.362051615s
                        Max: 2.362051615s
                        Histogram:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 5.54806903s
                        Min: 5.54806903s
                        Max: 5.54806903s
                        Histogram:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 89.229018ms
                        Min: 89.229018ms
                        Max: 89.229018ms
                        Histogram:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.736068394s
                        Min: 1.736068394s
                        Max: 1.736068394s
                        Histogram:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 37.716113309s
                        Min: 37.716113309s
                        Max: 37.716113309s
                        Histogram:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.048816558s
                        Min: 1.048816558s
                        Max: 1.048816558s
                        Histogram:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-57ab943a/VolumeIoSuite12/EntityNumberOverTime.png

[2025-01-22 20:50:07]  INFO Avg time of a run:   41.90s
[2025-01-22 20:50:07]  INFO Avg time of a del:   12.09s
[2025-01-22 20:50:07]  INFO Avg time of all:     55.15s
[2025-01-22 20:50:07]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/22/25 20:50:07.858
  STEP:      Executing  Delete custom resource [1] @ 01/22/25 20:50:07.931
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/22/25 20:50:07.982

err: found the following pods: powermax-controller-bff7c699d-9mpz7,powermax-controller-bff7c699d-xtp9x,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar] @ 01/22/25 20:50:58.074
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:50:58.132
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:50:58.184
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/22/25 20:50:58.216
  STEP: Ending: Install PowerMax Driver with TLS (Sidecar)
   @ 01/22/25 20:50:58.298
  STEP: Starting: Install PowerMax Driver(With Observability)  @ 01/22/25 20:51:03.303
  STEP: Returning false here @ 01/22/25 20:51:03.303
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/22/25 20:51:03.303
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:51:03.326
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/22/25 20:51:04.019
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:51:04.302
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar] @ 01/22/25 20:51:04.669
  STEP:      Executing  Apply custom resource [1] @ 01/22/25 20:51:05.166
  I0122 20:51:05.167065 2727 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0122 20:51:05.506105 2727 builder.go:146] stderr: ""
  I0122 20:51:05.506184 2727 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/22/25 20:51:05.506

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/22/25 20:51:55.611

err:
The container(registrar) in pod(powermax-node-rjq5j) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2025-01-22 20:51:42 +0000 UTC,FinishedAt:2025-01-22 20:52:12 +0000 UTC,ContainerID:containerd://bc01d7518678451939fdd223e35120c11aa0d298c501d6587bb4972e079d3417,}}
  STEP:      Executing  Validate [observability] module from CR [1] is installed @ 01/22/25 20:52:45.762
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/22/25 20:52:55.932
  STEP:      Executing  Delete custom resource [1] @ 01/22/25 20:52:56.007
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/22/25 20:52:56.061

err: found the following pods: powermax-controller-6b78ff6667-bnx4d,powermax-controller-6b78ff6667-zn4rg,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar] @ 01/22/25 20:53:46.163
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:53:46.227
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:53:46.28
  STEP: Ending: Install PowerMax Driver(With Observability)
   @ 01/22/25 20:53:46.312
  STEP: Starting: Install PowerMax Driver (With Auth V1 module)  @ 01/22/25 20:53:51.313
  STEP: Returning false here @ 01/22/25 20:53:51.313
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/22/25 20:53:51.313
  STEP:      Executing  Create [authorization-proxy-server] prerequisites from CR [1] @ 01/22/25 20:53:51.335
=== Creating Authorization Proxy Server Prerequisites ===

Deleting all CSM from namespace: authorization
  STEP:      Executing  Apply custom resource [1] @ 01/22/25 20:53:59.321
  I0122 20:53:59.321913 2727 builder.go:121] Running '/usr/bin/kubectl --namespace=authorization apply --validate=true -f -'
  I0122 20:53:59.812192 2727 builder.go:146] stderr: ""
  I0122 20:53:59.812279 2727 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/authorization created\nconfigmap/csm-config-params created\n"
  STEP:      Executing  Validate [authorization-proxy-server] module from CR [1] is installed @ 01/22/25 20:53:59.812

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The pod(proxy-server-5459bd4d65-rszvj) is Pending
The pod(role-service-747c9d6db5-5qmsv) is Pending
The pod(storage-service-6c7955667c-m4k2r) is Pending
The pod(tenant-service-677bc6f84b-q288p) is Pending
  STEP:      Executing  Configure authorization-proxy-server for [powermax] for CR [1] @ 01/22/25 20:54:50.048
=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=====Waiting for everything to be up and running, adding a sleep time of 120 seconds before creating the role, tenant and role binding===
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===


=== Checking Storage ===

=== Checking Storage ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml storage list --insecure --addr csm-authorization.com:32658

=== Creating Storage ===

=== Storage ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml storage create --type powermax --endpoint https://10.230.24.220:8443 --system-id 000120001607 --user smc --password smc --array-insecure --insecure --addr csm-authorization.com:32658


=== Creating Tenant ===

=== Tenant ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml tenant create -n PancakeGroup --insecure --addr csm-authorization.com:32658
=== Checking Roles ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml role list --insecure --addr csm-authorization.com:32658


=== Creating Role ===

=== Role ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml role create --role=CSIGold=powermax=000120001607=SRP_1=100000000 --insecure --addr csm-authorization.com:32658


=== Creating RoleBinding ===

=== Binding Role ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml rolebinding create --tenant PancakeGroup --role CSIGold --insecure --addr csm-authorization.com:32658


=== Generating token ===

=== Token ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml generate token --tenant PancakeGroup --insecure --addr csm-authorization.com:32658 --access-token-expiration 2h0m0s


=== Applying token ===

=== Token Applied ===

  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:56:56.537
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar] @ 01/22/25 20:56:57.197
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/22/25 20:56:57.677
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:56:57.97
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxReverseProxy] @ 01/22/25 20:56:58.405
  STEP:      Executing  Apply custom resource [2] @ 01/22/25 20:56:58.87
  I0122 20:56:58.870590 2727 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0122 20:56:59.231911 2727 builder.go:146] stderr: ""
  I0122 20:56:59.231969 2727 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [2] @ 01/22/25 20:56:59.232
  STEP:      Executing  Validate [powermax] driver from CR [2] is installed @ 01/22/25 20:57:19.335
  STEP:      Executing  Validate [authorization] module from CR [2] is installed @ 01/22/25 20:57:39.394
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
  STEP:      Executing  Run custom test @ 01/22/25 20:57:49.505
  I0122 20:57:49.505261 2727 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1]
[2025-01-22 20:57:49]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-22 20:57:49]  INFO Using EVENT observer type
[2025-01-22 20:57:49]  INFO Using config from /root/.kube/config
[2025-01-22 20:57:49]  INFO Successfully loaded config. Host: https://10.227.248.175:6443
[2025-01-22 20:57:49]  INFO Created new KubeClient
[2025-01-22 20:57:49]  INFO Running 1 iteration(s)
[2025-01-22 20:57:49]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-22 20:57:49]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-22 20:57:49]  INFO Successfully created namespace volumeio-test-5229b32d
[2025-01-22 20:57:49]  INFO Using default number of volumes
[2025-01-22 20:57:49]  INFO Using default image: docker.io/centos:latest
[2025-01-22 20:57:49]  INFO Creating IO pod
[2025-01-22 20:57:49]  INFO Waiting for pod iowriter-test-m4f2f to be READY
[2025-01-22 20:58:33]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-22 20:58:35]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-22 20:58:37]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-22 20:58:37]  INFO VolumeAttachment deleted
[2025-01-22 20:58:37]  INFO Deleting all resources in namespace volumeio-test-5229b32d
[2025-01-22 20:58:49]  INFO Namespace volumeio-test-5229b32d was deleted in 12.087061997s
[2025-01-22 20:58:54]  INFO SUCCESS: VolumeIoSuite in 1m5.204226639s
[2025-01-22 20:58:54]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-22 20:58:54]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->] 100.00% ? p/s1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 814 p/s[2025-01-22 20:58:55]  WARN No ResourceUsageMetrics provided
[2025-01-22 20:58:55] ERROR no ResourceUsageMetrics provided
report-test-run-a30f5d29:
Name: test-run-a30f5d29
Host: https://10.227.248.175:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-a30f5d29/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-a30f5d29/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-a30f5d29/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-a30f5d29/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-a30f5d29/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-22 20:57:49.699523179 +0000 UTC
            Ended:     2025-01-22 20:58:54.946112642 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 6.567609774s
                        Min: 6.567609774s
                        Max: 6.567609774s
                        Histogram:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.801020569s
                        Min: 2.801020569s
                        Max: 2.801020569s
                        Histogram:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 9.673839485s
                        Min: 9.673839485s
                        Max: 9.673839485s
                        Histogram:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 9.990115ms
                        Min: 9.990115ms
                        Max: 9.990115ms
                        Histogram:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.859933055s
                        Min: 1.859933055s
                        Max: 1.859933055s
                        Histogram:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 43.733969577s
                        Min: 43.733969577s
                        Max: 43.733969577s
                        Histogram:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.994409295s
                        Min: 1.994409295s
                        Max: 1.994409295s
                        Histogram:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-a30f5d29/VolumeIoSuite13/EntityNumberOverTime.png

[2025-01-22 20:58:55]  INFO Avg time of a run:   48.02s
[2025-01-22 20:58:55]  INFO Avg time of a del:   12.09s
[2025-01-22 20:58:55]  INFO Avg time of all:     65.20s
[2025-01-22 20:58:55]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [2] @ 01/22/25 20:58:55.461
  STEP:      Executing  Delete custom resource [2] @ 01/22/25 20:58:55.548
  STEP:      Executing  Delete custom resource [1] @ 01/22/25 20:58:55.602
  STEP:      Executing  Validate [powermax] driver from CR [2] is not installed @ 01/22/25 20:58:55.647

err: found the following pods: powermax-controller-5d54ffb8d9-gncqs,powermax-controller-5d54ffb8d9-lmwc2,
  STEP:      Executing  Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar] @ 01/22/25 20:59:45.737
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:59:45.785
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy] @ 01/22/25 20:59:45.815
  STEP: Ending: Install PowerMax Driver (With Auth V1 module)
   @ 01/22/25 20:59:45.842
  STEP: Starting: Install Powermax Driver(Standalone), Enable Resiliency  @ 01/22/25 20:59:50.842
  STEP: Returning false here @ 01/22/25 20:59:50.843
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/22/25 20:59:50.843
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 20:59:50.864
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/22/25 20:59:51.517
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 20:59:51.794
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar] @ 01/22/25 20:59:52.191
  STEP:      Executing  Apply custom resource [1] @ 01/22/25 20:59:52.664
  I0122 20:59:52.665173 2727 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0122 20:59:53.029266 2727 builder.go:146] stderr: ""
  I0122 20:59:53.029320 2727 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/22/25 20:59:53.029
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/22/25 21:00:13.089
  STEP:      Executing  Validate [resiliency] module from CR [1] is not installed @ 01/22/25 21:00:33.165
  STEP:      Executing  Enable [resiliency] module from CR [1] @ 01/22/25 21:00:43.246
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/22/25 21:00:58.332

err:
The pod(powermax-controller-67bf5977b5-6lmfq) is Pending
  STEP:      Executing  Validate [resiliency] module from CR [1] is installed @ 01/22/25 21:01:48.465
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/22/25 21:01:58.566
  STEP:      Executing  Delete custom resource [1] @ 01/22/25 21:01:58.634
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/22/25 21:01:58.686

err: found the following pods: csipowermax-reverseproxy-bbbc6c6b7-jkvdh,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar] @ 01/22/25 21:02:48.748
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 21:02:48.809
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 21:02:48.872
  STEP: Ending: Install Powermax Driver(Standalone), Enable Resiliency
   @ 01/22/25 21:02:48.907
  STEP: Starting: Install Powermax Driver(With Resiliency), Disable Resiliency module  @ 01/22/25 21:02:53.908
  STEP: Returning false here @ 01/22/25 21:02:53.908
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/22/25 21:02:53.908
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 21:02:53.929
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/22/25 21:02:54.641
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 21:02:54.908
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxAuthSidecar] @ 01/22/25 21:02:55.294
  STEP:      Executing  Apply custom resource [1] @ 01/22/25 21:02:55.794
  I0122 21:02:55.795058 2727 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0122 21:02:56.148859 2727 builder.go:146] stderr: ""
  I0122 21:02:56.148911 2727 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/22/25 21:02:56.148

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/22/25 21:03:46.256
  STEP:      Executing  Validate [resiliency] module from CR [1] is installed @ 01/22/25 21:04:06.315
  STEP:      Executing  Disable [resiliency] module from CR [1] @ 01/22/25 21:04:16.429
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/22/25 21:04:16.502

err:
The pod(powermax-controller-6b78ff6667-5rm7p) is Pending
The pod(powermax-controller-6b78ff6667-wk2t9) is Pending

err:
The pod(powermax-controller-6b78ff6667-5rm7p) is Pending
The container(attacher) in pod(powermax-controller-6b78ff6667-wk2t9) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 10s restarting failed container=attacher pod=powermax-controller-6b78ff6667-wk2t9_powermax(4d5021a9-6426-47ce-83f3-e717d57b2d06),} nil nil}

err:
The container(attacher) in pod(powermax-controller-6b78ff6667-5rm7p) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:Lost connection to CSI driver, exiting,StartedAt:2025-01-22 21:05:26 +0000 UTC,FinishedAt:2025-01-22 21:05:32 +0000 UTC,ContainerID:containerd://18a8dd9bd2f9ae686d6edd38b00427314fa6c055b9fcbbe851aa3850c43cb5e5,}}
  STEP:      Executing  Validate [resiliency] module from CR [1] is not installed @ 01/22/25 21:06:06.782
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/22/25 21:06:16.865
  STEP:      Executing  Delete custom resource [1] @ 01/22/25 21:06:16.917
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/22/25 21:06:16.971

err: found the following pods: powermax-controller-6b78ff6667-5rm7p,powermax-controller-6b78ff6667-wk2t9,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config.yaml] for [pmaxAuthSidecar] @ 01/22/25 21:07:07.033
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/22/25 21:07:07.085
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 01/22/25 21:07:07.129
  STEP: Ending: Install Powermax Driver(With Resiliency), Disable Resiliency module
   @ 01/22/25 21:07:07.156
• [1724.699 seconds]
------------------------------

Ran 1 of 1 Specs in 1725.272 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 28m56.154618859s
Test Suite Passed
```
</details>

- [x] Add Minimal Test for Powermax Use Secret
<details>

```
-> # bash run-e2e-test.sh --pmax
/root/git/public/dell/csm-operator/tests/e2e
  W0124 16:16:31.528517   14742 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0124 16:16:31.531926 14742 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/git/public/dell/csm-operator/tests/e2e
===========================================================================================
Random Seed: 1737735377

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 01/24/25 16:16:31.534
  STEP: [powermax] @ 01/24/25 16:16:31.534
  STEP: Reading values file @ 01/24/25 16:16:31.534
  STEP: Getting a k8s client @ 01/24/25 16:16:31.549
[BeforeSuite] PASSED [0.029 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver with Mount Credentials (Minimal)  @ 01/24/25 16:16:31.563
  STEP: Returning false here @ 01/24/25 16:16:31.563
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/24/25 16:16:31.563
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/24/25 16:16:31.651
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-creds] in namespace [powermax] for [pmaxUseSecret] @ 01/24/25 16:16:33.027
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/24/25 16:16:33.804
  STEP:      Executing  Apply custom resource [1] @ 01/24/25 16:16:34.596
  I0124 16:16:34.596821 14742 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0124 16:16:35.154799 14742 builder.go:146] stderr: ""
  I0124 16:16:35.154864 14742 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/24/25 16:16:35.154

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/24/25 16:17:25.254
  STEP:      Executing  Validate [powermax] driver spec from CR [1] @ 01/24/25 16:17:45.334
  STEP:      Executing  Run custom test @ 01/24/25 16:17:45.356
  I0124 16:17:45.356123 14742 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-24 16:17:45]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-24 16:17:45]  INFO Using EVENT observer type
[2025-01-24 16:17:45]  INFO Using config from /root/.kube/config
[2025-01-24 16:17:45]  INFO Successfully loaded config. Host: https://10.227.248.175:6443
[2025-01-24 16:17:45]  INFO Created new KubeClient
[2025-01-24 16:17:45]  INFO Running 1 iteration(s)
[2025-01-24 16:17:45]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-24 16:17:45]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-24 16:17:45]  INFO Successfully created namespace volumeio-test-e3df4ab4
[2025-01-24 16:17:45]  INFO Using default number of volumes
[2025-01-24 16:17:45]  INFO Using default image: docker.io/centos:latest
[2025-01-24 16:17:45]  INFO Creating IO pod
[2025-01-24 16:17:45]  INFO Waiting for pod iowriter-test-x65d8 to be READY
[2025-01-24 16:18:27]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-24 16:18:28]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-24 16:18:31]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-24 16:18:31]  INFO VolumeAttachment deleted
[2025-01-24 16:18:31]  INFO Deleting all resources in namespace volumeio-test-e3df4ab4
[2025-01-24 16:18:43]  INFO Namespace volumeio-test-e3df4ab4 was deleted in 12.089884509s
[2025-01-24 16:18:45]  INFO SUCCESS: VolumeIoSuite in 1m0.178780255s
[2025-01-24 16:18:45]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-24 16:18:45]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-24 16:18:46]  WARN No ResourceUsageMetrics provided
[2025-01-24 16:18:46] ERROR no ResourceUsageMetrics provided
report-test-run-d51e5efc:
Name: test-run-d51e5efc
Host: https://10.227.248.175:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-d51e5efc/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-d51e5efc/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-d51e5efc/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-d51e5efc/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-d51e5efc/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-24 16:17:45.56952127 +0000 UTC
            Ended:     2025-01-24 16:18:45.790783049 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 6.300474034s
                        Min: 6.300474034s
                        Max: 6.300474034s
                        Histogram:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.803956782s
                        Min: 2.803956782s
                        Max: 2.803956782s
                        Histogram:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 9.329152694s
                        Min: 9.329152694s
                        Max: 9.329152694s
                        Histogram:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 11.188354ms
                        Min: 11.188354ms
                        Max: 11.188354ms
                        Histogram:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.875946326s
                        Min: 1.875946326s
                        Max: 1.875946326s
                        Histogram:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 41.148407127s
                        Min: 41.148407127s
                        Max: 41.148407127s
                        Histogram:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.368655756s
                        Min: 1.368655756s
                        Max: 1.368655756s
                        Histogram:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-d51e5efc/VolumeIoSuite15/EntityNumberOverTime.png

[2025-01-24 16:18:46]  INFO Avg time of a run:   46.05s
[2025-01-24 16:18:46]  INFO Avg time of a del:   12.09s
[2025-01-24 16:18:46]  INFO Avg time of all:     60.17s
[2025-01-24 16:18:46]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/24/25 16:18:46.365
  STEP:      Executing  Delete custom resource [1] @ 01/24/25 16:18:46.414
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/24/25 16:18:46.462

err: found the following pods: powermax-controller-76f78b4dc9-5z2c6,powermax-controller-76f78b4dc9-grq9v,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/24/25 16:19:36.561
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 01/24/25 16:19:36.654
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/24/25 16:19:36.77
  STEP: Ending: Install PowerMax Driver with Mount Credentials (Minimal)
   @ 01/24/25 16:19:36.912
• [190.353 seconds]
------------------------------

Ran 1 of 1 Specs in 190.382 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 3m24.791727409s
Test Suite Passed
```
</details>