### PR TITLE
Changed GOPOWERSTORE_DEBUG default to false

### DIFF
--- a/pkg/drivers/powerstore.go
+++ b/pkg/drivers/powerstore.go
@@ -109,8 +109,7 @@ func ModifyPowerstoreCR(yamlString string, cr csmv1.ContainerStorageModule, file
 	powerstoreExternalAccess := ""
 	storageCapacity := "false"
 	maxVolumesPerNode := ""
-	// GOPOWERSTORE_DEBUG defaults to true
-	debug := "true"
+	debug := "false"
 	if cr.Spec.Driver.Common != nil {
 		for _, env := range cr.Spec.Driver.Common.Envs {
 			if env.Name == "GOPOWERSTORE_DEBUG" {

--- a/pkg/drivers/powerstore_test.go
+++ b/pkg/drivers/powerstore_test.go
@@ -76,20 +76,20 @@ var (
 		{
 			name:       "update GOPOWERSTORE_DEBUG value for Controller",
 			yamlString: "<GOPOWERSTORE_DEBUG>",
-			csm:        gopowerstoreDebug("false"),
+			csm:        gopowerstoreDebug("true"),
 			ct:         powerStoreClient,
 			sec:        powerStoreSecret,
 			fileType:   "Controller",
-			expected:   "false",
+			expected:   "true",
 		},
 		{
 			name:       "update GOPOWERSTORE_DEBUG value for Node",
 			yamlString: "<GOPOWERSTORE_DEBUG>",
-			csm:        gopowerstoreDebug("false"),
+			csm:        gopowerstoreDebug("true"),
 			ct:         powerStoreClient,
 			sec:        powerStoreSecret,
 			fileType:   "Node",
-			expected:   "false",
+			expected:   "true",
 		},
 	}
 )

--- a/samples/storage_csm_powerstore_v2110.yaml
+++ b/samples/storage_csm_powerstore_v2110.yaml
@@ -59,9 +59,9 @@ spec:
         - name: CSI_LOG_LEVEL
           value: info
         # GOPOWERSTORE_DEBUG: Enable/disable debug logs from gopowerstore library.
-        # Default value: true
+        # Default value: false
         - name: "GOPOWERSTORE_DEBUG"
-          value: "true"
+          value: "false"
     sideCars:
       # 'csivol' represents a string prepended to each volume created by the CSI driver
       - name: provisioner

--- a/samples/storage_csm_powerstore_v2120.yaml
+++ b/samples/storage_csm_powerstore_v2120.yaml
@@ -59,9 +59,9 @@ spec:
         - name: CSI_LOG_LEVEL
           value: info
         # GOPOWERSTORE_DEBUG: Enable/disable debug logs from gopowerstore library.
-        # Default value: true
+        # Default value: false
         - name: "GOPOWERSTORE_DEBUG"
-          value: "true"
+          value: "false"
     sideCars:
       # 'csivol' represents a string prepended to each volume created by the CSI driver
       - name: provisioner

--- a/samples/storage_csm_powerstore_v2130.yaml
+++ b/samples/storage_csm_powerstore_v2130.yaml
@@ -59,9 +59,9 @@ spec:
         - name: CSI_LOG_LEVEL
           value: info
         # GOPOWERSTORE_DEBUG: Enable/disable debug logs from gopowerstore library.
-        # Default value: true
+        # Default value: false
         - name: "GOPOWERSTORE_DEBUG"
-          value: "true"
+          value: "false"
     sideCars:
       # 'csivol' represents a string prepended to each volume created by the CSI driver
       - name: provisioner

--- a/tests/config/driverconfig/powerstore/v2.11.0/controller.yaml
+++ b/tests/config/driverconfig/powerstore/v2.11.0/controller.yaml
@@ -247,7 +247,7 @@ spec:
             - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
               value: /powerstore-config-params/driver-config-params.yaml
             - name: GOPOWERSTORE_DEBUG
-              value: true
+              value: false
             - name: CSI_AUTO_ROUND_OFF_FILESYSTEM_SIZE
               value: false
             - name: X_CSI_HEALTH_MONITOR_ENABLED

--- a/tests/config/driverconfig/powerstore/v2.11.0/node.yaml
+++ b/tests/config/driverconfig/powerstore/v2.11.0/node.yaml
@@ -130,7 +130,7 @@ spec:
             - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
               value: /powerstore-config-params/driver-config-params.yaml
             - name: GOPOWERSTORE_DEBUG
-              value: "true"
+              value: "false"
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
           volumeMounts:

--- a/tests/config/driverconfig/powerstore/v2.12.0/controller.yaml
+++ b/tests/config/driverconfig/powerstore/v2.12.0/controller.yaml
@@ -247,7 +247,7 @@ spec:
             - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
               value: /powerstore-config-params/driver-config-params.yaml
             - name: GOPOWERSTORE_DEBUG
-              value: true
+              value: false
             - name: CSI_AUTO_ROUND_OFF_FILESYSTEM_SIZE
               value: false
             - name: X_CSI_HEALTH_MONITOR_ENABLED

--- a/tests/config/driverconfig/powerstore/v2.12.0/node.yaml
+++ b/tests/config/driverconfig/powerstore/v2.12.0/node.yaml
@@ -130,7 +130,7 @@ spec:
             - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
               value: /powerstore-config-params/driver-config-params.yaml
             - name: GOPOWERSTORE_DEBUG
-              value: "true"
+              value: "false"
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
           volumeMounts:

--- a/tests/config/driverconfig/powerstore/v2.13.0/controller.yaml
+++ b/tests/config/driverconfig/powerstore/v2.13.0/controller.yaml
@@ -247,7 +247,7 @@ spec:
             - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
               value: /powerstore-config-params/driver-config-params.yaml
             - name: GOPOWERSTORE_DEBUG
-              value: true
+              value: false
             - name: CSI_AUTO_ROUND_OFF_FILESYSTEM_SIZE
               value: false
             - name: X_CSI_HEALTH_MONITOR_ENABLED

--- a/tests/config/driverconfig/powerstore/v2.13.0/node.yaml
+++ b/tests/config/driverconfig/powerstore/v2.13.0/node.yaml
@@ -130,7 +130,7 @@ spec:
             - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
               value: /powerstore-config-params/driver-config-params.yaml
             - name: GOPOWERSTORE_DEBUG
-              value: "true"
+              value: "false"
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "<X_CSI_HEALTH_MONITOR_ENABLED>"
           volumeMounts:


### PR DESCRIPTION
# Description
Per stakeholder feedback I am moving the default for GOPOWERSTORE_DEBUG to false, consistent with other library debug flags. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1762 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (https://github.com/dell/csm-docs/pull/1458)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios
