### PR TITLE
Add auth v1 e2e tests using PowerMax mount credentials

### DIFF
--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1875,6 +1875,47 @@
       run:
         - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
+- scenario: "Install PowerMax Driver with Mount Credentials, Enable Authorization v1"
+  paths:
+    - "testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server.yaml"
+    - "testfiles/storage_csm_powermax_secret.yaml"
+  tags:
+    - "authorizationproxyserver"
+    - "authorization"
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create [authorization-proxy-server] prerequisites from CR [1]"
+    - "Apply custom resource [1]"
+    - "Validate [authorization-proxy-server] module from CR [1] is installed"
+    - "Configure authorization-proxy-server for [powermax] for CR [1]"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar]"
+    - "Set up reverse proxy tls secret namespace [powermax]"
+    - "Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [2]"
+    - "Validate custom resource [2]"
+    - "Validate [powermax] driver from CR [2] is installed"
+    - "Validate [authorization] module from CR [2] is not installed"
+    - "Enable [authorization] module from CR [2]"
+    - "Validate [powermax] driver from CR [2] is installed"
+    - "Validate [authorization] module from CR [2] is installed"
+    - "Run custom test"
+    # cleanup
+    - "Enable forceRemoveDriver on CR [2]"
+    - "Delete custom resource [2]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [2] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar]"
+    - "Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1
+
 - scenario: "Install PowerMax Driver with Mount Credentials (Sidecar)"
   paths:
     - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
@@ -1930,6 +1971,47 @@
     - name: Cert CSI
       run:
         - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
+
+- scenario: "Install PowerMax Driver with Mount Credentials (Sidecar), Enable Authorization v1"
+  paths:
+    - "testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server.yaml"
+    - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
+  tags:
+    - "authorizationproxyserver"
+    - "authorization"
+    - "powermax"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Create [authorization-proxy-server] prerequisites from CR [1]"
+    - "Apply custom resource [1]"
+    - "Validate [authorization-proxy-server] module from CR [1] is installed"
+    - "Configure authorization-proxy-server for [powermax] for CR [1]"
+    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar]"
+    - "Set up reverse proxy tls secret namespace [powermax]"
+    - "Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret]"
+    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
+    - "Apply custom resource [2]"
+    - "Validate custom resource [2]"
+    - "Validate [powermax] driver from CR [2] is installed"
+    - "Validate [authorization] module from CR [2] is not installed"
+    - "Enable [authorization] module from CR [2]"
+    - "Validate [powermax] driver from CR [2] is installed"
+    - "Validate [authorization] module from CR [2] is installed"
+    - "Run custom test"
+    # cleanup
+    - "Enable forceRemoveDriver on CR [2]"
+    - "Delete custom resource [2]"
+    - "Delete custom resource [1]"
+    - "Validate [powermax] driver from CR [2] is not installed"
+    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
+    - "Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar]"
+    - "Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret]"
+    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy]"
+  customTest:
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1
 
 - scenario: "Install PowerMax Driver with TLS (Standalone)"
   paths:

--- a/tests/e2e/testfiles/storage_csm_powermax_secret.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_secret.yaml
@@ -359,3 +359,18 @@ spec:
             # configMap name which has all array/endpoint related info
             - name: "X_CSI_CONFIG_MAP_NAME"
               value: "powermax-reverseproxy-config"
+    # Authorization: enable csm-authorization for RBAC
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: false
+      configVersion: v1.12.0
+      components:
+        - name: karavi-authorization-proxy
+          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
+          envs:
+            # proxyHost: hostname of the csm-authorization server
+            - name: "PROXY_HOST"
+              value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"
+            # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
+            - name: "SKIP_CERTIFICATE_VALIDATION"
+              value: "true"

--- a/tests/e2e/testfiles/storage_csm_powermax_secret_sidecar.yaml
+++ b/tests/e2e/testfiles/storage_csm_powermax_secret_sidecar.yaml
@@ -359,3 +359,18 @@ spec:
             # configMap name which has all array/endpoint related info
             - name: "X_CSI_CONFIG_MAP_NAME"
               value: "powermax-reverseproxy-config"
