### PR TITLE
PowerMax Mount Credentials: Override Minimal Manifest Images

### DIFF
--- a/pkg/drivers/commonconfig.go
+++ b/pkg/drivers/commonconfig.go
@@ -277,12 +277,16 @@ func GetNode(ctx context.Context, cr csmv1.ContainerStorageModule, operatorConfi
 	for i, c := range containers {
 		if c.Name != nil && string(*c.Name) == "driver" {
 			// Check if Common is not nil before accessing its fields
-			if cr.Spec.Driver.Common != nil && cr.Spec.Driver.Node != nil {
-				containers[i].Env = utils.ReplaceAllApplyCustomEnvs(c.Env, cr.Spec.Driver.Common.Envs, cr.Spec.Driver.Node.Envs)
-				c.Env = containers[i].Env
-				if string(cr.Spec.Driver.Common.Image) != "" {
+			if cr.Spec.Driver.Common != nil {
+				// With minimal, this will override the node image if the driver image is overridden.
+				if cr.Spec.Driver.Common.Image != "" {
 					image := string(cr.Spec.Driver.Common.Image)
 					c.Image = &image
+				}
+
+				if cr.Spec.Driver.Node != nil {
+					containers[i].Env = utils.ReplaceAllApplyCustomEnvs(c.Env, cr.Spec.Driver.Common.Envs, cr.Spec.Driver.Node.Envs)
+					c.Env = containers[i].Env
 				}
 			}
 		}

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 require (
 	github.com/dell/csm-operator v0.0.0
-	github.com/onsi/ginkgo/v2 v2.22.2
+	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.36.2
 	golang.org/x/mod v0.24.0
 	k8s.io/api v0.32.0
@@ -118,7 +118,7 @@ require (
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
-	golang.org/x/tools v0.28.0 // indirect
+	golang.org/x/tools v0.30.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241219192143-6b3ec007d9bb // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241219192143-6b3ec007d9bb // indirect
 	google.golang.org/grpc v1.69.2 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -158,8 +158,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU=
-github.com/onsi/ginkgo/v2 v2.22.2/go.mod h1:oeMosUL+8LtarXBHu/c0bx2D/K9zyQ6uX3cTyztHwsk=
+github.com/onsi/ginkgo/v2 v2.23.3 h1:edHxnszytJ4lD9D5Jjc4tiDkPBZ3siDeJJkUZJJVkp0=
+github.com/onsi/ginkgo/v2 v2.23.3/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -306,8 +306,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.28.0 h1:WuB6qZ4RPCQo5aP3WdKZS7i595EdWqWR8vqJTlwTVK8=
-golang.org/x/tools v0.28.0/go.mod h1:dcIOrVd3mfQKTgrDVQHqCPMWy6lnhfhtX3hLXYVLfRw=
+golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tests/e2e/steps/steps_def.go
+++ b/tests/e2e/steps/steps_def.go
@@ -360,16 +360,11 @@ func (step *Step) validateMinimalCSMDriverSpec(res Resource, driverName string, 
 		len(driver.InitContainers) > 0 ||
 		len(driver.SnapshotClass) > 0 ||
 		driver.Controller != nil ||
-		driver.Node != nil ||
 		driver.CSIDriverSpec != nil ||
 		driver.DNSPolicy != "" ||
 		driver.AuthSecret != "" ||
 		driver.TLSCertSecret != "" {
 		return fmt.Errorf("unexpected fields found in Driver spec: %+v", driver)
-	}
-
-	if driver.CSIDriverType == csmv1.PowerMax && found.HasModule(csmv1.ReverseProxy) {
-		return fmt.Errorf("csm resource '%s' contains reverse proxy module", cr.Name)
 	}
 
 	return nil

--- a/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/storage_csm_powermax_secret.yaml
@@ -9,10 +9,15 @@ spec:
     configVersion: v2.14.0
     forceRemoveDriver: true
     common:
+      image: quay.io/dell/container-storage-modules/csi-powermax:nightly
       envs:
         - name: "X_CSI_REVPROXY_USE_SECRET"
           value: "true"
   modules:
+    - name: csireverseproxy
+      components:
+        - name: csipowermax-reverseproxy
+          image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:nightly
     - name: authorization
       enabled: false
     - name: resiliency
@@ -21,3 +26,10 @@ spec:
       enabled: false
     - name: observability
       enabled: false
+      components:
+        - name: metrics-powermax
+          enabled: true
+          image: quay.io/dell/container-storage-modules/csm-metrics-powermax:nightly
+        - name: topology
+          enabled: true
+          image: quay.io/dell/container-storage-modules/csm-topology:nightly


### PR DESCRIPTION
# Description
The recent changes of updating all image versions to a tagged version has led to the issue of the minimal manifests attempting to pull unreleased images in the testfiles. After further investigation, the fix appears to be to override the `image` field for all modules/drivers that would be needed.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1824 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Manually install PowerMax Mount Credentials through minimal manifest and ensure that it is properly pulling and using the nightly images.
- [x] Update and run minimal manifest e2e for PowerMax Mount Credentials.
<details>

```
$ bash run-e2e-test.sh --pmax
/home/falfaroc/git/public/dell/csm-operator/tests/e2e
  W0402 13:56:11.436403   95804 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0402 13:56:11.436466 95804 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CSM Operator End-to-End Tests - /home/falfaroc/git/public/dell/csm-operator/tests/e2e
====================================================================================================
Random Seed: 1743616568

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/home/falfaroc/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 04/02/25 13:56:11.436
  STEP: [powermax] @ 04/02/25 13:56:11.436
  STEP: Reading values file @ 04/02/25 13:56:11.437
  STEP: Getting a k8s client @ 04/02/25 13:56:11.437
[BeforeSuite] PASSED [0.002 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/home/falfaroc/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerMax Driver with Mount Credentials (Minimal)  @ 04/02/25 13:56:11.439
  STEP: Returning false here @ 04/02/25 13:56:11.439
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 04/02/25 13:56:11.439
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 04/02/25 13:56:11.952
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-creds] in namespace [powermax] for [pmaxUseSecret] @ 04/02/25 13:56:13.838
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 04/02/25 13:56:14.984
  STEP:      Executing  Apply custom resource [1] @ 04/02/25 13:56:16.018
  I0402 13:56:16.018579 95804 builder.go:121] Running '/usr/local/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0402 13:56:16.958024 95804 builder.go:146] stderr: ""
  I0402 13:56:16.958092 95804 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 04/02/25 13:56:16.958

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 04/02/25 13:57:07.669
  STEP:      Executing  Validate [powermax] driver spec from CR [1] @ 04/02/25 13:57:28.07
  STEP:      Executing  Run custom test @ 04/02/25 13:57:28.203
  I0402 13:57:28.203259 95804 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-04-02 13:57:28]  INFO Starting cert-csi; ver. 1.6.0
[2025-04-02 13:57:28]  INFO Using EVENT observer type
[2025-04-02 13:57:28]  INFO Using config from /home/falfaroc/.kube/config
[2025-04-02 13:57:28]  INFO Successfully loaded config. Host: __
[2025-04-02 13:57:28]  INFO Created new KubeClient
[2025-04-02 13:57:28]  INFO Running 1 iteration(s)
[2025-04-02 13:57:28]  INFO     *** ITERATION NUMBER 1 ***
[2025-04-02 13:57:28]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-04-02 13:57:29]  INFO Successfully created namespace volumeio-test-b84d2986
[2025-04-02 13:57:29]  INFO Using default number of volumes
[2025-04-02 13:57:29]  INFO Using default image: quay.io/centos/centos:latest
[2025-04-02 13:57:29]  INFO Creating IO pod
[2025-04-02 13:57:29]  INFO Waiting for pod iowriter-test-6bgdw to be READY
[2025-04-02 13:57:51]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-04-02 13:57:53]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-04-02 13:58:13]  INFO Waiting until no Volume Attachments with PV  left
[2025-04-02 13:58:13]  INFO VolumeAttachment deleted
[2025-04-02 13:58:13]  INFO Deleting all resources in namespace volumeio-test-b84d2986
[2025-04-02 13:58:26]  INFO Namespace volumeio-test-b84d2986 was deleted in 12.510192477s
[2025-04-02 13:58:29]  INFO SUCCESS: VolumeIoSuite in 1m0.671247002s
[2025-04-02 13:58:29]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-04-02 13:58:29]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-04-02 13:58:29]  WARN No ResourceUsageMetrics provided
[2025-04-02 13:58:29] ERROR no ResourceUsageMetrics provided
report-test-run-e758d230:
Name: test-run-e758d230
Host: __
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/home/falfaroc/.cert-csi/reports/test-run-e758d230/PodsCreatingOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-e758d230/PodsReadyOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-e758d230/PodsTerminatingOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-e758d230/PvcsCreatingOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-e758d230/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-04-02 13:57:28.867059775 -0400 -0400
            Ended:     2025-04-02 13:58:29.53658712 -0400 -0400
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 6.012384396s
                        Min: 6.012384396s
                        Max: 6.012384396s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCAttachment.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 3.468340343s
                        Min: 3.468340343s
                        Max: 3.468340343s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCBind.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 10.382142712s
                        Min: 10.382142712s
                        Max: 10.382142712s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCCreation.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 101.382896ms
                        Min: 101.382896ms
                        Max: 101.382896ms
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCDeletion.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 2.054062017s
                        Min: 2.054062017s
                        Max: 2.054062017s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCUnattachment.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 21.471436693s
                        Min: 21.471436693s
                        Max: 21.471436693s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PodCreation.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 17.327862757s
                        Min: 17.327862757s
                        Max: 17.327862757s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PodDeletion.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /home/falfaroc/.cert-csi/reports/test-run-e758d230/VolumeIoSuite21/EntityNumberOverTime.png

[2025-04-02 13:58:29]  INFO Avg time of a run:   44.55s
[2025-04-02 13:58:29]  INFO Avg time of a del:   12.51s
[2025-04-02 13:58:29]  INFO Avg time of all:     60.67s
[2025-04-02 13:58:29]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 04/02/25 13:58:29.713
  STEP:      Executing  Delete custom resource [1] @ 04/02/25 13:58:30.108
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 04/02/25 13:58:30.369

err: found the following pods: powermax-controller-69d94f6fb5-pwbh9,powermax-controller-69d94f6fb5-pzqhn,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 04/02/25 13:59:21.02
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 04/02/25 13:59:21.024
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 04/02/25 13:59:21.03
  STEP: Ending: Install PowerMax Driver with Mount Credentials (Minimal)
   @ 04/02/25 13:59:21.034
  STEP: Starting: Install PowerMax Driver with Mount Credentials (Minimal), Enable Observability  @ 04/02/25 13:59:26.039
  STEP: Returning false here @ 04/02/25 13:59:26.039
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 04/02/25 13:59:26.039
  STEP:      Executing  Create storageclass with name [op-e2e-pmax] and template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 04/02/25 13:59:26.167
  STEP:      Executing  Set up secret with template [testfiles/powermax-templates/powermax-use-secret-template.yaml] name [powermax-creds] in namespace [powermax] for [pmaxUseSecret] @ 04/02/25 13:59:27.981
  STEP:      Executing  Set up creds with template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 04/02/25 13:59:29.551
  STEP:      Executing  Apply custom resource [1] @ 04/02/25 13:59:30.355
  I0402 13:59:30.355469 95804 builder.go:121] Running '/usr/local/bin/kubectl --namespace=powermax apply --validate=true -f -'
  I0402 13:59:31.143625 95804 builder.go:146] stderr: ""
  I0402 13:59:31.143937 95804 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powermax created\n"
  STEP:      Executing  Validate custom resource [1] @ 04/02/25 13:59:31.144

err: expected custom resource status to be Succeeded. Got: Failed
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 04/02/25 14:00:21.404
  STEP:      Executing  Validate [observability] module from CR [1] is not installed @ 04/02/25 14:00:42.036
  STEP:      Executing  Enable [observability] module from CR [1] @ 04/02/25 14:00:52.552
  STEP:      Executing  Validate [powermax] driver from CR [1] is installed @ 04/02/25 14:01:07.834
  STEP:      Executing  Validate [observability] module from CR [1] is installed @ 04/02/25 14:01:28.345
  STEP:      Executing  Validate [powermax] driver spec from CR [1] @ 04/02/25 14:01:39.241
  STEP:      Executing  Run custom test @ 04/02/25 14:01:39.367
  I0402 14:01:39.368006 95804 util.go:650] Running cert-csi [test vio --sc op-e2e-pmax --chainLength 1 --chainNumber 1]
[2025-04-02 14:01:39]  INFO Starting cert-csi; ver. 1.6.0
[2025-04-02 14:01:39]  INFO Using EVENT observer type
[2025-04-02 14:01:39]  INFO Using config from /home/falfaroc/.kube/config
[2025-04-02 14:01:39]  INFO Successfully loaded config. Host: __
[2025-04-02 14:01:39]  INFO Created new KubeClient
[2025-04-02 14:01:40]  INFO Running 1 iteration(s)
[2025-04-02 14:01:40]  INFO     *** ITERATION NUMBER 1 ***
[2025-04-02 14:01:40]  INFO Starting VolumeIoSuite with op-e2e-pmax storage class
[2025-04-02 14:01:40]  INFO Successfully created namespace volumeio-test-e93bad7b
[2025-04-02 14:01:40]  INFO Using default number of volumes
[2025-04-02 14:01:40]  INFO Using default image: quay.io/centos/centos:latest
[2025-04-02 14:01:40]  INFO Creating IO pod
[2025-04-02 14:01:41]  INFO Waiting for pod iowriter-test-kqb4n to be READY
[2025-04-02 14:02:03]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-04-02 14:02:04]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-04-02 14:02:22]  INFO Waiting until no Volume Attachments with PV  left
[2025-04-02 14:02:22]  INFO VolumeAttachment deleted
[2025-04-02 14:02:22]  INFO Deleting all resources in namespace volumeio-test-e93bad7b
[2025-04-02 14:02:35]  INFO Namespace volumeio-test-e93bad7b was deleted in 12.528520397s
[2025-04-02 14:02:35]  INFO SUCCESS: VolumeIoSuite in 55.698724207s
[2025-04-02 14:02:35]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sCollecting metrics
Generating plots
[2025-04-02 14:02:35]  INFO Started generating reports...
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-04-02 14:02:35]  WARN No ResourceUsageMetrics provided
[2025-04-02 14:02:35] ERROR no ResourceUsageMetrics provided
report-test-run-0e6e1d37:
Name: test-run-0e6e1d37
Host: __
StorageClass: op-e2e-pmax
Minimum and Maximum EntityOverTime charts:

/home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/PodsCreatingOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/PodsReadyOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/PodsTerminatingOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/PvcsCreatingOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-04-02 14:01:40.069193742 -0400 -0400
            Ended:     2025-04-02 14:02:35.767693865 -0400 -0400
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 6.024844898s
                        Min: 6.024844898s
                        Max: 6.024844898s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCAttachment.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 3.190411591s
                        Min: 3.190411591s
                        Max: 3.190411591s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCBind.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 9.397668201s
                        Min: 9.397668201s
                        Max: 9.397668201s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCCreation.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 7.447106ms
                        Min: 7.447106ms
                        Max: 7.447106ms
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCDeletion.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.970585701s
                        Min: 1.970585701s
                        Max: 1.970585701s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCUnattachment.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 20.792907413s
                        Min: 20.792907413s
                        Max: 20.792907413s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PodCreation.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 14.609079142s
                        Min: 14.609079142s
                        Max: 14.609079142s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PodDeletion.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /home/falfaroc/.cert-csi/reports/test-run-0e6e1d37/VolumeIoSuite22/EntityNumberOverTime.png

[2025-04-02 14:02:35]  INFO Avg time of a run:   42.78s
[2025-04-02 14:02:35]  INFO Avg time of a del:   12.53s
[2025-04-02 14:02:35]  INFO Avg time of all:     55.70s
[2025-04-02 14:02:35]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 04/02/25 14:02:35.941
  STEP:      Executing  Delete custom resource [1] @ 04/02/25 14:02:36.206
  STEP:      Executing  Validate [powermax] driver from CR [1] is not installed @ 04/02/25 14:02:36.473

err: found the following pods: powermax-controller-69d94f6fb5-fvkl9,powermax-controller-69d94f6fb5-pz6ss,
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-storageclass-template.yaml] for [pmax] @ 04/02/25 14:03:27.053
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-use-secret-template.yaml] for [pmaxUseSecret] @ 04/02/25 14:03:27.057
  STEP:      Executing  Restore template [testfiles/powermax-templates/powermax-array-config.yaml] for [pmaxArrayConfig] @ 04/02/25 14:03:27.061
  STEP: Ending: Install PowerMax Driver with Mount Credentials (Minimal), Enable Observability
   @ 04/02/25 14:03:27.064
• [440.647 seconds]
------------------------------

Ran 1 of 1 Specs in 440.649 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 7m23.488843833s
Test Suite Passed
```

</details>
