### PR TITLE
Reintroduce PowerMax Mount Credentials E2E Tests

### DIFF
--- a/samples/minimal-samples/powermax_v2140.yaml
+++ b/samples/minimal-samples/powermax_v2140.yaml
@@ -1,0 +1,48 @@
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: powermax
+  namespace: powermax
+spec:
+  driver:
+    csiDriverType: "powermax"
+    configVersion: v2.14.0
+    forceRemoveDriver: true
+    common:
+      envs:
+        - name: "X_CSI_REVPROXY_USE_SECRET"
+          value: "false"
+  # These are the modules which are optional and can be enabled by specifying to enable/disable.
+  modules:
+    - name: authorization
+      # enable: Enable/Disable csm-authorization
+      enabled: false
+      # For Auth 2.0, use v2.1.0 as configVersion
+      configVersion: v2.1.0
+      components:
+        - name: karavi-authorization-proxy
+          envs:
+            # proxyHost: hostname of the csm-authorization server
+            - name: "PROXY_HOST"
+              value: "authorization-ingress-nginx-controller.authorization.svc.cluster.local"
+    - name: resiliency
+      enabled: false
+    - name: replication
+      enabled: false
+    - name: observability
+      # enabled: Enable/Disable observability
+      enabled: false
+      components:
+        - name: topology
+          enabled: true
+        - name: otel-collector
+          enabled: true
+        - name: cert-manager
+          # enabled: Enable/Disable cert-manager
+          # Allowed values:
+          #   true: enable deployment of cert-manager
+          #   false: disable deployment of cert-manager only if it's already deployed
+          # Default value: false
+          enabled: false
+        - name: metrics-powermax
+          enabled: true