+    # Authorization: enable csm-authorization for RBAC
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: false
+      configVersion: v1.12.0
+      components:
+        - name: karavi-authorization-proxy
+          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v1.12.0
+          envs:
+            # proxyHost: hostname of the csm-authorization server
+            - name: "PROXY_HOST"
+              value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"
+            # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
+            - name: "SKIP_CERTIFICATE_VALIDATION"
+              value: "true"


### PR DESCRIPTION
# Description
Add E2E tests that installs the Powermax driver using mount credentials and enables Authorization v1.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1614 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Add and run associated e2e tests.
<details>

```
-> # bash run-e2e-test.sh --pmax
/root/git/public/dell/csm-operator/tests/e2e
  W0204 15:58:22.205666   24432 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0204 15:58:22.206486 24432 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/git/public/dell/csm-operator/tests/e2e
===========================================================================================
Random Seed: 1738684635

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 02/04/25 15:58:22.206
  STEP: [powermax] @ 02/04/25 15:58:22.206
  STEP: Reading values file @ 02/04/25 15:58:22.206
  STEP: Getting a k8s client @ 02/04/25 15:58:22.213
[BeforeSuite] PASSED [0.010 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver with Mount Credentials, Enable Auth v1  @ 02/04/25 15:58:22.216
  STEP: Returning false here @ 02/04/25 15:58:22.216
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 02/04/25 15:58:22.216
  STEP:      Executing  Create [authorization-proxy-server] prerequisites from CR [1] @ 02/04/25 15:58:22.225
=== Creating Authorization Proxy Server Prerequisites ===

Deleting all CSM from namespace: authorization
  STEP:      Executing  Apply custom resource [1] @ 02/04/25 15:58:29.968
  I0204 15:58:29.969252 24432 builder.go:121] Running '/usr/bin/kubectl --namespace=authorization apply --validate=true -f -'
  I0204 15:58:30.283351 24432 builder.go:146] stderr: ""
  I0204 15:58:30.283406 24432 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/authorization created\nconfigmap/csm-config-params created\n"
  STEP:      Executing  Validate [authorization-proxy-server] module from CR [1] is installed @ 02/04/25 15:58:30.283
  STEP:      Executing  Configure authorization-proxy-server for [powermax] for CR [1] @ 02/04/25 15:59:00.316
=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=====Waiting for everything to be up and running, adding a sleep time of 120 seconds before creating the role, tenant and role binding===
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===


=== Checking Storage ===

=== Checking Storage ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml storage list --insecure --addr csm-authorization.com:30559

=== Creating Storage ===

=== Storage ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml storage create --type powermax --endpoint https://10.247.22.118:8443 --system-id 000120001647 --user smc --password smc --array-insecure --insecure --addr csm-authorization.com:30559


=== Creating Tenant ===

=== Tenant ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml tenant create -n PancakeGroup --insecure --addr csm-authorization.com:30559
=== Checking Roles ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml role list --insecure --addr csm-authorization.com:30559


=== Creating Role ===

=== Role ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml role create --role=CSIGold=powermax=000120001647=SRP_1=100000000 --insecure --addr csm-authorization.com:30559


=== Creating RoleBinding ===

=== Binding Role ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml rolebinding create --tenant PancakeGroup --role CSIGold --insecure --addr csm-authorization.com:30559


=== Generating token ===

=== Token ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml generate token --tenant PancakeGroup --insecure --addr csm-authorization.com:30559 --access-token-expiration 2h0m0s


=== Applying token ===

=== Token Applied ===

  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 02/04/25 16:01:06.222
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar] @ 02/04/25 16:01:06.72
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 02/04/25 16:01:06.93
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret] @ 02/04/25 16:01:07.121
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 02/04/25 16:01:07.358
  STEP:      Executing  Apply custom resource [2] @ 02/04/25 16:01:07.756
  I0204 16:01:07.756938 24432 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0204 16:01:08.094137 24432 builder.go:146] stderr: ""
  I0204 16:01:08.094273 24432 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [2] @ 02/04/25 16:01:08.094

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [2] is installed @ 02/04/25 16:05:58.253
  STEP:      Executing  Validate [authorization] module from CR [2] is not installed @ 02/04/25 16:06:18.276
  STEP:      Executing  Enable [authorization] module from CR [2] @ 02/04/25 16:06:28.306
  STEP:      Executing  Validate [powermax] driver from CR [2] is installed @ 02/04/25 16:06:43.337

err:
The pod(powermax-controller-87d9cddbc-pvstx) is Pending
The pod(powermax-node-dnscx) is Pending
  STEP:      Executing  Validate [authorization] module from CR [2] is installed @ 02/04/25 16:07:33.367
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:2]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:2]
  STEP:      Executing  Run custom test @ 02/04/25 16:07:43.404
  I0204 16:07:43.404674 24432 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1]
[2025-02-04 16:07:43]  INFO Starting cert-csi; ver. 1.4.1
[2025-02-04 16:07:43]  INFO Using EVENT observer type
[2025-02-04 16:07:43]  INFO Using config from /root/.kube/config
[2025-02-04 16:07:43]  INFO Successfully loaded config. Host: https://10.247.142.130:6443
[2025-02-04 16:07:43]  INFO Created new KubeClient
[2025-02-04 16:07:43]  INFO Running 1 iteration(s)
[2025-02-04 16:07:43]  INFO     *** ITERATION NUMBER 1 ***
[2025-02-04 16:07:43]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-02-04 16:07:43]  INFO Successfully created namespace volumeio-test-64d7d048
[2025-02-04 16:07:43]  INFO Using default number of volumes
[2025-02-04 16:07:43]  INFO Using default image: docker.io/centos:latest
[2025-02-04 16:07:43]  INFO Creating IO pod
[2025-02-04 16:07:43]  INFO Waiting for pod iowriter-test-tkl22 to be READY
[2025-02-04 16:08:09]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-02-04 16:08:13]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-02-04 16:08:25]  INFO Waiting until no Volume Attachments with PV  left
[2025-02-04 16:08:25]  INFO VolumeAttachment deleted
[2025-02-04 16:08:25]  INFO Deleting all resources in namespace volumeio-test-64d7d048
[2025-02-04 16:08:37]  INFO Namespace volumeio-test-64d7d048 was deleted in 12.013027436s
[2025-02-04 16:08:38]  INFO SUCCESS: VolumeIoSuite in 55.0941081s
[2025-02-04 16:08:38]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-02-04 16:08:38]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-02-04 16:08:39]  WARN No ResourceUsageMetrics provided
[2025-02-04 16:08:39] ERROR no ResourceUsageMetrics provided
report-test-run-548ac539:
Name: test-run-548ac539
Host: https://10.247.142.130:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-548ac539/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-548ac539/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-548ac539/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-548ac539/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-548ac539/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-02-04 16:07:43.68895218 +0000 UTC
            Ended:     2025-02-04 16:08:38.783965459 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 5.560522033s
                        Min: 5.560522033s
                        Max: 5.560522033s
                        Histogram:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.793170979s
                        Min: 2.793170979s
                        Max: 2.793170979s
                        Histogram:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 8.585224765s
                        Min: 8.585224765s
                        Max: 8.585224765s
                        Histogram:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 8.265618ms
                        Min: 8.265618ms
                        Max: 8.265618ms
                        Histogram:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 2.050561337s
                        Min: 2.050561337s
                        Max: 2.050561337s
                        Histogram:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 25.320614053s
                        Min: 25.320614053s
                        Max: 25.320614053s
                        Histogram:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 7.961730569s
                        Min: 7.961730569s
                        Max: 7.961730569s
                        Histogram:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-548ac539/VolumeIoSuite36/EntityNumberOverTime.png

[2025-02-04 16:08:39]  INFO Avg time of a run:   42.00s
[2025-02-04 16:08:39]  INFO Avg time of a del:   12.01s
[2025-02-04 16:08:39]  INFO Avg time of all:     55.09s
[2025-02-04 16:08:39]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [2] @ 02/04/25 16:08:39.281
  STEP:      Executing  Delete custom resource [2] @ 02/04/25 16:08:39.298
  STEP:      Executing  Delete custom resource [1] @ 02/04/25 16:08:39.312
  STEP:      Executing  Validate [powermax] driver from CR [2] is not installed @ 02/04/25 16:08:39.322

err: found the following pods: csipowermax-reverseproxy-5bfd48dc89-x7g6m,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 02/04/25 16:09:29.358
  STEP:      Executing  Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar] @ 02/04/25 16:09:29.42
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 02/04/25 16:09:29.459
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy] @ 02/04/25 16:09:29.526
  STEP: Ending: Install PowerMax Driver with Mount Credentials, Enable Auth v1
   @ 02/04/25 16:09:29.55
  STEP: Starting: Install PowerMax Driver with Mount Credentials (Sidecar), Enable Auth v1  @ 02/04/25 16:09:34.554
  STEP: Returning false here @ 02/04/25 16:09:34.555
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 02/04/25 16:09:34.555
  STEP:      Executing  Create [authorization-proxy-server] prerequisites from CR [1] @ 02/04/25 16:09:34.558
=== Creating Authorization Proxy Server Prerequisites ===

Deleting all CSM from namespace: authorization
  STEP:      Executing  Apply custom resource [1] @ 02/04/25 16:09:41.998
  I0204 16:09:41.999202 24432 builder.go:121] Running '/usr/bin/kubectl --namespace=authorization apply --validate=true -f -'
  I0204 16:09:42.311742 24432 builder.go:146] stderr: ""
  I0204 16:09:42.311824 24432 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/authorization created\nconfigmap/csm-config-params created\n"
  STEP:      Executing  Validate [authorization-proxy-server] module from CR [1] is installed @ 02/04/25 16:09:42.311
  STEP:      Executing  Configure authorization-proxy-server for [powermax] for CR [1] @ 02/04/25 16:10:12.324
=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=====Waiting for everything to be up and running, adding a sleep time of 120 seconds before creating the role, tenant and role binding===
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===


=== Checking Storage ===

=== Checking Storage ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml storage list --insecure --addr csm-authorization.com:30834

=== Creating Storage ===

=== Storage ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml storage create --type powermax --endpoint https://10.247.22.118:8443 --system-id 000120001647 --user smc --password smc --array-insecure --insecure --addr csm-authorization.com:30834


=== Creating Tenant ===

=== Tenant ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml tenant create -n PancakeGroup --insecure --addr csm-authorization.com:30834
=== Checking Roles ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml role list --insecure --addr csm-authorization.com:30834


=== Creating Role ===

=== Role ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml role create --role=CSIGold=powermax=000120001647=SRP_1=100000000 --insecure --addr csm-authorization.com:30834


=== Creating RoleBinding ===

=== Binding Role ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml rolebinding create --tenant PancakeGroup --role CSIGold --insecure --addr csm-authorization.com:30834


=== Generating token ===

=== Token ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml generate token --tenant PancakeGroup --insecure --addr csm-authorization.com:30834 --access-token-expiration 2h0m0s


=== Applying token ===

=== Token Applied ===

  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 02/04/25 16:12:18.17
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar] @ 02/04/25 16:12:18.64
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 02/04/25 16:12:18.927
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret] @ 02/04/25 16:12:19.082
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 02/04/25 16:12:19.392
  STEP:      Executing  Apply custom resource [2] @ 02/04/25 16:12:19.733
  I0204 16:12:19.733520 24432 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0204 16:12:19.970266 24432 builder.go:146] stderr: ""
  I0204 16:12:19.970326 24432 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [2] @ 02/04/25 16:12:19.97

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [2] is installed @ 02/04/25 16:13:40.039
  STEP:      Executing  Validate [authorization] module from CR [2] is not installed @ 02/04/25 16:14:00.044
  STEP:      Executing  Enable [authorization] module from CR [2] @ 02/04/25 16:14:10.068
  STEP:      Executing  Validate [powermax] driver from CR [2] is installed @ 02/04/25 16:14:25.095

err:
The pod(powermax-controller-54ddc95549-dxzdq) is Pending
The pod(powermax-controller-54ddc95549-w7jwv) is Pending
The pod(powermax-node-k7p6n) is Pending
The pod(powermax-node-vsvt6) is Succeeded

err:
The container(attacher) in pod(powermax-controller-54ddc95549-dxzdq) is {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 10s restarting failed container=attacher pod=powermax-controller-54ddc95549-dxzdq_powermax(5b5fe110-3421-4f56-bd42-3a77f7a2cfa8),} nil nil}
The pod(powermax-controller-54ddc95549-w7jwv) is Pending
The pod(powermax-controller-56cd56997c-5d86f) is Failed

err:
The pod(powermax-controller-54ddc95549-w7jwv) is Pending
The pod(powermax-controller-56cd56997c-p56lf) is Failed
k
err:
The container(attacher) in pod(powermax-controller-54ddc95549-w7jwv) is {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:Lost connection to CSI driver, exiting,StartedAt:2025-02-04 16:15:45 +0000 UTC,FinishedAt:2025-02-04 16:15:58 +0000 UTC,ContainerID:containerd://ce066f2db9c6dc4fedae9caaff74493e94b1c80b591af692ae9aa8f883df9ba2,}}
  STEP:      Executing  Validate [authorization] module from CR [2] is installed @ 02/04/25 16:16:45.174
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:2]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:2]
  STEP:      Executing  Run custom test @ 02/04/25 16:16:55.206
  I0204 16:16:55.207059 24432 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1]
[2025-02-04 16:16:55]  INFO Starting cert-csi; ver. 1.4.1
[2025-02-04 16:16:55]  INFO Using EVENT observer type
[2025-02-04 16:16:55]  INFO Using config from /root/.kube/config
[2025-02-04 16:16:55]  INFO Successfully loaded config. Host: https://10.247.142.130:6443
[2025-02-04 16:16:55]  INFO Created new KubeClient
[2025-02-04 16:16:55]  INFO Running 1 iteration(s)
[2025-02-04 16:16:55]  INFO     *** ITERATION NUMBER 1 ***
[2025-02-04 16:16:55]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-02-04 16:16:55]  INFO Successfully created namespace volumeio-test-83df2cab
[2025-02-04 16:16:55]  INFO Using default number of volumes
[2025-02-04 16:16:55]  INFO Using default image: docker.io/centos:latest
[2025-02-04 16:16:55]  INFO Creating IO pod
[2025-02-04 16:16:55]  INFO Waiting for pod iowriter-test-wbhgn to be READY
[2025-02-04 16:17:19]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-02-04 16:17:22]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-02-04 16:17:29]  INFO Waiting until no Volume Attachments with PV  left
[2025-02-04 16:17:29]  INFO VolumeAttachment deleted
[2025-02-04 16:17:29]  INFO Deleting all resources in namespace volumeio-test-83df2cab
[2025-02-04 16:17:41]  INFO Namespace volumeio-test-83df2cab was deleted in 12.011473429s
[2025-02-04 16:17:45]  INFO SUCCESS: VolumeIoSuite in 50.108818106s
[2025-02-04 16:17:45]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-02-04 16:17:45]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sGenerating plots
1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->] 100.00% ? p/s1 / 1 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 87 p/s[2025-02-04 16:17:45]  WARN No ResourceUsageMetrics provided
[2025-02-04 16:17:45] ERROR no ResourceUsageMetrics provided
report-test-run-fb0f9aac:
Name: test-run-fb0f9aac
Host: https://10.247.142.130:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-fb0f9aac/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-fb0f9aac/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-fb0f9aac/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-fb0f9aac/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-fb0f9aac/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-02-04 16:16:55.307752449 +0000 UTC
            Ended:     2025-02-04 16:17:45.417900842 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 5.245472588s
                        Min: 5.245472588s
                        Max: 5.245472588s
                        Histogram:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.450395284s
                        Min: 2.450395284s
                        Max: 2.450395284s
                        Histogram:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 8.302692425s
                        Min: 8.302692425s
                        Max: 8.302692425s
                        Histogram:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 8.134254ms
                        Min: 8.134254ms
                        Max: 8.134254ms
                        Histogram:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.814054923s
                        Min: 1.814054923s
                        Max: 1.814054923s
                        Histogram:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 23.153703041s
                        Min: 23.153703041s
                        Max: 23.153703041s
                        Histogram:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 5.353356254s
                        Min: 5.353356254s
                        Max: 5.353356254s
                        Histogram:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-fb0f9aac/VolumeIoSuite37/EntityNumberOverTime.png

[2025-02-04 16:17:45]  INFO Avg time of a run:   34.61s
[2025-02-04 16:17:45]  INFO Avg time of a del:   12.01s
[2025-02-04 16:17:45]  INFO Avg time of all:     50.10s
[2025-02-04 16:17:45]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [2] @ 02/04/25 16:17:45.926
  STEP:      Executing  Delete custom resource [2] @ 02/04/25 16:17:45.942
  STEP:      Executing  Delete custom resource [1] @ 02/04/25 16:17:45.954
  STEP:      Executing  Validate [powermax] driver from CR [2] is not installed @ 02/04/25 16:17:45.964

err: found the following pods: powermax-controller-54ddc95549-dxzdq,powermax-controller-54ddc95549-w7jwv,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 02/04/25 16:18:35.994
  STEP:      Executing  Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar] @ 02/04/25 16:18:36.046
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 02/04/25 16:18:36.114
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy] @ 02/04/25 16:18:36.192
  STEP: Ending: Install PowerMax Driver with Mount Credentials (Sidecar), Enable Auth v1
   @ 02/04/25 16:18:36.225
• [1219.012 seconds]
------------------------------

Ran 1 of 1 Specs in 1219.022 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 21m26.057543062s
Test Suite Passed
```
</details>

