### PR TITLE
Add debug flags to samples - PowerFlex + PowerMax

### DIFF
--- a/samples/storage_csm_powerflex_v2110.yaml
+++ b/samples/storage_csm_powerflex_v2110.yaml
@@ -34,6 +34,11 @@ spec:
           value: "false"
         - name: X_CSI_DEBUG
           value: "true"
+        # Log level for CSI driver, passed to logrus.
+        # Options are "PANIC", "FATAL", "ERROR", "WARN", "INFO",
+        # "DEBUG", and "TRACE".
+        - name: CSI_LOG_LEVEL
+          value: "INFO"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/samples/storage_csm_powerflex_v2120.yaml
+++ b/samples/storage_csm_powerflex_v2120.yaml
@@ -34,6 +34,11 @@ spec:
           value: "false"
         - name: X_CSI_DEBUG
           value: "true"
+        # Log level for CSI driver, passed to logrus.
+        # Options are "PANIC", "FATAL", "ERROR", "WARN", "INFO",
+        # "DEBUG", and "TRACE".
+        - name: CSI_LOG_LEVEL
+          value: "INFO"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/samples/storage_csm_powerflex_v2130.yaml
+++ b/samples/storage_csm_powerflex_v2130.yaml
@@ -31,6 +31,11 @@ spec:
           value: "false"
         - name: X_CSI_DEBUG
           value: "true"
+        # Log level for CSI driver, passed to logrus.
+        # Options are "PANIC", "FATAL", "ERROR", "WARN", "INFO",
+        # "DEBUG", and "TRACE".
+        - name: CSI_LOG_LEVEL
+          value: "INFO"
         # Specify kubelet config dir path.
         # Ensure that the config.yaml file is present at this path.
         # Default value: /var/lib/kubelet

--- a/samples/storage_csm_powermax_v2110.yaml
+++ b/samples/storage_csm_powermax_v2110.yaml
@@ -133,6 +133,9 @@ spec:
         # Default value: "TEXT"
         - name: "CSI_LOG_FORMAT"
           value: "TEXT"
+        # X_CSI_POWERMAX_DEBUG: Enable/disable debug logs from gopowermax library.
+        - name: "X_CSI_POWERMAX_DEBUG"
+          value: "true"
     controller:
       envs:
         # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition

--- a/samples/storage_csm_powermax_v2120.yaml
+++ b/samples/storage_csm_powermax_v2120.yaml
@@ -102,6 +102,9 @@ spec:
         # Default value: "TEXT"
         - name: "CSI_LOG_FORMAT"
           value: "TEXT"
+        # X_CSI_POWERMAX_DEBUG: Enable/disable debug logs from gopowermax library.
+        - name: "X_CSI_POWERMAX_DEBUG"
+          value: "true"
     controller:
       envs:
         # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition

--- a/samples/storage_csm_powermax_v2130.yaml
+++ b/samples/storage_csm_powermax_v2130.yaml
@@ -113,6 +113,9 @@ spec:
         # Default value: "TEXT"
         - name: "CSI_LOG_FORMAT"
           value: "TEXT"
+        # X_CSI_POWERMAX_DEBUG: Enable/disable debug logs from gopowermax library.
+        - name: "X_CSI_POWERMAX_DEBUG"
+          value: "true"
     controller:
       envs:
         # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition


### PR DESCRIPTION
# Description
Appropriate flags for logging have been added to PowerFlex and PowerMax sample CSM files. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1762 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?

For csi-powerflex, I have added appropriate env variable to the sample and verified that it propagates to the driver on installation. When set to trace: 