--- a/samples/storage_csm_powermax_v2140.yaml
+++ b/samples/storage_csm_powermax_v2140.yaml
@@ -1,0 +1,496 @@
+#
+# Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+apiVersion: storage.dell.com/v1
+kind: ContainerStorageModule
+metadata:
+  name: powermax
+  namespace: powermax
+spec:
+  # Add fields here
+  driver:
+    csiDriverType: "powermax"
+    csiDriverSpec:
+      # in OCP <= 4.16 and K8s <= 1.29, fsGroupPolicy is an immutable field
+      # fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+      # Allowed values: ReadWriteOnceWithFSType, File , None
+      # Default value: ReadWriteOnceWithFSType
+      fSGroupPolicy: "ReadWriteOnceWithFSType"
+      # storageCapacity: Helps the scheduler to schedule the pod on a node satisfying the topology constraints, only if the requested capacity is available on the storage array
+      # Allowed values:
+      #   true: enable storage capacity tracking
+      #   false: disable storage capacity tracking
+      storageCapacity: true
+    configVersion: v2.14.0
+    # replica: Define the number of PowerMax controller nodes
+    # to deploy to the Kubernetes release
+    # Controller count
+    # Allowed values: n, where n > 0
+    # Default value: 2
+    replicas: 2
+    # Default credential secret for Powermax, if not set it to ""
+    authSecret: powermax-creds
+    dnsPolicy: ClusterFirstWithHostNet
+    forceRemoveDriver: true
+    common:
+      image: quay.io/dell/container-storage-modules/csi-powermax:nightly
+      # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
+      # Allowed values:
+      #  Always: Always pull the image.
+      #  IfNotPresent: Only pull the image if it does not already exist on the node.
+      #  Never: Never pull the image.
+      # Default value: None
+      imagePullPolicy: IfNotPresent
+      envs:
+        # X_CSI_K8S_CLUSTER_PREFIX: Define a prefix that is appended onto
+        # all resources created in the Array
+        # This should be unique per K8s/CSI deployment
+        # maximum length of this value is 3 characters
+        # Default value: "CSM"
+        # Examples: "XYZ", "EMC"
+        - name: X_CSI_K8S_CLUSTER_PREFIX
+          value: "CSM"
+        # Specify kubelet config dir path.
+        # Ensure that the config.yaml file is present at this path.
+        # Default value: /var/lib/kubelet
+        - name: KUBELET_CONFIG_DIR
+          value: /var/lib/kubelet
+        # VMware/vSphere virtualization support
+        # set X_CSI_VSPHERE_ENABLED to true, if you to enable VMware virtualized environment support via RDM
+        # Allowed values:
+        #   "true" - vSphere volumes are enabled
+        #   "false" - vSphere volumes are disabled
+        # Default value: "false"
+        - name: "X_CSI_VSPHERE_ENABLED"
+          value: "false"
+        # X_CSI_VSPHERE_PORTGROUP: An existing portGroup that driver will use for vSphere
+        # recommended format: csi-x-VC-PG, x can be anything of user choice
+        # Allowed value: valid existing port group on the array
+        # Default value: "" <empty>
+        - name: "X_CSI_VSPHERE_PORTGROUP"
+          value: ""
+        # X_CSI_VSPHERE_HOSTNAME: An existing host(initiator group)/ host group(cascaded initiator group) that driver will use for vSphere
+        # this host should contain initiators from all the ESXs/ESXi host where the cluster is deployed
+        # recommended format: csi-x-VC-HN, x can be anything of user choice
+        # Allowed value: valid existing host/host group on the array
+        # Default value: "" <empty>
+        - name: "X_CSI_VSPHERE_HOSTNAME"
+          value: ""
+        # X_CSI_VCENTER_HOST: URL/endpoint of the vCenter where all the ESX are present
+        # Allowed value: valid vCenter host endpoint
+        # Default value: "" <empty>
+        - name: "X_CSI_VCENTER_HOST"
+          value: ""
+        # CSI driver log level
+        # Allowed values: "error", "warn"/"warning", "info", "debug"
+        # Default value: "debug"
+        - name: "CSI_LOG_LEVEL"
+          value: "info"
+        # X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION: It determines if driver is going to skip verification
+        # of TLS certificates while connecting to Unisphere RESTAPI interface
+        # If it is set to false,
+        # then a secret powermax-certs has to be created with a X.509 certificate of CA
+        # which signed the Unisphere certificate
+        # Allowed values:
+        #   "true"  - TLS certificates verification will be skipped
+        #   "false" - TLS certificates will be verified
+        # Default value: "true"
+        - name: "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION"
+          value: "true"
+        # CSI driver log format
+        # Allowed values: "TEXT" or "JSON"
+        # Default value: "TEXT"
+        - name: "CSI_LOG_FORMAT"
+          value: "TEXT"
+        # X_CSI_POWERMAX_DEBUG: Enable/disable debug logs from gopowermax library.
+        - name: "X_CSI_POWERMAX_DEBUG"
+          value: "true"
+        # X_CSI_REVPROXY_USE_SECRET: Define whether or not to use the new secret format for the reverse proxy.
+        # Allowed values:
+        #   "true" - Use secret format for the reverse proxy
+        #   "false" - Use configmap format for the reverse proxy
+        # Default value: "false"
+        - name: "X_CSI_REVPROXY_USE_SECRET"
+          value: "false"
+    controller:
+      envs:
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+      # nodeSelector: Define node selection constraints for controller pods.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations that would be applied to controller deployment
+      # Leave as blank to install controller on worker nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  - key: "node-role.kubernetes.io/control-plane"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+    node:
+      envs:
+        # X_CSI_POWERMAX_ISCSI_ENABLE_CHAP: Determine if the driver is going to configure
+        # ISCSI node databases on the nodes with the CHAP credentials
+        # If enabled, the CHAP secret must be provided in the credentials secret
+        # and set to the key "chapsecret"
+        # Allowed values:
+        #   "true"  - CHAP is enabled
+        #   "false" - CHAP is disabled
+        # Default value: "false"
+        - name: X_CSI_POWERMAX_ISCSI_ENABLE_CHAP
+          value: "false"
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_TOPOLOGY_CONTROL_ENABLED provides a way to filter topology keys on a node based on array and transport protocol
+        # if enabled, user can create custom topology keys by editing node-topology-config configmap.
+        # Allowed values:
+        #   true: enable the filtration based on config map
+        #   false: disable the filtration based on config map
+        # Default value: false
+        - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+          value: "false"
+        # X_CSI_MAX_VOLUMES_PER_NODE: Defines the maximum PowerMax volumes that the controller can schedule on the node
+        # Allowed values: Any value greater than or equal to 0
+        # Default value: "0"
+        - name: X_CSI_MAX_VOLUMES_PER_NODE
+          value: "0"
+      # nodeSelector: Define node selection constraints for node pods.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
+      #  node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations that would be applied to node daemonset
+      # Add/Remove tolerations as per requirement
+      # Leave as blank if you wish to not apply any tolerations
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      tolerations:
+        - key: "node.kubernetes.io/memory-pressure"
+          operator: "Exists"
+          effect: "NoExecute"
+        - key: "node.kubernetes.io/disk-pressure"
+          operator: "Exists"
+          effect: "NoExecute"
+        - key: "node.kubernetes.io/network-unavailable"
+          operator: "Exists"
+          effect: "NoExecute"
+    # Uncomment and tab if nodes you wish to use have the node-role.kubernetes.io/master taint
+    # - key: "node-role.kubernetes.io/master"
+    #   operator: "Exists"
+    #   effect: "NoSchedule"
+    # Uncomment and tab if CSM for Resiliency and CSI Driver pods monitor is enabled
+    #  - key: "offline.powermax.storage.dell.com"
+    #    operator: "Exists"
+    #    effect: "NoSchedule"
+    #  - key: "powermax.podmon.storage.dell.com"
+    #    operator: "Exists"
+    #    effect: "NoSchedule"
+    sideCars:
+      # 'csivol' represents a string prepended to each volume created by the CSI driver
+      - name: provisioner
+        image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+        args: ["--volume-name-prefix=csivol"]
+      - name: attacher
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+      - name: registrar
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+      - name: resizer
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+      - name: snapshotter
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
+      - name: csi-metadata-retriever
+        image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
+      # health monitor is disabled by default, refer to driver documentation before enabling it
+      # Default monitor-interval: 60s
+      - name: external-health-monitor
+        enabled: false
+        args: ["--monitor-interval=60s"]
+        image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.14.0
+        # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+        # Configure only when the storageCapacity is set as "true"
+        # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+        # - name: provisioner
+        #  args: ["--capacity-poll-interval=5m"]
+  modules:
+    # CSI Powermax Reverseproxy is a mandatory module for Powermax
+    - name: csireverseproxy
+      configVersion: v2.13.0
+      components:
+        - name: csipowermax-reverseproxy
+          # image: Define the container images used for the reverse proxy
+          # Default value: None
+          image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
+          envs:
+            # "tlsSecret" defines the TLS secret that is created with certificate
+            # and its associated key
+            # Default value: None
+            # Example: "tls-secret"
+            - name: X_CSI_REVPROXY_TLS_SECRET
+              value: "csirevproxy-tls-secret"
+            - name: X_CSI_REVPROXY_PORT
+              value: "2222"
+            - name: X_CSI_CONFIG_MAP_NAME
+              value: "powermax-reverseproxy-config"
+            # deployAsSidecar defines the way reversproxy is installed with the driver
+            # set it true, if csm-auth is enabled / you want it as a sidecar container
+            # set it false, if you want it as a deployment
+            - name: "DeployAsSidecar"
+              value: "true"
+    # Authorization: enable csm-authorization for RBAC
+    - name: authorization
+      # enabled: Enable/Disable csm-authorization
+      # Default value: false
+      enabled: false
+      configVersion: v2.1.0
+      components:
+        - name: karavi-authorization-proxy
+          image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.1.0
+          envs:
+            # proxyHost: hostname of the csm-authorization server
+            # Default value: none
+            - name: "PROXY_HOST"
+              value: "csm-authorization.com"
+            # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
+            # Default value: "true"
+            - name: "SKIP_CERTIFICATE_VALIDATION"
+              value: "true"
+    # Replication: allows configuring replication module
+    # Replication CRDs must be installed before installing driver
+    - name: replication
+      # enabled: Enable/Disable replication feature
+      # Allowed values:
+      #   true: enable replication feature(install dell-csi-replicator sidecar)
+      #   false: disable replication feature(do not install dell-csi-replicator sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.10.0
+      components:
+        - name: dell-csi-replicator
+          # image: Image to use for dell-csi-replicator. This shouldn't be changed
+          # Allowed values: string
+          # Default value: None
+          image: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.11.0
+          envs:
+            # replicationPrefix: prefix to prepend to storage classes parameters
+            # Allowed values: string
+            # Default value: replication.storage.dell.com
+            - name: "X_CSI_REPLICATION_PREFIX"
+              value: "replication.storage.dell.com"
+            # replicationContextPrefix: prefix to use for naming of resources created by replication feature
+            # Allowed values: string
+            # Default value: powermax
+            - name: "X_CSI_REPLICATION_CONTEXT_PREFIX"
+              value: "powermax"
+        - name: dell-replication-controller-manager
+          # image: Defines controller image. This shouldn't be changed
+          # Allowed values: string
+          image: quay.io/dell/container-storage-modules/dell-replication-controller:v1.11.0
+          envs:
+            # TARGET_CLUSTERS_IDS: comma separated list of cluster IDs of the targets clusters. DO NOT include the source(wherever CSM Operator is deployed) cluster ID
+            # Set the value to "self" in case of stretched/single cluster configuration
+            # Allowed values: string
+            - name: "TARGET_CLUSTERS_IDS"
+              value: "target-cluster-1"
+            # Replication log level
+            # Allowed values: "error", "warn"/"warning", "info", "debug"
+            # Default value: "debug"
+            - name: "REPLICATION_CTRL_LOG_LEVEL"
+              value: "debug"
+            # replicas: Defines number of controller replicas
+            # Allowed values: int
+            # Default value: 1
+            - name: "REPLICATION_CTRL_REPLICAS"
+              value: "1"
+            # retryIntervalMin: Initial retry interval of failed reconcile request.
+            # It doubles with each failure, upto retry-interval-max
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MIN"
+              value: "1s"
+            # RETRY_INTERVAL_MAX: Maximum retry interval of failed reconcile request
+            # Allowed values: time
+            - name: "RETRY_INTERVAL_MAX"
+              value: "5m"
+    # observability: allows to configure observability
+    - name: observability
+      # enabled: Enable/Disable observability
+      # Default value: false
+      enabled: false
+      configVersion: v1.12.0
+      components:
+        - name: topology
+          # enabled: Enable/Disable topology
+          # Default value: false
+          enabled: false
+          # image: Defines karavi-topology image. This shouldn't be changed
+          # Allowed values: string
+          image: quay.io/dell/container-storage-modules/csm-topology:v1.11.0
+          # certificate: base64-encoded certificate for cert/private-key pair -- add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # topology log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "TOPOLOGY_LOG_LEVEL"
+              value: "INFO"
+        - name: otel-collector
+          # enabled: Enable/Disable OpenTelemetry Collector
+          # Default value: false
+          enabled: false
+          # image: Defines otel-collector image. This shouldn't be changed
+          # Allowed values: string
+          image: docker.io/otel/opentelemetry-collector:0.42.0
+          # certificate: base64-encoded certificate for cert/private-key pair -- add cert here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          certificate: ""
+          # privateKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+          #  for self-signed certs, leave empty string
+          # Allowed values: string
+          privateKey: ""
+          envs:
+            # image of nginx proxy image
+            # Allowed values: string
+            # Default value: "docker.io/nginxinc/nginx-unprivileged:1.27"
+            - name: "NGINX_PROXY_IMAGE"
+              value: "docker.io/nginxinc/nginx-unprivileged:1.27"
+        - name: cert-manager
+          # enabled: Enable/Disable cert-manager
+          # Allowed values:
+          #   true: enable deployment of cert-manager
+          #   false: disable deployment of cert-manager only if it's already deployed
+          # Default value: false
+          enabled: false
+        - name: metrics-powermax
+          # enabled: Enable/Disable PowerMax metrics
+          # Default value: false
+          enabled: false
+          # image: Defines PowerMax metrics image. This shouldn't be changed
+          image: quay.io/dell/container-storage-modules/csm-metrics-powermax:nightly
+          envs:
+            # POWERMAX_MAX_CONCURRENT_QUERIES: set the default max concurrent queries to PowerMax
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_MAX_CONCURRENT_QUERIES"
+              value: "10"
+            # POWERMAX_CAPACITY_METRICS_ENABLED: enable/disable collection of capacity metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERMAX_CAPACITY_METRICS_ENABLED"
+              value: "true"
+            # POWERMAX_PERFORMANCE_METRICS_ENABLED: enable/disable collection of volume performance metrics
+            # Allowed values: ture, false
+            # Default value: true
+            - name: "POWERMAX_PERFORMANCE_METRICS_ENABLED"
+              value: "true"
+            # POWERMAX_CAPACITY_POLL_FREQUENCY: set polling frequency to get capacity metrics data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_CAPACITY_POLL_FREQUENCY"
+              value: "10"
+            # POWERMAX_PERFORMANCE_POLL_FREQUENCY: set polling frequency to get volume performance data
+            # Allowed values: int
+            # Default value: 10
+            - name: "POWERMAX_PERFORMANCE_POLL_FREQUENCY"
+              value: "10"
+            # PowerMax metrics log level
+            # Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+            # Default value: "INFO"
+            - name: "POWERMAX_LOG_LEVEL"
+              value: "INFO"
+            # PowerMax Metrics Output logs in the specified format
+            # Valid values: TEXT, JSON
+            # Default value: "TEXT"
+            - name: "POWERMAX_LOG_FORMAT"
+              value: "TEXT"
+            # otel collector address
+            # Allowed values: String
+            # Default value: "otel-collector:55680"
+            - name: "COLLECTOR_ADDRESS"
+              value: "otel-collector:55680"
+            # configMap name which has all array/endpoint related info
+            - name: "X_CSI_CONFIG_MAP_NAME"
+              value: "powermax-reverseproxy-config"
+    - name: resiliency
+      # enabled: Enable/Disable Resiliency feature
+      # Allowed values:
+      #   true: enable Resiliency feature(deploy podmon sidecar)
+      #   false: disable Resiliency feature(do not deploy podmon sidecar)
+      # Default value: false
+      enabled: false
+      configVersion: v1.12.0
+      components:
+        - name: podmon-controller
+          image: quay.io/dell/container-storage-modules/podmon:v1.12.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--labelvalue=csi-powermax"
+            - "--arrayConnectivityPollRate=60"
+            - "--skipArrayConnectionValidation=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            - "--arrayConnectivityConnectionLossThreshold=3"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/run/csi/csi.sock"
+            - "--mode=controller"
+            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
+            - "--driverPath=csi-powermax.dellemc.com"
+        - name: podmon-node
+          image: quay.io/dell/container-storage-modules/podmon:v1.12.0
+          imagePullPolicy: IfNotPresent
+          envs:
+            # podmonAPIPort: Defines the port to be used within the kubernetes cluster
+            # Allowed values: Any valid and free port (string)
+            # Default value: 8083
+            - name: "X_CSI_PODMON_API_PORT"
+              value: "8083"
+          args:
+            - "--labelvalue=csi-powermax"
+            - "--arrayConnectivityPollRate=60"
+            - "--leaderelection=false"
+            - "--driverPodLabelValue=dell-storage"
+            - "--ignoreVolumelessPods=false"
+            # Below 4 args should not be modified.
+            - "--csisock=unix:/var/lib/kubelet/plugins/powermax.emc.dell.com/csi_sock"
+            - "--mode=node"
+            - "--driver-config-params=/powermax-config-params/driver-config-params.yaml"
+            - "--driverPath=csi-powermax.dellemc.com"