- [x] Ensure that installation of Auth v1 works with ConfigMap as expected
<details>

```
-> # bash run-e2e-test.sh --pmax
/root/git/public/dell/csm-operator/tests/e2e
  W0204 16:38:23.628466   14419 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0204 16:38:23.628703 14419 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /root/git/public/dell/csm-operator/tests/e2e
===========================================================================================
Random Seed: 1738687091

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 02/04/25 16:38:23.629
  STEP: [powermax] @ 02/04/25 16:38:23.629
  STEP: Reading values file @ 02/04/25 16:38:23.629
  STEP: Getting a k8s client @ 02/04/25 16:38:23.636
[BeforeSuite] PASSED [0.017 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/root/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver (With Auth V1 module)  @ 02/04/25 16:38:23.645
  STEP: Returning false here @ 02/04/25 16:38:23.645
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 02/04/25 16:38:23.645
  STEP:      Executing  Create [authorization-proxy-server] prerequisites from CR [1] @ 02/04/25 16:38:23.654
=== Creating Authorization Proxy Server Prerequisites ===

Deleting all CSM from namespace: authorization
  STEP:      Executing  Apply custom resource [1] @ 02/04/25 16:38:33.322
  I0204 16:38:33.322615 14419 builder.go:121] Running '/usr/bin/kubectl --namespace=authorization apply --validate=true -f -'
  I0204 16:38:33.934161 14419 builder.go:146] stderr: ""
  I0204 16:38:33.934215 14419 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/authorization created\nconfigmap/csm-config-params created\n"
  STEP:      Executing  Validate [authorization-proxy-server] module from CR [1] is installed @ 02/04/25 16:38:33.934

err: failed to check for AuthorizationProxyServer installation in default-source-cluster:
The pod(authorization-ingress-nginx-controller-6f98d6b9c-bl5c6) is Pending
The pod(cert-manager-webhook-8657bb7c67-7q4k5) is Pending
The pod(proxy-server-576bcb98fc-t7tk5) is Pending
The pod(redis-commander-7bddb7679f-5spj5) is Pending
The pod(redis-primary-5db5fd6657-mhbhl) is Pending
The pod(tenant-service-56b4ccc7c6-nlkr2) is Pending
  STEP:      Executing  Configure authorization-proxy-server for [powermax] for CR [1] @ 02/04/25 16:39:23.973
=== Configuring Authorization Proxy Server ===
Address: csm-authorization.com
=====Waiting for everything to be up and running, adding a sleep time of 120 seconds before creating the role, tenant and role binding===
=== Generating Admin Token ===
=== Writing Admin Token to Tmp File ===


=== Checking Storage ===

=== Checking Storage ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml storage list --insecure --addr csm-authorization.com:31666

=== Creating Storage ===

=== Storage ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml storage create --type powermax --endpoint https://10.247.22.118:8443 --system-id 000120001647 --user smc --password smc --array-insecure --insecure --addr csm-authorization.com:31666


=== Creating Tenant ===

=== Tenant ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml tenant create -n PancakeGroup --insecure --addr csm-authorization.com:31666
=== Checking Roles ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml role list --insecure --addr csm-authorization.com:31666


=== Creating Role ===

=== Role ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml role create --role=CSIGold=powermax=000120001647=SRP_1=100000000 --insecure --addr csm-authorization.com:31666


=== Creating RoleBinding ===

=== Binding Role ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml rolebinding create --tenant PancakeGroup --role CSIGold --insecure --addr csm-authorization.com:31666


=== Generating token ===

=== Token ===
 /usr/local/bin/karavictl --admin-token /tmp/adminToken.yaml generate token --tenant PancakeGroup --insecure --addr csm-authorization.com:31666 --access-token-expiration 2h0m0s


=== Applying token ===

=== Token Applied ===

  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 02/04/25 16:41:30.422
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar] @ 02/04/25 16:41:32.256
  STEP:      Executing  Set up reverse proxy tls secret namespace [powermax] @ 02/04/25 16:41:33.397
revproxy-certs secret already exists, skipping creation.
csirevproxy-tls-secret already exists, skipping creation.
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 02/04/25 16:41:34.062
  STEP:      Executing  Set up configMap with template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] name [powermax-reverseproxy-config] in namespace [powermax] for [pmaxReverseProxy] @ 02/04/25 16:41:34.863
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 02/04/25 16:41:35.483
  STEP:      Executing  Apply custom resource [2] @ 02/04/25 16:41:37.078
  I0204 16:41:37.079388 14419 builder.go:121] Running '/usr/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0204 16:41:37.780152 14419 builder.go:146] stderr: ""
  I0204 16:41:37.780221 14419 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [2] @ 02/04/25 16:41:37.78

err: expected custom resource status to be Succeeded. Got: Failed

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [2] is installed @ 02/04/25 16:42:57.84
  STEP:      Executing  Validate [authorization] module from CR [2] is installed @ 02/04/25 16:43:17.845
map[com.dell.karavi-authorization-proxy:true deployment.kubernetes.io/revision:1]
map[com.dell.karavi-authorization-proxy:true deprecated.daemonset.template.generation:1]
  STEP:      Executing  Run custom test @ 02/04/25 16:43:27.88
  I0204 16:43:27.880429 14419 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1]
[2025-02-04 16:43:27]  INFO Starting cert-csi; ver. 1.4.1
[2025-02-04 16:43:28]  INFO Using EVENT observer type
[2025-02-04 16:43:28]  INFO Using config from /root/.kube/config
[2025-02-04 16:43:28]  INFO Successfully loaded config. Host: https://10.247.142.130:6443
[2025-02-04 16:43:28]  INFO Created new KubeClient
[2025-02-04 16:43:28]  INFO Running 1 iteration(s)
[2025-02-04 16:43:28]  INFO     *** ITERATION NUMBER 1 ***
[2025-02-04 16:43:28]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-02-04 16:43:28]  INFO Successfully created namespace volumeio-test-839567e1
[2025-02-04 16:43:28]  INFO Using default number of volumes
[2025-02-04 16:43:28]  INFO Using default image: docker.io/centos:latest
[2025-02-04 16:43:28]  INFO Creating IO pod
[2025-02-04 16:43:28]  INFO Waiting for pod iowriter-test-4gg6s to be READY
[2025-02-04 16:43:44]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-02-04 16:43:45]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-02-04 16:43:49]  INFO Waiting until no Volume Attachments with PV  left
[2025-02-04 16:43:49]  INFO VolumeAttachment deleted
[2025-02-04 16:43:49]  INFO Deleting all resources in namespace volumeio-test-839567e1
[2025-02-04 16:44:01]  INFO Namespace volumeio-test-839567e1 was deleted in 12.012718162s
[2025-02-04 16:44:03]  INFO SUCCESS: VolumeIoSuite in 35.071594087s
Collecting metrics
[2025-02-04 16:44:03]  INFO Started generating reports...
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sCollecting metrics
Generating plots
[2025-02-04 16:44:03]  INFO Started generating reports...
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 5 p/s[2025-02-04 16:44:03]  WARN No ResourceUsageMetrics provided
[2025-02-04 16:44:03] ERROR no ResourceUsageMetrics provided
report-test-run-e7f338c6:
Name: test-run-e7f338c6
Host: https://10.247.142.130:6443
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-e7f338c6/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-e7f338c6/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-e7f338c6/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-e7f338c6/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-e7f338c6/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-02-04 16:43:28.052036973 +0000 UTC
            Ended:     2025-02-04 16:44:03.137009225 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 5.205380964s
                        Min: 5.205380964s
                        Max: 5.205380964s
                        Histogram:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 2.737612107s
                        Min: 2.737612107s
                        Max: 2.737612107s
                        Histogram:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 8.255744957s
                        Min: 8.255744957s
                        Max: 8.255744957s
                        Histogram:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 14.296038ms
                        Min: 14.296038ms
                        Max: 14.296038ms
                        Histogram:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.623649635s
                        Min: 1.623649635s
                        Max: 1.623649635s
                        Histogram:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 14.321223193s
                        Min: 14.321223193s
                        Max: 14.321223193s
                        Histogram:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 2.116656033s
                        Min: 2.116656033s
                        Max: 2.116656033s
                        Histogram:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-e7f338c6/VolumeIoSuite38/EntityNumberOverTime.png

[2025-02-04 16:44:03]  INFO Avg time of a run:   21.78s
[2025-02-04 16:44:03]  INFO Avg time of a del:   12.01s
[2025-02-04 16:44:03]  INFO Avg time of all:     35.07s
[2025-02-04 16:44:03]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [2] @ 02/04/25 16:44:03.961
  STEP:      Executing  Delete custom resource [2] @ 02/04/25 16:44:03.979
  STEP:      Executing  Delete custom resource [1] @ 02/04/25 16:44:03.992
  STEP:      Executing  Validate [powermax] driver from CR [2] is not installed @ 02/04/25 16:44:04.004

err: found the following pods: powermax-controller-64f7856f95-fpfsw,powermax-controller-64f7856f95-qrqnw,powermax-node-kvfkp,
  STEP:      Executing  Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar] @ 02/04/25 16:44:54.035
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-secret-template.yaml] for [pmaxCreds] @ 02/04/25 16:44:54.13
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy] @ 02/04/25 16:44:54.191
  STEP: Ending: Install PowerMax Driver (With Auth V1 module)
   @ 02/04/25 16:44:54.254
• [395.610 seconds]
------------------------------

Ran 1 of 1 Specs in 395.627 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 6m48.241278353s
Test Suite Passed
```
</details>