### PR TITLE
powermax karavi topology e2e fix

### DIFF
--- a/operatorconfig/moduleconfig/observability/v1.10.0/karavi-topology.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.10.0/karavi-topology.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: karavi
 data:
   karavi-topology.yaml: |
-    PROVISIONER_NAMES: csi-isilon.dellemc.com,csi-vxflexos.dellemc.com, csi-powermax.dellemc.com
+    PROVISIONER_NAMES: csi-isilon.dellemc.com,csi-vxflexos.dellemc.com,csi-powermax.dellemc.com
     LOG_LEVEL: <TOPOLOGY_LOG_LEVEL>
     LOG_FORMAT: text
     ZIPKIN_URI: ""

--- a/operatorconfig/moduleconfig/observability/v1.11.0/karavi-topology.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.11.0/karavi-topology.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: karavi
 data:
   karavi-topology.yaml: |
-    PROVISIONER_NAMES: csi-isilon.dellemc.com,csi-vxflexos.dellemc.com, csi-powermax.dellemc.com
+    PROVISIONER_NAMES: csi-isilon.dellemc.com,csi-vxflexos.dellemc.com,csi-powermax.dellemc.com
     LOG_LEVEL: <TOPOLOGY_LOG_LEVEL>
     LOG_FORMAT: text
     ZIPKIN_URI: ""

--- a/operatorconfig/moduleconfig/observability/v1.12.0/karavi-topology.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.12.0/karavi-topology.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: karavi
 data:
   karavi-topology.yaml: |
-    PROVISIONER_NAMES: csi-isilon.dellemc.com,csi-vxflexos.dellemc.com, csi-powermax.dellemc.com
+    PROVISIONER_NAMES: csi-isilon.dellemc.com,csi-vxflexos.dellemc.com,csi-powermax.dellemc.com
     LOG_LEVEL: <TOPOLOGY_LOG_LEVEL>
     LOG_FORMAT: text
     ZIPKIN_URI: ""

--- a/operatorconfig/moduleconfig/observability/v1.9.0/karavi-topology.yaml
+++ b/operatorconfig/moduleconfig/observability/v1.9.0/karavi-topology.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: karavi
 data:
   karavi-topology.yaml: |
-    PROVISIONER_NAMES: csi-isilon.dellemc.com,csi-vxflexos.dellemc.com, csi-powermax.dellemc.com
+    PROVISIONER_NAMES: csi-isilon.dellemc.com,csi-vxflexos.dellemc.com,csi-powermax.dellemc.com
     LOG_LEVEL: <TOPOLOGY_LOG_LEVEL>
     LOG_FORMAT: text
     ZIPKIN_URI: ""


### PR DESCRIPTION
# Description

- Update to karavi topology template for powermax

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1747|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?

- [x] Successfully ran karavi-topology e2e tests for powrmax

```
=== RUN   Test_Query_Topology
2025/03/04 01:05:23 TestTimeout=7, DumpOutput=false
time="2025-03-04T01:05:23-02:00" level=info msg="Running: /root/.local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 5 --chainLength 1 --no-metrics --no-reports --longevity %s 10m"

 length of volume map 0

 length of volume map 0

 length of volume map 0

 length of volume map 4
time="2025-03-04T01:05:23-02:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-03-04T01:05:23-02:00" level=info msg="Signal SIGKILL sent to 348342. Waiting for process to exit..."
time="2025-03-04T01:05:23-02:00" level=info msg="Wait for cert-csi completed"
time="2025-03-04T01:05:23-02:00" level=info msg="Running: /root/.local/bin/cert-csi cleanup"
time="2025-03-04T01:05:23-02:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-03-04T01:05:23-02:00" level=info msg="Process exited without error"
--- PASS: Test_Query_Topology (18.13s)
PASS
ok      karavi-testing/karavi-topology/topology-test    19.149s
```
