### PR TITLE
Dynamically mount secret or config map on Powermax observability

### DIFF
--- a/operatorconfig/moduleconfig/common/version-values.yaml
+++ b/operatorconfig/moduleconfig/common/version-values.yaml
@@ -65,5 +65,5 @@ powermax:
     csireverseproxy: "v2.13.0"
     authorization: "v2.1.0"
     replication: "v1.11.0"
-    observability: "v1.11.0"
+    observability: "v1.12.0"
     resiliency: "v1.12.0"

--- a/operatorconfig/moduleconfig/observability/v1.12.0/custom-cert.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/custom-cert.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: <OBSERVABILITY_SECRET_PREFIX>-secret
+  namespace: karavi
+data:
+  # replace with actual base64-encoded certificate
+  tls.crt: <BASE64_CERTIFICATE>
+  # replace with actual base64-encoded private key
+  tls.key: <BASE64_PRIVATE_KEY>
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: <OBSERVABILITY_SECRET_PREFIX>-issuer
+  namespace: karavi
+spec:
+  ca:
+    secretName: <OBSERVABILITY_SECRET_PREFIX>-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: <OBSERVABILITY_SECRET_PREFIX>
+  namespace: karavi
+spec:
+  secretName: <OBSERVABILITY_SECRET_PREFIX>-tls
+  duration: 2160h  # 90d
+  renewBefore: 360h  # 15d
+  subject:
+    organizations:
+      - dell
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - <OBSERVABILITY_SECRET_PREFIX>
+    - <OBSERVABILITY_SECRET_PREFIX>.karavi.svc.kubernetes.local
+  issuerRef:
+    name: <OBSERVABILITY_SECRET_PREFIX>-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powerflex.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powerflex.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karavi-metrics-powerflex-controller
+  namespace: karavi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karavi-metrics-powerflex-controller
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes", "storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["*"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karavi-metrics-powerflex-controller
+subjects:
+  - kind: ServiceAccount
+    name: karavi-metrics-powerflex-controller
+    namespace: karavi
+roleRef:
+  kind: ClusterRole
+  name: karavi-metrics-powerflex-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powerflex
+    app.kubernetes.io/instance: karavi
+  name: karavi-metrics-powerflex
+  namespace: karavi
+spec:
+  type: ClusterIP
+  ports:
+    - name: karavi-metrics-powerflex
+      port: 2222
+      targetPort: 2222
+  selector:
+    app.kubernetes.io/name: karavi-metrics-powerflex
+    app.kubernetes.io/instance: karavi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: karavi-metrics-powerflex-configmap
+  namespace: karavi
+data:
+  karavi-metrics-powerflex.yaml: |
+    COLLECTOR_ADDR: <COLLECTOR_ADDRESS>
+    PROVISIONER_NAMES: csi-vxflexos.dellemc.com
+    POWERFLEX_SDC_METRICS_ENABLED: <POWERFLEX_SDC_METRICS_ENABLED>
+    POWERFLEX_SDC_IO_POLL_FREQUENCY: <POWERFLEX_SDC_IO_POLL_FREQUENCY>
+    POWERFLEX_VOLUME_IO_POLL_FREQUENCY: <POWERFLEX_VOLUME_IO_POLL_FREQUENCY>
+    POWERFLEX_VOLUME_METRICS_ENABLED: <POWERFLEX_VOLUME_METRICS_ENABLED>
+    POWERFLEX_STORAGE_POOL_METRICS_ENABLED: <POWERFLEX_STORAGE_POOL_METRICS_ENABLED>
+    POWERFLEX_STORAGE_POOL_POLL_FREQUENCY: <POWERFLEX_STORAGE_POOL_POLL_FREQUENCY>
+    POWERFLEX_MAX_CONCURRENT_QUERIES: <POWERFLEX_MAX_CONCURRENT_QUERIES>
+    LOG_LEVEL: <POWERFLEX_LOG_LEVEL>
+    LOG_FORMAT: <POWERFLEX_LOG_FORMAT>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: karavi
+data:
+  driver-config-params.yaml: |
+    CSI_LOG_LEVEL: debug
+    CSI_LOG_FORMAT: TEXT
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karavi-metrics-powerflex
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powerflex
+    app.kubernetes.io/instance: karavi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-metrics-powerflex
+      app.kubernetes.io/instance: karavi
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karavi-metrics-powerflex
+        app.kubernetes.io/instance: karavi
+        csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
+    spec:
+      serviceAccount: karavi-metrics-powerflex-controller
+      containers:
+        - name: karavi-metrics-powerflex
+          image: quay.io/dell/container-storage-modules/csm-metrics-powerflex:v1.11.0
+          resources: {}
+          env:
+            - name: POWERFLEX_METRICS_ENDPOINT
+              value: "karavi-metrics-powerflex"
+            - name: POWERFLEX_METRICS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TLS_ENABLED
+              value: "true"
+          volumeMounts:
+            - name: vxflexos-config
+              mountPath: /vxflexos-config
+            - name: tls-secret
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            - name: karavi-metrics-powerflex-configmap
+              mountPath: /etc/config
+      volumes:
+        - name: vxflexos-config
+          secret:
+            secretName: <DriverDefaultReleaseName>-config
+        - name: tls-secret
+          secret:
+            secretName: otel-collector-tls
+            items:
+              - key: tls.crt
+                path: cert.crt
+        - name: karavi-metrics-powerflex-configmap
+          configMap:
+            name: karavi-metrics-powerflex-configmap
+        - name: vxflexos-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+      restartPolicy: Always
+status: {}

--- a/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powermax.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powermax.yaml
@@ -1,0 +1,154 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karavi-metrics-powermax-controller
+  namespace: karavi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karavi-metrics-powermax-controller
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes", "storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karavi-metrics-powermax-controller
+subjects:
+  - kind: ServiceAccount
+    name: karavi-metrics-powermax-controller
+    namespace: karavi
+roleRef:
+  kind: ClusterRole
+  name: karavi-metrics-powermax-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powermax
+    app.kubernetes.io/instance: karavi
+  name: karavi-metrics-powermax
+  namespace: karavi
+spec:
+  type: ClusterIP
+  ports:
+    - name: karavi-metrics-powermax
+      port: 8081
+      targetPort: 8081
+  selector:
+    app.kubernetes.io/name: karavi-metrics-powermax
+    app.kubernetes.io/instance: karavi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: karavi-metrics-powermax-configmap
+  namespace: karavi
+data:
+  karavi-metrics-powermax.yaml: |
+    COLLECTOR_ADDR: <COLLECTOR_ADDRESS>
+    PROVISIONER_NAMES: csi-powermax.dellemc.com
+    POWERMAX_CAPACITY_METRICS_ENABLED: <POWERMAX_CAPACITY_METRICS_ENABLED>
+    POWERMAX_CAPACITY_POLL_FREQUENCY: <POWERMAX_CAPACITY_POLL_FREQUENCY>
+    POWERMAX_PERFORMANCE_METRICS_ENABLED: <POWERMAX_PERFORMANCE_METRICS_ENABLED>
+    POWERMAX_PERFORMANCE_POLL_FREQUENCY: <POWERMAX_PERFORMANCE_POLL_FREQUENCY>
+    POWERMAX_MAX_CONCURRENT_QUERIES: <POWERMAX_MAX_CONCURRENT_QUERIES>
+    LOG_LEVEL: <POWERMAX_LOG_LEVEL>
+    LOG_FORMAT: <POWERMAX_LOG_FORMAT>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: karavi
+data:
+  driver-config-params.yaml: |
+    CSI_LOG_LEVEL: debug
+    CSI_LOG_FORMAT: TEXT
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karavi-metrics-powermax
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powermax
+    app.kubernetes.io/instance: karavi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-metrics-powermax
+      app.kubernetes.io/instance: karavi
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karavi-metrics-powermax
+        app.kubernetes.io/instance: karavi
+        csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
+    spec:
+      serviceAccountName: karavi-metrics-powermax-controller
+      containers:
+        - name: karavi-metrics-powermax
+          image: quay.io/dell/container-storage-modules/csm-metrics-powermax:v1.6.0
+          resources: {}
+          env:
+            - name: POWERMAX_METRICS_ENDPOINT
+              value: "karavi-metrics-powermax"
+            - name: POWERMAX_METRICS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TLS_ENABLED
+              value: "true"
+            - name: SSL_CERT_DIR
+              value: /certs
+          volumeMounts:
+            # - name: <X_CSI_CONFIG_MAP_NAME>
+            #   mountPath: /etc/reverseproxy
+            - name: tls-secret
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            - name: karavi-metrics-powermax-configmap
+              mountPath: /etc/config
+            - name: certs
+              mountPath: /certs
+      volumes:
+        - name: certs
+          emptyDir: {}
+        # - name: <X_CSI_CONFIG_MAP_NAME>
+        #   configMap:
+        #     name: <X_CSI_CONFIG_MAP_NAME>
+        - name: tls-secret
+          secret:
+            secretName: otel-collector-tls
+            items:
+              - key: tls.crt
+                path: cert.crt
+        - name: karavi-metrics-powermax-configmap
+          configMap:
+            name: karavi-metrics-powermax-configmap
+        - name: powermax-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+      restartPolicy: Always
+status: {}

--- a/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powermax.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powermax.yaml
@@ -123,8 +123,6 @@ spec:
             - name: SSL_CERT_DIR
               value: /certs
           volumeMounts:
-            # - name: <X_CSI_CONFIG_MAP_NAME>
-            #   mountPath: /etc/reverseproxy
             - name: tls-secret
               mountPath: /etc/ssl/certs
               readOnly: true
@@ -135,9 +133,6 @@ spec:
       volumes:
         - name: certs
           emptyDir: {}
-        # - name: <X_CSI_CONFIG_MAP_NAME>
-        #   configMap:
-        #     name: <X_CSI_CONFIG_MAP_NAME>
         - name: tls-secret
           secret:
             secretName: otel-collector-tls

--- a/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powermax.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powermax.yaml
@@ -110,6 +110,7 @@ spec:
       containers:
         - name: karavi-metrics-powermax
           image: quay.io/dell/container-storage-modules/csm-metrics-powermax:v1.6.0
+          imagePullPolicy: Always
           resources: {}
           env:
             - name: POWERMAX_METRICS_ENDPOINT

--- a/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powerscale.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/karavi-metrics-powerscale.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karavi-metrics-powerscale-controller
+  namespace: karavi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karavi-metrics-powerscale-controller
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes", "storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["*"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karavi-metrics-powerscale-controller
+subjects:
+  - kind: ServiceAccount
+    name: karavi-metrics-powerscale-controller
+    namespace: karavi
+roleRef:
+  kind: ClusterRole
+  name: karavi-metrics-powerscale-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powerscale
+    app.kubernetes.io/instance: karavi
+  name: karavi-metrics-powerscale
+  namespace: karavi
+spec:
+  type: ClusterIP
+  ports:
+    - name: karavi-metrics-powerscale
+      port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: karavi-metrics-powerscale
+    app.kubernetes.io/instance: karavi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: karavi-metrics-powerscale-configmap
+  namespace: karavi
+data:
+  karavi-metrics-powerscale.yaml: |
+    COLLECTOR_ADDR: <COLLECTOR_ADDRESS>
+    PROVISIONER_NAMES: csi-isilon.dellemc.com
+    POWERSCALE_MAX_CONCURRENT_QUERIES: <POWERSCALE_MAX_CONCURRENT_QUERIES>
+    POWERSCALE_CAPACITY_METRICS_ENABLED: <POWERSCALE_CAPACITY_METRICS_ENABLED>
+    POWERSCALE_PERFORMANCE_METRICS_ENABLED: <POWERSCALE_PERFORMANCE_METRICS_ENABLED>
+    POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY: <POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY>
+    POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY: <POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY>
+    POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY: <POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY>
+    POWERSCALE_ISICLIENT_INSECURE: <ISICLIENT_INSECURE>
+    POWERSCALE_ISICLIENT_AUTH_TYPE: <ISICLIENT_AUTH_TYPE>
+    POWERSCALE_ISICLIENT_VERBOSE: <ISICLIENT_VERBOSE>
+    LOG_LEVEL: <POWERSCALE_LOG_LEVEL>
+    LOG_FORMAT: <POWERSCALE_LOG_FORMAT>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <DriverDefaultReleaseName>-config-params
+  namespace: karavi
+data:
+  driver-config-params.yaml: |
+    CSI_LOG_LEVEL: debug
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karavi-metrics-powerscale
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powerscale
+    app.kubernetes.io/instance: karavi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-metrics-powerscale
+      app.kubernetes.io/instance: karavi
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karavi-metrics-powerscale
+        app.kubernetes.io/instance: karavi
+        csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
+    spec:
+      serviceAccount: karavi-metrics-powerscale-controller
+      containers:
+        - name: karavi-metrics-powerscale
+          image: quay.io/dell/container-storage-modules/csm-metrics-powerscale:v1.8.0
+          resources: {}
+          env:
+            - name: POWERSCALE_METRICS_ENDPOINT
+              value: "karavi-metrics-powerscale"
+            - name: POWERSCALE_METRICS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TLS_ENABLED
+              value: "true"
+          volumeMounts:
+            - name: isilon-creds
+              mountPath: /isilon-creds
+            - name: tls-secret
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            - name: karavi-metrics-powerscale-configmap
+              mountPath: /etc/config
+      volumes:
+        - name: isilon-creds
+          secret:
+            secretName: <DriverDefaultReleaseName>-creds
+        - name: tls-secret
+          secret:
+            secretName: otel-collector-tls
+            items:
+              - key: tls.crt
+                path: cert.crt
+        - name: karavi-metrics-powerscale-configmap
+          configMap:
+            name: karavi-metrics-powerscale-configmap
+        - name: csi-isilon-config-params
+          configMap:
+            name: <DriverDefaultReleaseName>-config-params
+      restartPolicy: Always
+status: {}

--- a/operatorconfig/moduleconfig/observability/v1.12.0/karavi-otel-collector.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/karavi-otel-collector.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+data:
+  otel-collector-config.yaml: |-
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:55680
+            tls:
+              cert_file: /etc/ssl/certs/tls.crt
+              key_file: /etc/ssl/certs/tls.key
+
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+      logging:
+
+    extensions:
+      health_check: {}
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: []
+          exporters: [logging,prometheus]
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: karavi
+---
+apiVersion: v1
+data:
+  nginx.conf: |-
+    worker_processes  1;
+    events {
+      worker_connections  1024;
+    }
+
+    pid /tmp/nginx.pid;
+
+    http {
+      include       mime.types;
+      default_type  application/octet-stream;
+      sendfile        on;
+      keepalive_timeout  65;
+      server {
+        listen       8443 ssl;
+        server_name  localhost;
+        ssl_certificate      /etc/ssl/certs/tls.crt;
+        ssl_certificate_key  /etc/ssl/certs/tls.key;
+        ssl_protocols TLSv1.2;
+        ssl_ciphers AESGCM:-aNULL:-DH:-kRSA:@STRENGTH;
+        ssl_prefer_server_ciphers on;
+        location / {
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header Host $http_host;
+          proxy_pass http://127.0.0.1:8889/;
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: karavi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: karavi-observability
+spec:
+  type: ClusterIP
+  ports:
+    - port: 55680
+      targetPort: 55680
+      name: receiver
+    - port: 8443
+      targetPort: 8443
+      name: exporter-https
+  selector:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: karavi-observability
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: karavi-observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+      app.kubernetes.io/instance: karavi-observability
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-collector
+        app.kubernetes.io/instance: karavi-observability
+        csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
+    spec:
+      volumes:
+        - name: tls-secret
+          secret:
+            secretName: otel-collector-tls
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+        - name: otel-collector-config
+          configMap:
+            name: otel-collector-config
+      containers:
+        - name: nginx-proxy
+          image: <NGINX_PROXY_IMAGE>
+          volumeMounts:
+            - name: tls-secret
+              mountPath: /etc/ssl/certs
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+        - name: otel-collector
+          image: <OTEL_COLLECTOR_IMAGE>
+          args:
+            - --config=/etc/otel-collector-config.yaml
+          resources: {}
+          volumeMounts:
+            - name: otel-collector-config
+              mountPath: /etc/otel-collector-config.yaml
+              subPath: otel-collector-config.yaml
+            - name: tls-secret
+              mountPath: /etc/ssl/certs
+      restartPolicy: Always
+status: {}

--- a/operatorconfig/moduleconfig/observability/v1.12.0/karavi-topology.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/karavi-topology.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: karavi-topology-configmap
+  namespace: karavi
+data:
+  karavi-topology.yaml: |
+    PROVISIONER_NAMES: csi-isilon.dellemc.com,csi-vxflexos.dellemc.com, csi-powermax.dellemc.com
+    LOG_LEVEL: <TOPOLOGY_LOG_LEVEL>
+    LOG_FORMAT: text
+    ZIPKIN_URI: ""
+    ZIPKIN_SERVICE_NAME: karavi-topology
+    ZIPKIN_PROBABILITY: 0.0
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karavi-observability-topology-controller
+  namespace: karavi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karavi-observability-topology-controller
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karavi-observability-topology-controller
+subjects:
+  - kind: ServiceAccount
+    name: karavi-observability-topology-controller
+    namespace: karavi
+roleRef:
+  kind: ClusterRole
+  name: karavi-observability-topology-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: karavi-topology
+    app.kubernetes.io/instance: karavi-observability
+  name: karavi-topology
+  namespace: karavi
+spec:
+  type: ClusterIP
+  ports:
+    - name: karavi-topology
+      port: 8443
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/name: karavi-topology
+    app.kubernetes.io/instance: karavi-observability
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karavi-topology
+  namespace: karavi
+  labels:
+    app.kubernetes.io/name: karavi-topology
+    app.kubernetes.io/instance: karavi-observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-topology
+      app.kubernetes.io/instance: karavi-observability
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karavi-topology
+        app.kubernetes.io/instance: karavi-observability
+        csm: <NAME>
+        csmNamespace: <CSM_NAMESPACE>
+    spec:
+      volumes:
+        - name: karavi-topology-secret-volume
+          secret:
+            secretName: karavi-topology-tls
+            items:
+              - key: tls.crt
+                path: localhost.crt
+              - key: tls.key
+                path: localhost.key
+        - name: karavi-topology-configmap
+          configMap:
+            name: karavi-topology-configmap
+      serviceAccount: karavi-observability-topology-controller
+      containers:
+        - name: karavi-topology
+          image: quay.io/dell/container-storage-modules/csm-topology:v1.11.0
+          resources: {}
+          env:
+            - name: PORT
+              value: "8443"
+            - name: DEBUG
+              value: "false"
+          volumeMounts:
+            - name: karavi-topology-secret-volume
+              mountPath: "/certs"
+            - name: karavi-topology-configmap
+              mountPath: "/etc/config"
+      restartPolicy: Always
+status: {}

--- a/operatorconfig/moduleconfig/observability/v1.12.0/selfsigned-cert.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/selfsigned-cert.yaml
@@ -1,0 +1,35 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: karavi
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: <OBSERVABILITY_SECRET_PREFIX>
+  namespace: karavi
+spec:
+  secretName: <OBSERVABILITY_SECRET_PREFIX>-tls
+  duration: 2160h  # 90d
+  renewBefore: 360h  # 15d
+  subject:
+    organizations:
+      - dell
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - <OBSERVABILITY_SECRET_PREFIX>
+    - <OBSERVABILITY_SECRET_PREFIX>.karavi.svc.kubernetes.local
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -77,6 +77,8 @@ const (
 
 	CSIPowerMaxConfigPathKey   string = "X_CSI_POWERMAX_CONFIG_PATH"
 	CSIPowerMaxConfigPathValue string = "/powermax-config-params/driver-config-params.yaml"
+
+	PowerMaxMountCredentialMinVersion string = "v2.14.0"
 )
 
 type CustomEnv struct {

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -397,7 +397,7 @@ func DynamicallyMountPowermaxContent(configuration interface{}, cr csmv1.Contain
 
 		// Adding volume mount for both the reverseproxy and driver
 		for i, cnt := range podTemplate.Spec.Containers {
-			if *cnt.Name == "driver" || *cnt.Name == "reverseproxy" {
+			if *cnt.Name == "driver" || *cnt.Name == "reverseproxy" || *cnt.Name == "karavi-metrics-powermax" {
 				setPowermaxMountCredentialContent(&podTemplate.Spec.Containers[i])
 			}
 		}

--- a/pkg/modules/observability.go
+++ b/pkg/modules/observability.go
@@ -904,10 +904,7 @@ func PowerMaxMetrics(ctx context.Context, isDeleting bool, op utils.OperatorConf
 	useSecret := drivers.UseReverseProxySecret(&cr)
 	if secretSupported && useSecret {
 		// Append config map or mount cred secret.
-		err = drivers.DynamicallyMountPowermaxContent(dpApply, cr)
-		if err != nil {
-			return err
-		}
+		_ = drivers.DynamicallyMountPowermaxContent(dpApply, cr)
 	}
 
 	if !useSecret {
@@ -956,11 +953,9 @@ func PowerMaxMetrics(ctx context.Context, isDeleting bool, op utils.OperatorConf
 	return nil
 }
 
-func setPowerMaxMetricsConfigMap(dp *confv1.DeploymentApplyConfiguration, cr csmv1.ContainerStorageModule) error {
-	obs, err := getObservabilityModule(cr)
-	if err != nil {
-		return err
-	}
+func setPowerMaxMetricsConfigMap(dp *confv1.DeploymentApplyConfiguration, cr csmv1.ContainerStorageModule) {
+	// Previous calls already checked existence of the observability module
+	obs, _ := getObservabilityModule(cr)
 
 	cm := "powermax-reverseproxy-config"
 	// Get the config map name from the observability module
@@ -1006,8 +1001,6 @@ func setPowerMaxMetricsConfigMap(dp *confv1.DeploymentApplyConfiguration, cr csm
 	if !contains {
 		dp.Spec.Template.Spec.Containers[0].VolumeMounts = append(dp.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMount)
 	}
-
-	return nil
 }
 
 // getPowerMaxMetricsObject - get powermax metrics yaml string

--- a/pkg/modules/observability.go
+++ b/pkg/modules/observability.go
@@ -900,7 +900,7 @@ func PowerMaxMetrics(ctx context.Context, isDeleting bool, op utils.OperatorConf
 	}
 
 	// Dynamic secret/configMap mounting is only supported in v2.14.0 and above
-	secretSupported, _ := utils.MinVersionCheck("v2.14.0", cr.Spec.Driver.ConfigVersion)
+	secretSupported, _ := utils.MinVersionCheck(drivers.PowerMaxMountCredentialMinVersion, cr.Spec.Driver.ConfigVersion)
 	useSecret := drivers.UseReverseProxySecret(&cr)
 	if secretSupported && useSecret {
 		// Append config map or mount cred secret.

--- a/pkg/modules/observability.go
+++ b/pkg/modules/observability.go
@@ -904,6 +904,7 @@ func PowerMaxMetrics(ctx context.Context, isDeleting bool, op utils.OperatorConf
 	useSecret := drivers.UseReverseProxySecret(&cr)
 	if secretSupported && useSecret {
 		// Append config map or mount cred secret.
+		// We ensure that we pass through the DeploymentApplyConfiguration.
 		_ = drivers.DynamicallyMountPowermaxContent(dpApply, cr)
 	}
 

--- a/pkg/modules/observability.go
+++ b/pkg/modules/observability.go
@@ -11,6 +11,7 @@ package modules
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	confv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	acorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -897,6 +899,21 @@ func PowerMaxMetrics(ctx context.Context, isDeleting bool, op utils.OperatorConf
 		return fmt.Errorf("could not find deployment obj")
 	}
 
+	// Dynamic secret/configMap mounting is only supported in v2.14.0 and above
+	secretSupported, _ := utils.MinVersionCheck("v2.14.0", cr.Spec.Driver.ConfigVersion)
+	useSecret := drivers.UseReverseProxySecret(&cr)
+	if secretSupported && useSecret {
+		// Append config map or mount cred secret.
+		err = drivers.DynamicallyMountPowermaxContent(dpApply, cr)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !useSecret {
+		setPowerMaxMetricsConfigMap(dpApply, cr)
+	}
+
 	powerMaxMetricsObjects, err = appendObservabilitySecrets(ctx, cr, powerMaxMetricsObjects, ctrlClient, k8sClient)
 	if err != nil {
 		return fmt.Errorf("copy secrets from %s: %v", cr.Namespace, err)
@@ -934,6 +951,60 @@ func PowerMaxMetrics(ctx context.Context, isDeleting bool, op utils.OperatorConf
 		if err = deployment.SyncDeployment(ctx, *dpApply, k8sClient, cr.Name); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func setPowerMaxMetricsConfigMap(dp *confv1.DeploymentApplyConfiguration, cr csmv1.ContainerStorageModule) error {
+	obs, err := getObservabilityModule(cr)
+	if err != nil {
+		return err
+	}
+
+	cm := "powermax-reverseproxy-config"
+	// Get the config map name from the observability module
+	for _, component := range obs.Components {
+		if component.Name == ObservabilityMetricsPowerMaxName {
+			for _, env := range component.Envs {
+				if env.Name == "X_CSI_CONFIG_MAP_NAME" {
+					cm = env.Value
+					break
+				}
+			}
+		}
+	}
+
+	optional := false
+	vol := acorev1.VolumeApplyConfiguration{
+		Name: &cm,
+		VolumeSourceApplyConfiguration: acorev1.VolumeSourceApplyConfiguration{
+			ConfigMap: &acorev1.ConfigMapVolumeSourceApplyConfiguration{
+				LocalObjectReferenceApplyConfiguration: acorev1.LocalObjectReferenceApplyConfiguration{Name: &cm},
+				Optional:                               &optional,
+			},
+		},
+	}
+
+	// Dynamically add the volume
+	contains := slices.ContainsFunc(dp.Spec.Template.Spec.Volumes,
+		func(v acorev1.VolumeApplyConfiguration) bool { return *(v.Name) == *(vol.Name) },
+	)
+	if !contains {
+		dp.Spec.Template.Spec.Volumes = append(dp.Spec.Template.Spec.Volumes, vol)
+	}
+
+	mountPath := "/etc/reverseproxy"
+	volumeMount := acorev1.VolumeMountApplyConfiguration{Name: &cm, MountPath: &mountPath}
+	contains = slices.ContainsFunc(dp.Spec.Template.Spec.Containers[0].VolumeMounts,
+		func(v acorev1.VolumeMountApplyConfiguration) bool {
+			// Cast to pull out value instead of comparing addresses.
+			return *(v.Name) == *(volumeMount.Name)
+		},
+	)
+
+	if !contains {
+		dp.Spec.Template.Spec.Containers[0].VolumeMounts = append(dp.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMount)
 	}
 
 	return nil

--- a/pkg/modules/reverseproxy.go
+++ b/pkg/modules/reverseproxy.go
@@ -147,13 +147,13 @@ func ReverseProxyServer(ctx context.Context, isDeleting bool, op utils.OperatorC
 		if ctrlObj.GetName() == RevProxyServiceName && ctrlObj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
 			dp := ctrlObj.(*appsv1.Deployment)
 
-			revProxyModule, _, _ := getRevproxyApplyCR(cr, op)
-			secretSupported, _ := utils.MinVersionCheck("v2.13.0", revProxyModule.ConfigVersion)
+			secretSupported, _ := utils.MinVersionCheck(drivers.PowerMaxMountCredentialMinVersion, cr.Spec.Driver.ConfigVersion)
 			if secretSupported {
 				if drivers.UseReverseProxySecret(&cr) {
 					secretName := cr.Spec.Driver.AuthSecret
 					deploymentSetReverseProxySecretMounts(dp, secretName)
 				} else {
+					revProxyModule, _, _ := getRevproxyApplyCR(cr, op)
 					cm := getRevProxyEnvVariable(*revProxyModule, "X_CSI_CONFIG_MAP_NAME")
 					deploymentSetReverseProxyConfigMapMounts(dp, cm)
 				}
@@ -323,7 +323,7 @@ func ReverseProxyInjectDeployment(dp v1.DeploymentApplyConfiguration, cr csmv1.C
 	}
 
 	// Dynamic secret/configMap mounting is only supported in v2.14.0 and above
-	secretSupported, _ := utils.MinVersionCheck("v2.14.0", cr.Spec.Driver.ConfigVersion)
+	secretSupported, _ := utils.MinVersionCheck(drivers.PowerMaxMountCredentialMinVersion, cr.Spec.Driver.ConfigVersion)
 	useSecret := drivers.UseReverseProxySecret(&cr)
 	if secretSupported && useSecret {
 		err = drivers.DynamicallyMountPowermaxContent(&dp, cr)

--- a/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
@@ -913,6 +913,36 @@
       run:
         - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
+- scenario: "Install PowerMax Driver with Mount Credentials (Minimal), Enable Observability"
+  paths:
+    - "testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml"
+  tags:
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-creds] in namespace [powermax] for [pmaxUseSecret]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is not installed"
+    - "Enable [observability] module from CR [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is installed"
+    - "Validate [powermax] driver spec from CR [1]"
+    - "Run custom test"
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret]"
+    - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
+
 - scenario: "Install PowerMax Driver (Minimal, With no forceRemoveDriver)"
   paths:
     - "testfiles/minimal-testfiles/storage_csm_powermax_with_no_forceRemoveDriver.yaml"

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1845,6 +1845,36 @@
       run:
         - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
+- scenario: "Install PowerMax Driver with Mount Credentials, Enable Observability"
+  paths:
+    - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
+  tags:
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up reverse proxy tls secret namespace [powermax]"
+    - "Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is not installed"
+    - "Enable [observability] module from CR [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is installed"
+    - "Run custom test"
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret]"
+    - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
+
 - scenario: "Install PowerMax Driver with Mount Credentials (Sidecar)"
   paths:
     - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
@@ -1859,6 +1889,36 @@
     - "Apply custom resource [1]"
     - "Validate custom resource [1]"
     - "Validate [powermax] driver from CR [1] is installed"
+    - "Run custom test"
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret]"
+    - "Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
+
+- scenario: "Install PowerMax Driver with Mount Credentials (Sidecar), Enable Observability"
+  paths:
+    - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
+  tags:
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up reverse proxy tls secret namespace [powermax]"
+    - "Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is not installed"
+    - "Enable [observability] module from CR [1]"
+    - "Validate [powermax] driver from CR [1] is installed"
+    - "Validate [observability] module from CR [1] is installed"
     - "Run custom test"
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"

--- a/tests/e2e/testfiles/storage_csm_powermax_secret.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_secret.yaml
@@ -257,47 +257,105 @@ spec:
             # set it false, if you want it as a deployment
             - name: "DeployAsSidecar"
               value: "false"
-    - name: resiliency
-      # enabled: Enable/Disable Resiliency feature
-      # Allowed values:
-      #   true: enable Resiliency feature(deploy podmon sidecar)
-      #   false: disable Resiliency feature(do not deploy podmon sidecar)
-      # Default value: false
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
       enabled: false
       configVersion: v1.12.0
       components:
-        - name: podmon-controller
-          image: quay.io/dell/container-storage-modules/podmon:nightly
-          imagePullPolicy: Always
-          args:
-            - "--labelvalue=csi-powermax"
-            - "--arrayConnectivityPollRate=60"
-            - "--skipArrayConnectionValidation=false"
-            - "--driverPodLabelValue=dell-storage"
-            - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityConnectionLossThreshold=3"
-            # Below 4 args should not be modified.
-            - "--csisock=unix:/var/run/csi/csi.sock"
-            - "--mode=controller"
-            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
-            - "--driverPath=csi-powermax.dellemc.com"
-        - name: podmon-node
-          image: quay.io/dell/container-storage-modules/podmon:nightly
-          imagePullPolicy: Always
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: true
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: quay.io/dell/container-storage-modules/csm-topology:v1.10.0
+          # certificate: certificate for cert/private-key pair -- please add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: private key for cert/private-key pair -- please add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
           envs:
-            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
-            # Allowed values: Any valid and free port (string)
-            # Default value: 8083
-            - name: "X_CSI_PODMON_API_PORT"
-              value: "8083"
-          args:
-            - "--labelvalue=csi-powermax"
-            - "--arrayConnectivityPollRate=60"
-            - "--leaderelection=false"
-            - "--driverPodLabelValue=dell-storage"
-            - "--ignoreVolumelessPods=false"
-            # Below 4 args should not be modified.
-            - "--csisock=unix:/var/lib/kubelet/plugins/powermax.emc.dell.com/csi_sock"
-            - "--mode=node"
-            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
-            - "--driverPath=csi-powermax.dellemc.com"
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: true
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: otel/opentelemetry-collector:0.42.0
+          # certificate: certificate for cert/private-key pair -- please add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: private key for cert/private-key pair -- please add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.27"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.27"
+        - name: cert-manager
+          # enabled: Enable/Disable cert-manager
+          # Allowed values:
+          #   true: enable deployment of cert-manager
+          #   false: disable deployment of cert-manager only if it's already deployed
+          # Default value: false
+          enabled: true
+        - name: metrics-powermax
+          # enabled: Enable/Disable PowerMax metrics
+          enabled: true
+          # image: Defines PowerMax metrics image. This shouldn't be changed
+          image: quay.io/dell/container-storage-modules/csm-metrics-powermax:nightly
+          envs:
+            # POWERMAX_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerMax
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERMAX_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERMAX_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERMAX_PERFORMANCE_METRICS_ENABLED: enable/disable collection of volume performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERMAX_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERMAX_CAPACITY_POLL_FREQUENCY: set polling frequency to get capacity metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_CAPACITY_POLL_FREQUENCY"
+              value: "10"
+            # POWERMAX_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get volume performance data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_PERFORMANCE_POLL_FREQUENCY"
+              value: "10"
+            # PowerMax metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERMAX_LOG_LEVEL"
+              value: "INFO"
+            # PowerMax Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERMAX_LOG_FORMAT"
+              value: "TEXT"
+            # otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"
+            # configMap name which has all array/endpoint related info
+            - name: "X_CSI_CONFIG_MAP_NAME"
+              value: "powermax-reverseproxy-config"

--- a/tests/e2e/testfiles/storage_csm_powermax_secret_sidecar.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_secret_sidecar.yaml
@@ -257,47 +257,105 @@ spec:
             # set it false, if you want it as a deployment
             - name: "DeployAsSidecar"
               value: "true"
-    - name: resiliency
-      # enabled: Enable/Disable Resiliency feature
-      # Allowed values:
-      #   true: enable Resiliency feature(deploy podmon sidecar)
-      #   false: disable Resiliency feature(do not deploy podmon sidecar)
-      # Default value: false
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
       enabled: false
       configVersion: v1.12.0
       components:
-        - name: podmon-controller
-          image: quay.io/dell/container-storage-modules/podmon:nightly
-          imagePullPolicy: Always
-          args:
-            - "--labelvalue=csi-powermax"
-            - "--arrayConnectivityPollRate=60"
-            - "--skipArrayConnectionValidation=false"
-            - "--driverPodLabelValue=dell-storage"
-            - "--ignoreVolumelessPods=false"
-            - "--arrayConnectivityConnectionLossThreshold=3"
-            # Below 4 args should not be modified.
-            - "--csisock=unix:/var/run/csi/csi.sock"
-            - "--mode=controller"
-            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
-            - "--driverPath=csi-powermax.dellemc.com"
-        - name: podmon-node
-          image: quay.io/dell/container-storage-modules/podmon:nightly
-          imagePullPolicy: Always
+        - name: topology
+          # enabled: Enable/Disable topology
+          enabled: true
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: quay.io/dell/container-storage-modules/csm-topology:v1.10.0
+          # certificate: certificate for cert/private-key pair -- please add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: private key for cert/private-key pair -- please add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
           envs:
-            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
-            # Allowed values: Any valid and free port (string)
-            # Default value: 8083
-            - name: "X_CSI_PODMON_API_PORT"
-              value: "8083"
-          args:
-            - "--labelvalue=csi-powermax"
-            - "--arrayConnectivityPollRate=60"
-            - "--leaderelection=false"
-            - "--driverPodLabelValue=dell-storage"
-            - "--ignoreVolumelessPods=false"
-            # Below 4 args should not be modified.
-            - "--csisock=unix:/var/lib/kubelet/plugins/powermax.emc.dell.com/csi_sock"
-            - "--mode=node"
-            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
-            - "--driverPath=csi-powermax.dellemc.com"
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          enabled: true
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: otel/opentelemetry-collector:0.42.0
+          # certificate: certificate for cert/private-key pair -- please add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: private key for cert/private-key pair -- please add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "nginxinc/nginx-unprivileged:1.27"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "nginxinc/nginx-unprivileged:1.27"
+        - name: cert-manager
+          # enabled: Enable/Disable cert-manager
+          # Allowed values:
+          #   true: enable deployment of cert-manager
+          #   false: disable deployment of cert-manager only if it's already deployed
+          # Default value: false
+          enabled: true
+        - name: metrics-powermax
+          # enabled: Enable/Disable PowerMax metrics
+          enabled: true
+          # image: Defines PowerMax metrics image. This shouldn't be changed
+          image: quay.io/dell/container-storage-modules/csm-metrics-powermax:nightly
+          envs:
+            # POWERMAX_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerMax
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERMAX_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERMAX_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERMAX_PERFORMANCE_METRICS_ENABLED: enable/disable collection of volume performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERMAX_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERMAX_CAPACITY_POLL_FREQUENCY: set polling frequency to get capacity metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_CAPACITY_POLL_FREQUENCY"
+              value: "10"
+            # POWERMAX_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get volume performance data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_PERFORMANCE_POLL_FREQUENCY"
+              value: "10"
+            # PowerMax metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERMAX_LOG_LEVEL"
+              value: "INFO"
+            # PowerMax Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERMAX_LOG_FORMAT"
+              value: "TEXT"
+            # otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"
+            # configMap name which has all array/endpoint related info
+            - name: "X_CSI_CONFIG_MAP_NAME"
+              value: "powermax-reverseproxy-config"


### PR DESCRIPTION
# Description
Dynamically add and mount the config map or secret depending on which approach is defined during the Powermax CR installation.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1614 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Install with Mount Credentials Enabled
```
   karavi-metrics-powermax:
...
      X_CSI_REVPROXY_SECRET_FILEPATH:  /etc/powermax/config
      X_CSI_REVPROXY_USE_SECRET:       true
      X_CSI_POWERMAX_CONFIG_PATH:      /powermax-config-params/driver-config-params.yaml
    Mounts:
      /certs from certs (rw)
      /etc/config from karavi-metrics-powermax-configmap (rw)
      /etc/powermax from powermax-reverseproxy-secret (rw)
      /etc/ssl/certs from tls-secret (ro)
      powermax-config-params from powermax-config-params (rw)
  Volumes:
...
   powermax-config-params:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      powermax-config-params
    Optional:  false
   powermax-reverseproxy-secret:
    Type:          Secret (a volume populated by a Secret)
    SecretName:    powermax-config
    Optional:      false
```
- [x] Add unit tests for Powermax Observability using mount credentials.
```
PASS
coverage: 90.3% of statements
ok      github.com/dell/csm-operator/pkg/modules        0.885s  coverage: 90.3% of statements
```
- [x] Add and run new PowerMax Observability using mount credentials E2E tests.
<details>

```
-> # bash run-e2e-test.sh --pmax
/root/git/public/dell/csm-operator/tests/e2e
  W0131 16:24:12.979634    4483 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0131 16:24:12.980080 4483 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/git/public/dell/csm-operator/tests/e2e
===========================================================================================
Random Seed: 1738340629

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 01/31/25 16:24:12.98
  STEP: [powermax] @ 01/31/25 16:24:12.983
  STEP: Reading values file @ 01/31/25 16:24:12.983
  STEP: Getting a k8s client @ 01/31/25 16:24:12.986
[BeforeSuite] PASSED [0.009 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver with Mount Credentials, Enable Observability  @ 01/31/25 16:24:12.989
  STEP: Returning false here @ 01/31/25 16:24:12.989
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/31/25 16:24:12.989
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/31/25 16:24:13.004
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/31/25 16:24:14.34
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret] @ 01/31/25 16:24:14.772
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/31/25 16:24:15.753
  STEP:      Executing  Apply custom resource [1] @ 01/31/25 16:24:17.255
  I0131 16:24:17.257542 4483 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0131 16:24:17.924032 4483 builder.go:146] stderr: ""
  I0131 16:24:17.924113 4483 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/31/25 16:24:17.924

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/31/25 16:25:07.961
  STEP:      Executing  Validate [observability] module from CR [1] is not installed @ 01/31/25 16:25:27.971
  STEP:      Executing  Enable [observability] module from CR [1] @ 01/31/25 16:25:37.98
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/31/25 16:25:52.997
  STEP:      Executing  Validate [observability] module from CR [1] is installed @ 01/31/25 16:26:13.001
  STEP:      Executing  Run custom test @ 01/31/25 16:26:23.037
  I0131 16:26:23.037798 4483 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-31 16:26:23]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-31 16:26:23]  INFO Using EVENT observer type
[2025-01-31 16:26:23]  INFO Using config from /root/.kube/config
[2025-01-31 16:26:23]  INFO Successfully loaded config. Host: https://10.247.142.130:6443
[2025-01-31 16:26:23]  INFO Created new KubeClient
[2025-01-31 16:26:23]  INFO Running 1 iteration(s)
[2025-01-31 16:26:23]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-31 16:26:23]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-31 16:26:23]  INFO Successfully created namespace volumeio-test-a091f942
[2025-01-31 16:26:23]  INFO Using default number of volumes
[2025-01-31 16:26:23]  INFO Using default image: docker.io/centos:latest
[2025-01-31 16:26:23]  INFO Creating IO pod
[2025-01-31 16:26:23]  INFO Waiting for pod iowriter-test-89f9b to be READY
[2025-01-31 16:26:51]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-31 16:26:54]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-31 16:27:04]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-31 16:27:04]  INFO VolumeAttachment deleted
[2025-01-31 16:27:04]  INFO Deleting all resources in namespace volumeio-test-a091f942
[2025-01-31 16:27:16]  INFO Namespace volumeio-test-a091f942 was deleted in 12.011682431s
[2025-01-31 16:27:18]  INFO SUCCESS: VolumeIoSuite in 55.073234281s
[2025-01-31 16:27:18]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-31 16:27:18]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sGenerating plots
1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->] 100.00% ? p/s1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 217 p/s[2025-01-31 16:27:18]  WARN No ResourceUsageMetrics provided
[2025-01-31 16:27:18] ERROR no ResourceUsageMetrics provided
report-test-run-4c871c2a:
Name: test-run-4c871c2a
Host: https://10.247.142.130:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-4c871c2a/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-4c871c2a/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-4c871c2a/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-4c871c2a/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-4c871c2a/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-31 16:26:23.381689676 +0000 UTC
            Ended:     2025-01-31 16:27:18.455663641 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 5.122314719s
                        Min: 5.122314719s
                        Max: 5.122314719s
                        Histogram:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.356683546s
                        Min: 2.356683546s
                        Max: 2.356683546s
                        Histogram:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 8.181929219s
                        Min: 8.181929219s
                        Max: 8.181929219s
                        Histogram:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 7.547235ms
                        Min: 7.547235ms
                        Max: 7.547235ms
                        Histogram:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.695308226s
                        Min: 1.695308226s
                        Max: 1.695308226s
                        Histogram:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 27.56987566s
                        Min: 27.56987566s
                        Max: 27.56987566s
                        Histogram:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 6.568413763s
                        Min: 6.568413763s
                        Max: 6.568413763s
                        Histogram:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-4c871c2a/VolumeIoSuite28/EntityNumberOverTime.png

[2025-01-31 16:27:18]  INFO Avg time of a run:   41.50s
[2025-01-31 16:27:18]  INFO Avg time of a del:   12.01s
[2025-01-31 16:27:18]  INFO Avg time of all:     55.07s
[2025-01-31 16:27:18]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/31/25 16:27:18.971
  STEP:      Executing  Delete custom resource [1] @ 01/31/25 16:27:18.988
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/31/25 16:27:19.005

err: found the following pods: csipowermax-reverseproxy-5bfd48dc89-bxdkr,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/31/25 16:28:09.035
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 01/31/25 16:28:09.082
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/31/25 16:28:09.144
  STEP: Ending: Install PowerMax Driver with Mount Credentials, Enable Observability
   @ 01/31/25 16:28:09.212
• [241.227 seconds]
------------------------------

Ran 1 of 1 Specs in 241.236 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 4m24.6714596s
Test Suite Passed
root@lglbv2165 [16:28:14] [~/git/public/dell/csm-operator/tests/e2e] [usr/falfaroc/powermax-obs-secret-mount *]
-> # bash run-e2e-test.sh --pmax
/root/git/public/dell/csm-operator/tests/e2e
  W0131 16:30:59.905907    8775 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0131 16:30:59.906136 8775 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/git/public/dell/csm-operator/tests/e2e
===========================================================================================
Random Seed: 1738341044

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 01/31/25 16:30:59.908
  STEP: [powermax] @ 01/31/25 16:30:59.908
  STEP: Reading values file @ 01/31/25 16:30:59.908
  STEP: Getting a k8s client @ 01/31/25 16:30:59.911
[BeforeSuite] PASSED [0.006 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver with Mount Credentials (Sidecar), Enable Observability  @ 01/31/25 16:30:59.914
  STEP: Returning false here @ 01/31/25 16:30:59.914
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/31/25 16:30:59.914
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/31/25 16:30:59.928
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 01/31/25 16:31:01.166
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret] @ 01/31/25 16:31:01.72
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/31/25 16:31:02.572
  STEP:      Executing  Apply custom resource [1] @ 01/31/25 16:31:03.579
  I0131 16:31:03.580210 8775 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0131 16:31:04.135170 8775 builder.go:146] stderr: ""
  I0131 16:31:04.135235 8775 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/31/25 16:31:04.135

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/31/25 16:32:24.205
  STEP:      Executing  Validate [observability] module from CR [1] is not installed @ 01/31/25 16:32:44.228
  STEP:      Executing  Enable [observability] module from CR [1] @ 01/31/25 16:32:54.238
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/31/25 16:33:09.255
  STEP:      Executing  Validate [observability] module from CR [1] is installed @ 01/31/25 16:33:29.265
  STEP:      Executing  Run custom test @ 01/31/25 16:33:39.289
  I0131 16:33:39.290044 8775 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-31 16:33:39]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-31 16:33:39]  INFO Using EVENT observer type
[2025-01-31 16:33:39]  INFO Using config from /root/.kube/config
[2025-01-31 16:33:39]  INFO Successfully loaded config. Host: https://10.247.142.130:6443
[2025-01-31 16:33:39]  INFO Created new KubeClient
[2025-01-31 16:33:39]  INFO Running 1 iteration(s)
[2025-01-31 16:33:39]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-31 16:33:39]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-31 16:33:39]  INFO Successfully created namespace volumeio-test-53ccc4fa
[2025-01-31 16:33:39]  INFO Using default number of volumes
[2025-01-31 16:33:39]  INFO Using default image: docker.io/centos:latest
[2025-01-31 16:33:39]  INFO Creating IO pod
[2025-01-31 16:33:39]  INFO Waiting for pod iowriter-test-nhfpd to be READY
[2025-01-31 16:34:05]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-31 16:34:09]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-31 16:34:19]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-31 16:34:19]  INFO VolumeAttachment deleted
[2025-01-31 16:34:19]  INFO Deleting all resources in namespace volumeio-test-53ccc4fa
[2025-01-31 16:34:31]  INFO Namespace volumeio-test-53ccc4fa was deleted in 12.011375124s
[2025-01-31 16:34:34]  INFO SUCCESS: VolumeIoSuite in 55.1156757s
[2025-01-31 16:34:34]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-31 16:34:34]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->] 100.00% ? p/s1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 193 p/s[2025-01-31 16:34:34]  WARN No ResourceUsageMetrics provided
[2025-01-31 16:34:34] ERROR no ResourceUsageMetrics provided
report-test-run-c4c31264:
Name: test-run-c4c31264
Host: https://10.247.142.130:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-c4c31264/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-c4c31264/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-c4c31264/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-c4c31264/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-c4c31264/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-31 16:33:39.402462485 +0000 UTC
            Ended:     2025-01-31 16:34:34.560698857 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 5.22074927s
                        Min: 5.22074927s
                        Max: 5.22074927s
                        Histogram:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.259193291s
                        Min: 2.259193291s
                        Max: 2.259193291s
                        Histogram:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 8.269082845s
                        Min: 8.269082845s
                        Max: 8.269082845s
                        Histogram:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 11.8268ms
                        Min: 11.8268ms
                        Max: 11.8268ms
                        Histogram:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.705072234s
                        Min: 1.705072234s
                        Max: 1.705072234s
                        Histogram:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 24.308024809s
                        Min: 24.308024809s
                        Max: 24.308024809s
                        Histogram:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 6.085387008s
                        Min: 6.085387008s
                        Max: 6.085387008s
                        Histogram:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-c4c31264/VolumeIoSuite29/EntityNumberOverTime.png

[2025-01-31 16:34:35]  INFO Avg time of a run:   40.51s
[2025-01-31 16:34:35]  INFO Avg time of a del:   12.01s
[2025-01-31 16:34:35]  INFO Avg time of all:     55.11s
[2025-01-31 16:34:35]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/31/25 16:34:35.071
  STEP:      Executing  Delete custom resource [1] @ 01/31/25 16:34:35.087
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/31/25 16:34:35.102

err: found the following pods: powermax-controller-56cd56997c-62cdd,powermax-controller-56cd56997c-x6nj9,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/31/25 16:35:25.138
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 01/31/25 16:35:25.184
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/31/25 16:35:25.249
  STEP: Ending: Install PowerMax Driver with Mount Credentials (Sidecar), Enable Observability
   @ 01/31/25 16:35:25.322
• [270.409 seconds]
------------------------------

Ran 1 of 1 Specs in 270.416 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 4m45.424468904s
Test Suite Passed
```
</details>

- [x] Add and run e2e test for minimal manifest with observability on Powermax mount credentials.
<details>

```
/root/git/public/dell/csm-operator/tests/e2e
  W0131 18:13:32.228196   12943 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0131 18:13:32.232189 12943 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/git/public/dell/csm-operator/tests/e2e
===========================================================================================
Random Seed: 1738347161

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 01/31/25 18:13:32.233
  STEP: [powermax] @ 01/31/25 18:13:32.233
  STEP: Reading values file @ 01/31/25 18:13:32.233
  STEP: Getting a k8s client @ 01/31/25 18:13:32.235
[BeforeSuite] PASSED [0.012 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver with Mount Credentials (Minimal), Enable Observability  @ 01/31/25 18:13:32.245
  STEP: Returning false here @ 01/31/25 18:13:32.245
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 01/31/25 18:13:32.246
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/31/25 18:13:32.259
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-creds] in namespace [powermax] for [pmaxUseSecret] @ 01/31/25 18:13:33.387
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/31/25 18:13:34.363
  STEP:      Executing  Apply custom resource [1] @ 01/31/25 18:13:35.391
  I0131 18:13:35.392056 12943 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0131 18:13:35.678170 12943 builder.go:146] stderr: ""
  I0131 18:13:35.678239 12943 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 01/31/25 18:13:35.678

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/31/25 18:14:55.733
  STEP:      Executing  Validate [observability] module from CR [1] is not installed @ 01/31/25 18:15:15.756
  STEP:      Executing  Enable [observability] module from CR [1] @ 01/31/25 18:15:25.764
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 01/31/25 18:15:40.776
  STEP:      Executing  Validate [observability] module from CR [1] is installed @ 01/31/25 18:16:00.791
  STEP:      Executing  Validate [powermax] driver spec from CR [1] @ 01/31/25 18:16:10.811
  STEP:      Executing  Run custom test @ 01/31/25 18:16:10.814
  I0131 18:16:10.814824 12943 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-01-31 18:16:10]  INFO Starting cert-csi; ver. 1.4.1
[2025-01-31 18:16:10]  INFO Using EVENT observer type
[2025-01-31 18:16:10]  INFO Using config from /root/.kube/config
[2025-01-31 18:16:10]  INFO Successfully loaded config. Host: https://10.247.142.130:6443
[2025-01-31 18:16:10]  INFO Created new KubeClient
[2025-01-31 18:16:10]  INFO Running 1 iteration(s)
[2025-01-31 18:16:10]  INFO     *** ITERATION NUMBER 1 ***
[2025-01-31 18:16:10]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-01-31 18:16:10]  INFO Successfully created namespace volumeio-test-d7acb376
[2025-01-31 18:16:10]  INFO Using default number of volumes
[2025-01-31 18:16:10]  INFO Using default image: docker.io/centos:latest
[2025-01-31 18:16:10]  INFO Creating IO pod
[2025-01-31 18:16:10]  INFO Waiting for pod iowriter-test-qv8kr to be READY
[2025-01-31 18:16:28]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-01-31 18:16:30]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-01-31 18:16:34]  INFO Waiting until no Volume Attachments with PV  left
[2025-01-31 18:16:34]  INFO VolumeAttachment deleted
[2025-01-31 18:16:34]  INFO Deleting all resources in namespace volumeio-test-d7acb376
[2025-01-31 18:16:46]  INFO Namespace volumeio-test-d7acb376 was deleted in 12.010989919s
[2025-01-31 18:16:51]  INFO SUCCESS: VolumeIoSuite in 40.107843397s
[2025-01-31 18:16:51]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-31 18:16:51]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sGenerating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-01-31 18:16:51]  WARN No ResourceUsageMetrics provided
[2025-01-31 18:16:51] ERROR no ResourceUsageMetrics provided
report-test-run-0b10757b:
Name: test-run-0b10757b
Host: https://10.247.142.130:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-0b10757b/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-0b10757b/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-0b10757b/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-0b10757b/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-0b10757b/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-01-31 18:16:10.897569866 +0000 UTC
            Ended:     2025-01-31 18:16:51.004890557 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 5.143126987s
                        Min: 5.143126987s
                        Max: 5.143126987s
                        Histogram:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.211534851s
                        Min: 2.211534851s
                        Max: 2.211534851s
                        Histogram:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 8.15417108s
                        Min: 8.15417108s
                        Max: 8.15417108s
                        Histogram:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 12.314218ms
                        Min: 12.314218ms
                        Max: 12.314218ms
                        Histogram:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.780760982s
                        Min: 1.780760982s
                        Max: 1.780760982s
                        Histogram:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 16.938452003s
                        Min: 16.938452003s
                        Max: 16.938452003s
                        Histogram:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 2.836237072s
                        Min: 2.836237072s
                        Max: 2.836237072s
                        Histogram:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-0b10757b/VolumeIoSuite30/EntityNumberOverTime.png

[2025-01-31 18:16:51]  INFO Avg time of a run:   23.81s
[2025-01-31 18:16:51]  INFO Avg time of a del:   12.01s
[2025-01-31 18:16:51]  INFO Avg time of all:     40.10s
[2025-01-31 18:16:51]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 01/31/25 18:16:51.49
  STEP:      Executing  Delete custom resource [1] @ 01/31/25 18:16:51.5
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 01/31/25 18:16:51.509

err: found the following pods: powermax-controller-9dfb78bfb-jdhps,powermax-controller-9dfb78bfb-lltdd,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 01/31/25 18:17:41.546
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 01/31/25 18:17:41.62
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 01/31/25 18:17:41.701
  STEP: Ending: Install PowerMax Driver with Mount Credentials (Minimal), Enable Observability
   @ 01/31/25 18:17:41.783
• [254.537 seconds]
------------------------------

Ran 1 of 1 Specs in 254.550 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 5m5.403718408s
Test Suite Passed
```
</details>