--- a/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
@@ -891,7 +891,7 @@
   paths:
     - "testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml"
   tags:
-  #  - "powermax"
+   - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
@@ -917,7 +917,7 @@
   paths:
     - "testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml"
   tags:
-  #  - "powermax"
+   - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"

--- a/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
@@ -891,7 +891,7 @@
   paths:
     - "testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml"
   tags:
-   - "powermax"
+    - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
@@ -917,7 +917,7 @@
   paths:
     - "testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml"
   tags:
-   - "powermax"
+    - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1823,7 +1823,7 @@
   paths:
     - "testfiles/storage_csm_powermax_secret.yaml"
   tags:
-  #   - "powermax"
+    - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
@@ -1849,7 +1849,7 @@
   paths:
     - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
   tags:
-  #   - "powermax"
+    - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
@@ -1880,9 +1880,9 @@
     - "testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server.yaml"
     - "testfiles/storage_csm_powermax_secret.yaml"
   tags:
-  #   - "authorizationproxyserver"
-  #   - "authorization"
-  #   - "powermax"
+    - "authorizationproxyserver"
+    - "authorization"
+    - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create [authorization-proxy-server] prerequisites from CR [1]"
@@ -1920,7 +1920,7 @@
   paths:
     - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
   tags:
-  #   - "powermax"
+    - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
@@ -1946,7 +1946,7 @@
   paths:
     - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
   tags:
