### PR TITLE
Re-instate Node Mounts (PowerFlex) + E2E Fix

### DIFF
--- a/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
@@ -272,10 +272,6 @@ spec:
           hostPath:
             path: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com
             type: DirectoryOrCreate
-        - name: disks-path
-          hostPath:
-            path: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com/disks
-            type: DirectoryOrCreate
         - name: volumedevices-path
           hostPath:
             path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices

--- a/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
@@ -140,6 +140,7 @@ spec:
               mountPropagation: "Bidirectional"
             - name: pods-path
               mountPath: <KUBELET_CONFIG_DIR>/pods
+              mountPropagation: "Bidirectional"
             # will be removed if installing on OpenShift
             - name: scaleio-path-bin
               mountPath: /bin/emc/scaleio/

--- a/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
@@ -135,9 +135,6 @@ spec:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com
               mountPropagation: "Bidirectional"
-            - name: disks-path
-              mountPath: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com/disks
-              mountPropagation: "Bidirectional"
             - name: volumedevices-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices
               mountPropagation: "Bidirectional"

--- a/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
@@ -143,9 +143,6 @@ spec:
               mountPropagation: "Bidirectional"
             - name: pods-path
               mountPath: <KUBELET_CONFIG_DIR>/pods
-            - name: noderoot
-              mountPath: /noderoot
-              mountPropagation: "Bidirectional"
             # will be removed if installing on OpenShift
             - name: scaleio-path-bin
               mountPath: /bin/emc/scaleio/
@@ -289,10 +286,6 @@ spec:
         - name: pods-path
           hostPath:
             path: <KUBELET_CONFIG_DIR>/pods
-            type: Directory
-        - name: noderoot
-          hostPath:
-            path: /
             type: Directory
         - name: dev
           hostPath:

--- a/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.14.0/node.yaml
@@ -120,6 +120,10 @@ spec:
               value: <X_CSI_RENAME_SDC_PREFIX>
             - name: X_CSI_MAX_VOLUMES_PER_NODE
               value: <X_CSI_MAX_VOLUMES_PER_NODE>
+            - name: GOSCALEIO_DEBUG
+              value: <GOSCALEIO_DEBUG>
+            - name: GOSCALEIO_SHOWHTTP
+              value: <GOSCALEIO_SHOWHTTP>
             - name: X_CSI_POWERFLEX_KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -131,11 +135,16 @@ spec:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com
               mountPropagation: "Bidirectional"
+            - name: disks-path
+              mountPath: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com/disks
+              mountPropagation: "Bidirectional"
             - name: volumedevices-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices
               mountPropagation: "Bidirectional"
             - name: pods-path
               mountPath: <KUBELET_CONFIG_DIR>/pods
+            - name: noderoot
+              mountPath: /noderoot
               mountPropagation: "Bidirectional"
             # will be removed if installing on OpenShift
             - name: scaleio-path-bin
@@ -234,8 +243,8 @@ spec:
             - "/bin/sh"
             - "-c"
             - |
-              source /data/node_mdms.txt
-              /files/scripts/init.sh
+               source /data/node_mdms.txt
+               /files/scripts/init.sh
           env:
             - name: NODENAME
               valueFrom:
@@ -269,6 +278,10 @@ spec:
           hostPath:
             path: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com
             type: DirectoryOrCreate
+        - name: disks-path
+          hostPath:
+            path: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com/disks
+            type: DirectoryOrCreate
         - name: volumedevices-path
           hostPath:
             path: <KUBELET_CONFIG_DIR>/plugins/kubernetes.io/csi/volumeDevices
@@ -276,6 +289,10 @@ spec:
         - name: pods-path
           hostPath:
             path: <KUBELET_CONFIG_DIR>/pods
+            type: Directory
+        - name: noderoot
+          hostPath:
+            path: /
             type: Directory
         - name: dev
           hostPath:
@@ -312,9 +329,17 @@ spec:
         - name: vxflexos-config-params
           configMap:
             name: <DriverDefaultReleaseName>-config-params
+        - name: usr-bin
+          hostPath:
+            path: /usr/bin
+            type: Directory
         - name: kubelet-pods
           hostPath:
             path: /var/lib/kubelet/pods
+            type: Directory
+        - name: var-run
+          hostPath:
+            path: /var/run
             type: Directory
         - name: mdm-dir
           emptyDir: {}

--- a/tests/e2e/modify_zoning_labels.sh
+++ b/tests/e2e/modify_zoning_labels.sh
@@ -99,7 +99,7 @@ read_secret() {
 validate_zoning() {
   # read the secret and extract zone information
   secret_name="test-vxflexos-config"
-  namespace="vxflexos"
+  namespace="test-vxflexos"
   secret_content=$(read_secret $secret_name $namespace)
 
   # parse the secret content to extract zones


### PR DESCRIPTION
# Description
A recent PR ( https://github.com/dell/csm-operator/pull/913 ) erroneously removed some volumes from the operatorconfig for PowerFlex that were not used/mounted directly by the PowerFlex driver, but are necessary for some modules to function-- causing the CSM driver to fail. This PR reinstates those volumes. 

Also fixing a minor error in an E2E test script.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1782 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility
- [X] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Manually installed a CSM object that enables the previously-failing modules on OCP and verified that the driver installs successfully.
