### PR TITLE
Remove Invalid Mount from OCP - PowerFlex

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -795,6 +795,13 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 		modules.UpdatePowerMaxConfigMap(configMap, cr)
 	}
 
+	// if driver is powerflex and installing on openshift, we must remove the root host path, since it is read only
+	if cr.GetDriverType() == csmv1.PowerFlex {
+		if r.Config.IsOpenShift {
+			_ = drivers.RemoveVolume(&node.DaemonSetApplyConfig, drivers.ScaleioBinPath)
+		}
+	}
+
 	replicationEnabled, clusterClients, err := utils.GetDefaultClusters(ctx, cr, r)
 	if err != nil {
 		return err

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -849,6 +849,12 @@ func (suite *CSMControllerTestSuite) TestSyncCSM() {
 	reverseProxyWithSecret.Spec.Modules = getReverseProxyModuleWithSecret()
 	reverseProxyServerCSM.Spec.Driver.CSIDriverType = csmv1.PowerMax
 
+	// added for the powerflex on openshift case
+	r.Config.IsOpenShift = true
+	powerflexCSM := shared.MakeCSM(csmName, suite.namespace, configVersion)
+	powerflexCSM.Spec.Driver.CSIDriverType = csmv1.PowerFlex
+	suite.makeFakeCSM(csmName, suite.namespace, false, []csmv1.Module{})
+
 	syncCSMTests := []struct {
 		name        string
 		csm         csmv1.ContainerStorageModule
@@ -862,6 +868,7 @@ func (suite *CSMControllerTestSuite) TestSyncCSM() {
 		{"getDriverConfig bad op config", csm, badOperatorConfig, ""},
 		{"getDriverConfig error", csmBadType, badOperatorConfig, "no such file or directory"},
 		{"success: deployAsSidecar with secret", reverseProxyWithSecret, operatorConfig, ""},
+		{"powerflex on openshift - delete mount", powerflexCSM, operatorConfig, ""},
 	}
 
 	for _, tt := range syncCSMTests {

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -13,6 +13,8 @@
 package k8s
 
 import (
+	"os"
+
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -87,4 +89,23 @@ func NewControllerRuntimeClient(data []byte) (ctrlClient.Client, error) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	return ctrlClient.New(restConfig, ctrlClient.Options{Scheme: scheme})
+}
+
+// Unit tests require a kubeconfig that is known and stable between testing environments.
+func CreateTempKubeconfig(filepath string) {
+	kubeconfig := `clusters:
+- cluster:
+    server: https://some.hostname.or.ip:6443
+  name: fake-cluster
+contexts:
+- context:
+    cluster: fake-cluster
+    user: admin
+  name: admin
+current-context: admin
+preferences: {}
+users:
+- name: admin`
+
+	os.WriteFile(filepath, []byte(kubeconfig), 0o600)
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -92,7 +92,7 @@ func NewControllerRuntimeClient(data []byte) (ctrlClient.Client, error) {
 }
 
 // Unit tests require a kubeconfig that is known and stable between testing environments.
-func CreateTempKubeconfig(filepath string) {
+func CreateTempKubeconfig(filepath string) error {
 	kubeconfig := `clusters:
 - cluster:
     server: https://some.hostname.or.ip:6443
@@ -107,5 +107,5 @@ preferences: {}
 users:
 - name: admin`
 
-	os.WriteFile(filepath, []byte(kubeconfig), 0o600)
+	return os.WriteFile(filepath, []byte(kubeconfig), 0o600)
 }

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -115,7 +115,7 @@ func Test_IsOpenShift(t *testing.T) {
 			}
 
 			// Create a fake kubeconfig and set the KUBECONFIG environment variable.
-			createTempKubeconfig("./fake-kubeconfig")
+			CreateTempKubeconfig("./fake-kubeconfig")
 			os.Setenv("KUBECONFIG", "./fake-kubeconfig")
 
 			isOpenshift, err := IsOpenShift()
@@ -250,22 +250,4 @@ users:
 			}
 		})
 	}
-}
-
-func createTempKubeconfig(filepath string) {
-	kubeconfig := `clusters:
-- cluster:
-    server: https://some.hostname.or.ip:6443
-  name: fake-cluster
-contexts:
-- context:
-    cluster: fake-cluster
-    user: admin
-  name: admin
-current-context: admin
-preferences: {}
-users:
-- name: admin`
-
-	os.WriteFile(filepath, []byte(kubeconfig), 0o600)
 }

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -115,7 +115,8 @@ func Test_IsOpenShift(t *testing.T) {
 			}
 
 			// Create a fake kubeconfig and set the KUBECONFIG environment variable.
-			CreateTempKubeconfig("./fake-kubeconfig")
+			err := CreateTempKubeconfig("./fake-kubeconfig")
+			assert.NoError(t, err)
 			os.Setenv("KUBECONFIG", "./fake-kubeconfig")
 
 			isOpenshift, err := IsOpenShift()

--- a/main_test.go
+++ b/main_test.go
@@ -402,17 +402,19 @@ func TestGetOperatorConfig(t *testing.T) {
 
 func TestIsOpenshift(t *testing.T) {
 	// Create a fake kubeconfig and set the KUBECONFIG environment variable.
-	k8s.CreateTempKubeconfig("./fake-kubeconfig")
+	err := k8s.CreateTempKubeconfig("./fake-kubeconfig")
+	assert.NoError(t, err)
 	os.Setenv("KUBECONFIG", "./fake-kubeconfig")
-	_, err := isOpenShift()
+	_, err = isOpenShift()
 	assert.NotNil(t, err)
 }
 
 func TestGetKubeAPIServerVersion(t *testing.T) {
 	// Create a fake kubeconfig and set the KUBECONFIG environment variable.
-	k8s.CreateTempKubeconfig("./fake-kubeconfig")
+	err := k8s.CreateTempKubeconfig("./fake-kubeconfig")
+	assert.NoError(t, err)
 	os.Setenv("KUBECONFIG", "./fake-kubeconfig")
-	_, err := getKubeAPIServerVersion()
+	_, err = getKubeAPIServerVersion()
 	assert.NotNil(t, err)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -399,13 +399,14 @@ func TestGetOperatorConfig(t *testing.T) {
 }
 
 func TestIsOpenshift(t *testing.T) {
-	_, err := isOpenShift()
-	assert.NotNil(t, err)
+	openshift, err := isOpenShift()
+	assert.Nil(t, err)
+	assert.Equal(t, false, openshift)
 }
 
 func TestGetKubeAPIServerVersion(t *testing.T) {
 	_, err := getKubeAPIServerVersion()
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 }
 
 func TestGetConfigDir(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -16,10 +16,12 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/dell/csm-operator/controllers"
+	"github.com/dell/csm-operator/k8s"
 	"github.com/dell/csm-operator/pkg/logger"
 	"github.com/dell/csm-operator/pkg/utils"
 	"github.com/go-logr/logr"
@@ -399,14 +401,19 @@ func TestGetOperatorConfig(t *testing.T) {
 }
 
 func TestIsOpenshift(t *testing.T) {
-	openshift, err := isOpenShift()
-	assert.Nil(t, err)
-	assert.Equal(t, false, openshift)
+	// Create a fake kubeconfig and set the KUBECONFIG environment variable.
+	k8s.CreateTempKubeconfig("./fake-kubeconfig")
+	os.Setenv("KUBECONFIG", "./fake-kubeconfig")
+	_, err := isOpenShift()
+	assert.NotNil(t, err)
 }
 
 func TestGetKubeAPIServerVersion(t *testing.T) {
+	// Create a fake kubeconfig and set the KUBECONFIG environment variable.
+	k8s.CreateTempKubeconfig("./fake-kubeconfig")
+	os.Setenv("KUBECONFIG", "./fake-kubeconfig")
 	_, err := getKubeAPIServerVersion()
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetConfigDir(t *testing.T) {

--- a/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
@@ -137,6 +137,7 @@ spec:
             - name: pods-path
               mountPath: <KUBELET_CONFIG_DIR>/pods
               mountPropagation: "Bidirectional"
+            # will be removed if installing on OpenShift
             - name: scaleio-path-bin
               mountPath: /bin/emc/scaleio/
               readOnly: true
@@ -280,6 +281,7 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        # will be removed if installing on OpenShift
         - name: scaleio-path-bin
           hostPath:
             path: /bin/emc/scaleio/

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -20,8 +20,6 @@ import (
 	"regexp"
 	"strings"
 
-	v1 "k8s.io/client-go/applyconfigurations/apps/v1"
-
 	csmv1 "github.com/dell/csm-operator/api/v1"
 	"github.com/dell/csm-operator/pkg/logger"
 	"github.com/dell/csm-operator/pkg/utils"

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -20,10 +20,13 @@ import (
 	"regexp"
 	"strings"
 
+	v1 "k8s.io/client-go/applyconfigurations/apps/v1"
+
 	csmv1 "github.com/dell/csm-operator/api/v1"
 	"github.com/dell/csm-operator/pkg/logger"
 	"github.com/dell/csm-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -58,6 +61,9 @@ const (
 
 	// PowerFlexCSMNameSpace - namespace CSM is found in. Needed for cases where pod namespace is not namespace of CSM
 	PowerFlexCSMNameSpace string = "<CSM_NAMESPACE>"
+
+	// ScaleioBinPath - name of volume that is mounted by the CSI plugin when not running on OCP
+	ScaleioBinPath = "scaleio-path-bin"
 
 	// PowerFlexDebug - will be used to control the GOSCALEIO_DEBUG variable
 	PowerFlexDebug string = "<GOSCALEIO_DEBUG>"
@@ -449,5 +455,27 @@ func ValidateZonesInSecret(ctx context.Context, kube client.Client, namespace st
 		return fmt.Errorf("array details are not provided in secret")
 	}
 
+	return nil
+}
+
+func RemoveVolume(configuration *v1.DaemonSetApplyConfiguration, volumeName string) error {
+	if configuration == nil {
+		return fmt.Errorf("RemoveVolume called with a nil daemonset")
+	}
+	podTemplate := configuration.Spec.Template
+	for i, vol := range podTemplate.Spec.Volumes {
+		if vol.Name != nil && *vol.Name == volumeName {
+			podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes[0:i], podTemplate.Spec.Volumes[i+1:]...)
+			break
+		}
+	}
+	for c := range podTemplate.Spec.Containers {
+		for i, volMount := range podTemplate.Spec.Containers[c].VolumeMounts {
+			if volMount.Name != nil && *volMount.Name == volumeName {
+				podTemplate.Spec.Containers[c].VolumeMounts = append(podTemplate.Spec.Containers[c].VolumeMounts[0:i], podTemplate.Spec.Containers[c].VolumeMounts[i+1:]...)
+				break
+			}
+		}
+	}
 	return nil
 }

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -471,7 +471,7 @@ func RemoveVolume(configuration *v1.DaemonSetApplyConfiguration, volumeName stri
 		for i, volMount := range podTemplate.Spec.Containers[c].VolumeMounts {
 			if volMount.Name != nil && *volMount.Name == volumeName {
 				podTemplate.Spec.Containers[c].VolumeMounts = append(podTemplate.Spec.Containers[c].VolumeMounts[0:i], podTemplate.Spec.Containers[c].VolumeMounts[i+1:]...)
-				break
+				return nil
 			}
 		}
 	}

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	acorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -593,6 +595,67 @@ func TestExtractZonesFromSecret(t *testing.T) {
 				assert.NotNil(t, err)
 			} else {
 				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestRemoveVolume(t *testing.T) {
+	volumeName := ScaleioBinPath
+	containerName := "driver"
+	tests := []struct {
+		name          string
+		configuration *v1.DaemonSetApplyConfiguration
+		wantErr       bool
+	}{
+		{
+			name: "Remove volume and mount",
+			configuration: &v1.DaemonSetApplyConfiguration{
+				Spec: &v1.DaemonSetSpecApplyConfiguration{
+					Template: &acorev1.PodTemplateSpecApplyConfiguration{
+						Spec: &acorev1.PodSpecApplyConfiguration{
+							Volumes: []acorev1.VolumeApplyConfiguration{
+								{
+									Name: &volumeName,
+								},
+							},
+							Containers: []acorev1.ContainerApplyConfiguration{
+								{
+									Name: &containerName,
+									VolumeMounts: []acorev1.VolumeMountApplyConfiguration{
+										{
+											Name: &volumeName,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:          "RemoveVolume called with nil daemonset",
+			configuration: nil,
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := RemoveVolume(tt.configuration, volumeName); (err != nil) != tt.wantErr {
+				t.Errorf("RemoveVolume() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			// check that the volumes and volume mount were removed
+			if !tt.wantErr {
+				for i := range tt.configuration.Spec.Template.Spec.Volumes {
+					assert.NotEqual(t, *tt.configuration.Spec.Template.Spec.Volumes[i].Name, volumeName)
+				}
+				for c := range tt.configuration.Spec.Template.Spec.Containers {
+					for i := range tt.configuration.Spec.Template.Spec.Containers[c].VolumeMounts {
+						assert.NotEqual(t, *tt.configuration.Spec.Template.Spec.Containers[c].VolumeMounts[i].Name, volumeName)
+					}
+				}
 			}
 		})
 	}

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -602,6 +602,7 @@ func TestExtractZonesFromSecret(t *testing.T) {
 
 func TestRemoveVolume(t *testing.T) {
 	volumeName := ScaleioBinPath
+	differentVolumeName := "different-volume-name"
 	containerName := "driver"
 	tests := []struct {
 		name          string
@@ -636,6 +637,33 @@ func TestRemoveVolume(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "RemoveVolume called with a daemonset that doesn't include the volume",
+			configuration: &v1.DaemonSetApplyConfiguration{
+				Spec: &v1.DaemonSetSpecApplyConfiguration{
+					Template: &acorev1.PodTemplateSpecApplyConfiguration{
+						Spec: &acorev1.PodSpecApplyConfiguration{
+							Volumes: []acorev1.VolumeApplyConfiguration{
+								{
+									Name: &differentVolumeName,
+								},
+							},
+							Containers: []acorev1.ContainerApplyConfiguration{
+								{
+									Name: &containerName,
+									VolumeMounts: []acorev1.VolumeMountApplyConfiguration{
+										{
+											Name: &differentVolumeName,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:          "RemoveVolume called with nil daemonset",
 			configuration: nil,
 			wantErr:       true,
@@ -646,7 +674,7 @@ func TestRemoveVolume(t *testing.T) {
 			if err := RemoveVolume(tt.configuration, volumeName); (err != nil) != tt.wantErr {
 				t.Errorf("RemoveVolume() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			// check that the volumes and volume mount were removed
+			// check that the volume and volume mount were removed
 			if !tt.wantErr {
 				for i := range tt.configuration.Spec.Template.Spec.Volumes {
 					assert.NotEqual(t, *tt.configuration.Spec.Template.Spec.Volumes[i].Name, volumeName)


### PR DESCRIPTION
# Description
One of the Operator changes for a mounted volume is incompatible with OpenShift environments, because OCP denies write access to the root filesystem. This PR covers changes to identify and remove that mount when on OCP environments. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1782 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (comments in associated node.yaml)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility
- [X] I have executed the relevant end-to-end test scenarios (--pflex --no-modules)

# How Has This Been Tested?
Manually tested on OCP 4.16.37. 