```
opensuse154:~/git/csm-operator/scripts # k logs -n vxflexos vxflexos-controller-5b5d9f48d6-b6dz4 -c driver
time="2025-02-26T16:23:16Z" level=info msg="configured <REDACT>" allSystemNames= endpoint=<REDACT>" isDefault=true nasName=none password="********" skipCertificateValidation=true systemID=<REDACT> user=admin
time="2025-02-26T16:23:16Z" level=info msg="driver configuration file " file=/vxflexos-config-params/driver-config-params.yaml
time="2025-02-26T16:23:16Z" level=info msg="Read CSI_LOG_FORMAT from log configuration file" format=
time="2025-02-26T16:23:16Z" level=info msg="CSI_LOG_FORMAT value not recognized, setting to text" format=
time="2025-02-26T16:23:16Z" level=info msg="Read CSI_LOG_LEVEL from log configuration file" fields.level=trace ```
```

When set to info: 

```
opensuse154:~/git/csm-operator/scripts # k logs -n vxflexos vxflexos-controller-5b5d9f48d6-2np95 -c driver
time="2025-02-26T16:30:49Z" level=info msg="configured <REDACT>" allSystemNames= endpoint="<REDACT>" isDefault=true nasName=none password="********" skipCertificateValidation=true systemID=<REDACT>user=admin
time="2025-02-26T16:30:49Z" level=info msg="driver configuration file " file=/vxflexos-config-params/driver-config-params.yaml
time="2025-02-26T16:30:49Z" level=info msg="Read CSI_LOG_FORMAT from log configuration file" format=
time="2025-02-26T16:30:49Z" level=info msg="CSI_LOG_FORMAT value not recognized, setting to text" format=
time="2025-02-26T16:30:49Z" level=info msg="Read CSI_LOG_LEVEL from log configuration file" fields.level=info 
```

For csi-powermax, with X_CSI_POWERMAX_DEBUG set to true: 

```
opensuse154:~/git/csm-operator/defect-yamls # k logs -n powermax powermax-controller-7cf76dc6c5-hhvzp 
time="2025-02-26T18:50:51Z" level=info msg="---------inside setArrayConfig function----------"
time="2025-02-26T18:50:51Z" level=info msg="Read PortGroups from config file:iscsi"
time="2025-02-26T18:50:51Z" level=info msg="Read protocol from config file:ISCSI"
time="2025-02-26T18:50:51Z" level=info msg="Read endpoint from config file:<REDACT>"
time="2025-02-26T18:50:51Z" level=info msg="Managed arrays from config file:<REDACT>"
time="2025-02-26T18:50:51Z" level=info msg="Read CSI_LOG_FORMAT: text from configuration file"
time="2025-02-26T18:50:51Z" level=info msg="Read CSI_LOG_LEVEL: info from config file"
time="2025-02-26T18:50:51Z" level=info msg="Setting log level to info"
time="2025-02-26T18:50:51Z" level=info msg="Successfully started the lock request handler"
time="2025-02-26T18:50:51Z" level=info msg="CleanupMapEntries: Successfully started the cleanup worker. This will wake up every 240.00 minutes to clean up stale entries"
time="2025-02-26T18:50:51Z" level=error msg="Error: Path /sbin/nvme does not exist\n"
time="2025-02-26T18:50:51Z" level=info msg="PowerMax debug: true" 
time="2025-02-26T18:50:51Z" level=debug msg="username: smc , password: *****"
time="2025-02-26T18:50:51Z" level=debug msg="\n    -------------------------- POWERMAX HTTP REQUEST -------------------------\n    GET /univmax/restapi/version HTTP/1.1\n    Host: 0.0.0.0:2222\n    \n"
time="2025-02-26T18:50:51Z" level=error error="Get \"https://0.0.0.0:2222/univmax/restapi/version\": dial tcp 0.0.0.0:2222: connect: connection refused"
time="2025-02-26T18:51:01Z" level=info msg="PowerMax debug: true"
time="2025-02-26T18:51:01Z" level=debug msg="username: <REDACT>, password: *****"
```

With it set to false, no such "PowerMax debug: true" message appears, and debug messages are not printed. 

```
opensuse154:~/git/csm-operator/defect-yamls # k logs -n powermax powermax-controller-556c8cbd76-bmdj7 
time="2025-02-26T19:00:49Z" level=info msg="---------inside setArrayConfig function----------"
time="2025-02-26T19:00:49Z" level=info msg="Read PortGroups from config file:iscsi"
time="2025-02-26T19:00:49Z" level=info msg="Read protocol from config file:ISCSI"
time="2025-02-26T19:00:49Z" level=info msg="Read endpoint from config file:<REDACT>"
time="2025-02-26T19:00:49Z" level=info msg="Managed arrays from config file:<REDACT>"
time="2025-02-26T19:00:49Z" level=info msg="Read CSI_LOG_FORMAT: text from configuration file"
time="2025-02-26T19:00:49Z" level=info msg="Read CSI_LOG_LEVEL: info from config file"
time="2025-02-26T19:00:49Z" level=info msg="Setting log level to info"
time="2025-02-26T19:00:49Z" level=info msg="Successfully started the lock request handler"
time="2025-02-26T19:00:49Z" level=info msg="CleanupMapEntries: Successfully started the cleanup worker. This will wake up every 240.00 minutes to clean up stale entries"
time="2025-02-26T19:00:49Z" level=error msg="Error: Path /sbin/nvme does not exist\n"
time="2025-02-26T19:01:00Z" level=info msg="s.mode: controller"
time="2025-02-26T19:01:00Z" level=info msg="Configuring deletion worker with Cluster Prefix: CSM, Sym IDs: [000120001602]"
time="2025-02-26T19:01:00Z" level=info msg="Starting snapshots cleanup worker thread"
time="2025-02-26T19:01:00Z" level=info msg="configured csi-powermax.dellemc.com" PodmonFrequency= PodmonPort= ProxyServiceHost=0.0.0.0 ......
```

Additionally, after execing into the driver container to check the status of the flags, the value was verified to appear in the environment to match the setting I chose. 

```
opensuse154:~/git/csm-operator/defect-yamls # k exec --stdin --tty -n powermax powermax-controller-556c8cbd76-bmdj7 -c driver -- /bin/bash
bash-5.1# echo $X_CSI_POWERMAX_DEBUG
false 
```