-  #   - "powermax"
+    - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
@@ -1979,7 +1979,7 @@
   tags:
   #   - "authorizationproxyserver"
   #   - "authorization"
-  #   - "powermax"
+    - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Create [authorization-proxy-server] prerequisites from CR [1]"

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -2169,8 +2169,8 @@
     - "testfiles/authorization-templates/storage_csm_authorization_v2_crds.yaml"
     - "testfiles/storage_csm_powermax_secret_auth_v2.yaml"
   tags:
-   - "authorizationproxyserver"
-   - "authorization"
+    - "authorizationproxyserver"
+    - "authorization"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Install Authorization CRDs [2]"

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1875,47 +1875,6 @@
       run:
         - cert-csi test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1
 
-- scenario: "Install PowerMax Driver with Mount Credentials, Enable Authorization v1"
-  paths:
-    - "testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server.yaml"
-    - "testfiles/storage_csm_powermax_secret.yaml"
-  tags:
-    - "authorizationproxyserver"
-    - "authorization"
-    - "powermax"
-  steps:
-    - "Given an environment with k8s or openshift, and CSM operator installed"
-    - "Create [authorization-proxy-server] prerequisites from CR [1]"
-    - "Apply custom resource [1]"
-    - "Validate [authorization-proxy-server] module from CR [1] is installed"
-    - "Configure authorization-proxy-server for [powermax] for CR [1]"
-    - "Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
-    - "Set up secret with template [testfiles/powermax-templates/csm-authorization-config.json] name [karavi-authorization-config] in namespace [powermax] for [pmaxAuthSidecar]"
-    - "Set up reverse proxy tls secret namespace [powermax]"
-    - "Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-config] in namespace [powermax] for [pmaxUseSecret]"
-    - "Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig]"
-    - "Apply custom resource [2]"
-    - "Validate custom resource [2]"
-    - "Validate [powermax] driver from CR [2] is installed"
-    - "Validate [authorization] module from CR [2] is not installed"
-    - "Enable [authorization] module from CR [2]"
-    - "Validate [powermax] driver from CR [2] is installed"
-    - "Validate [authorization] module from CR [2] is installed"
-    - "Run custom test"
-    # cleanup
-    - "Enable forceRemoveDriver on CR [2]"
-    - "Delete custom resource [2]"
-    - "Delete custom resource [1]"
-    - "Validate [powermax] driver from CR [2] is not installed"
-    - "Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax]"
-    - "Restore template [testfiles/powermax-templates/csm-authorization-config.json] for [pmaxAuthSidecar]"
-    - "Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret]"
-    - "Restore template [testfiles/powermax-templates/powermax_reverse_proxy_config_auth.yaml] for [pmaxReverseProxy]"
-  customTest:
-    - name: Cert CSI
-      run:
-        - cert-csi test vio --sc op-e2e-pmax  --chainLength 1 --chainNumber 1
-
 - scenario: "Install PowerMax Driver with Mount Credentials (Sidecar)"
   paths:
     - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
@@ -2210,9 +2169,8 @@
     - "testfiles/authorization-templates/storage_csm_authorization_v2_crds.yaml"
     - "testfiles/storage_csm_powermax_secret_auth_v2.yaml"
   tags:
-  #  - "authorizationproxyserver"
-  #  - "authorization"
-  #  - "powermax"
+   - "authorizationproxyserver"
+   - "authorization"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"
     - "Install Authorization CRDs [2]"

--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1977,8 +1977,8 @@
     - "testfiles/authorization-templates/storage_csm_authorization_v1_proxy_server.yaml"
     - "testfiles/storage_csm_powermax_secret_sidecar.yaml"
   tags:
-  #   - "authorizationproxyserver"
-  #   - "authorization"
+    - "authorizationproxyserver"
+    - "authorization"
     - "powermax"
   steps:
     - "Given an environment with k8s or openshift, and CSM operator installed"


### PR DESCRIPTION
# Description
Reintroduce the PowerMax mount credentials e2e tests since the nightly image has been created for Powermax.

Also, add the sample files for v2.14.0 with the new `X_CSI_REVPROXY_USE_SECRET` variable that can be used to enable/disable mount credentials.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1614 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensure that the nightly images are properly available for mount credentials so that the e2e tests pass.
- [x] Deploy using the latest `v2.14.0` config versions for Powermax.
- [x] Run e2e test with nightly image for Mount Credentials to ensure everything is passing as expected.
