### PR TITLE
PowerStore: Support HBNFS with Minimal

### DIFF
--- a/pkg/drivers/powerstore_test.go
+++ b/pkg/drivers/powerstore_test.go
@@ -116,22 +116,22 @@ var (
 			name: "update HBNFS values for Controller",
 			yamlString: `
 			- name: X_CSI_NFS_EXPORT_DIRECTORY
-              value: "<X_CSI_NFS_EXPORT_DIRECTORY>"
-            - name: X_CSI_NFS_CLIENT_PORT
-              value: "<X_CSI_NFS_CLIENT_PORT>"
-            - name: X_CSI_NFS_SERVER_PORT
-              value: "<X_CSI_NFS_SERVER_PORT>"`,
+			  value: "<X_CSI_NFS_EXPORT_DIRECTORY>"
+			- name: X_CSI_NFS_CLIENT_PORT
+			  value: "<X_CSI_NFS_CLIENT_PORT>"
+			- name: X_CSI_NFS_SERVER_PORT
+			  value: "<X_CSI_NFS_SERVER_PORT>"`,
 			csm:      csmForPowerStoreWithHBNFS("csm"),
 			ct:       powerStoreClient,
 			sec:      powerStoreSecret,
 			fileType: "Controller",
 			expected: `
-		    - name: X_CSI_NFS_EXPORT_DIRECTORY
-              value: "/var/lib/dell/myNfsExport"
+			- name: X_CSI_NFS_EXPORT_DIRECTORY
+			  value: "/var/lib/dell/myNfsExport"
 			- name: X_CSI_NFS_CLIENT_PORT
-		      value: "2220"
-		    - name: X_CSI_NFS_SERVER_PORT
-		      value: "2221"`,
+			  value: "2220"
+			- name: X_CSI_NFS_SERVER_PORT
+			  value: "2221"`,
 		},
 		{
 			name: "minimal minifest - update HBNFS values for Node",

--- a/pkg/drivers/powerstore_test.go
+++ b/pkg/drivers/powerstore_test.go
@@ -95,22 +95,22 @@ var (
 			name: "update HBNFS values for Node",
 			yamlString: `
 			- name: X_CSI_NFS_EXPORT_DIRECTORY
-              value: "<X_CSI_NFS_EXPORT_DIRECTORY>"
-            - name: X_CSI_NFS_CLIENT_PORT
-              value: "<X_CSI_NFS_CLIENT_PORT>"
-            - name: X_CSI_NFS_SERVER_PORT
-              value: "<X_CSI_NFS_SERVER_PORT>"`,
+		      value: "<X_CSI_NFS_EXPORT_DIRECTORY>"
+		    - name: X_CSI_NFS_CLIENT_PORT
+		      value: "<X_CSI_NFS_CLIENT_PORT>"
+		    - name: X_CSI_NFS_SERVER_PORT
+		      value: "<X_CSI_NFS_SERVER_PORT>"`,
 			csm:      csmForPowerStoreWithHBNFS("csm"),
 			ct:       powerStoreClient,
 			sec:      powerStoreSecret,
 			fileType: "Node",
 			expected: `
 			- name: X_CSI_NFS_EXPORT_DIRECTORY
-              value: "/var/lib/dell/myNfsExport"
-            - name: X_CSI_NFS_CLIENT_PORT
-              value: "2220"
-            - name: X_CSI_NFS_SERVER_PORT
-              value: "2221"`,
+		      value: "/var/lib/dell/myNfsExport"
+		    - name: X_CSI_NFS_CLIENT_PORT
+		      value: "2220"
+		    - name: X_CSI_NFS_SERVER_PORT
+		      value: "2221"`,
 		},
 		{
 			name: "update HBNFS values for Controller",
@@ -126,12 +126,33 @@ var (
 			sec:      powerStoreSecret,
 			fileType: "Controller",
 			expected: `
-			- name: X_CSI_NFS_EXPORT_DIRECTORY
+		    - name: X_CSI_NFS_EXPORT_DIRECTORY
               value: "/var/lib/dell/myNfsExport"
+			- name: X_CSI_NFS_CLIENT_PORT
+		      value: "2220"
+		    - name: X_CSI_NFS_SERVER_PORT
+		      value: "2221"`,
+		},
+		{
+			name: "minimal minifest - update HBNFS values for Node",
+			yamlString: `
+			- name: X_CSI_NFS_EXPORT_DIRECTORY
+              value: "<X_CSI_NFS_EXPORT_DIRECTORY>"
             - name: X_CSI_NFS_CLIENT_PORT
-              value: "2220"
+              value: "<X_CSI_NFS_CLIENT_PORT>"
             - name: X_CSI_NFS_SERVER_PORT
-              value: "2221"`,
+              value: "<X_CSI_NFS_SERVER_PORT>"`,
+			csm:      csmForPowerStore("csm"),
+			ct:       powerStoreClient,
+			sec:      powerStoreSecret,
+			fileType: "Node",
+			expected: `
+			- name: X_CSI_NFS_EXPORT_DIRECTORY
+              value: "/var/lib/dell/nfs"
+            - name: X_CSI_NFS_CLIENT_PORT
+              value: "2050"
+            - name: X_CSI_NFS_SERVER_PORT
+              value: "2049"`,
 		},
 	}
 )

--- a/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/scenarios.yaml
@@ -25,6 +25,35 @@
       run:
         - cert-csi test vio --sc op-e2e-pstore --chainNumber 2 --chainLength 2
 
+- scenario: "Install PowerStore Driver with HBNFS (Minimal, Standalone)"
+  paths:
+    - "testfiles/minimal-testfiles/storage_csm_powerstore.yaml"
+  tags:
+    - "hbnfs"
+  steps:
+    - "Given an environment with k8s or openshift, and CSM operator installed"
+    - "Run [Is NFS Server Running]"
+    - "Create storageclass with name [op-e2e-pstore-hbnfs] and template [testfiles/powerstore-templates/storage-class-hbnfs.yaml] for [pstore]"
+    - "Set up secret with template [testfiles/powerstore-templates/powerstore-secret-template.yaml] name [powerstore-config] in namespace [powerstore] for [pstore]"
+    - "Apply custom resource [1]"
+    - "Validate custom resource [1]"
+    - "Validate [powerstore] driver from CR [1] is installed"
+    - "Validate [powerstore] driver spec from CR [1]"
+    - "Run [Cert CSI]"
+    # cleanup
+    - "Enable forceRemoveDriver on CR [1]"
+    - "Delete custom resource [1]"
+    - "Validate [powerstore] driver from CR [1] is not installed"
+    - "Restore template [testfiles/powerstore-templates/powerstore-secret-template.yaml] for [pstore]"
+    - "Restore template [testfiles/powerstore-templates/storage-class-hbnfs.yaml] for [pstore]"
+  customTest:
+    - name: Is NFS Server Running
+      run:
+        - /bin/bash scripts/verify_nfs.sh
+    - name: Cert CSI
+      run:
+        - cert-csi test vio --sc op-e2e-pstore-hbnfs --chainNumber 2 --chainLength 2
+
 - scenario: "Install PowerStore Driver (Minimal, With Resiliency)"
   paths:
     - "testfiles/minimal-testfiles/storage_csm_powerstore_resiliency.yaml"

--- a/tests/e2e/testfiles/minimal-testfiles/storage_csm_powerstore.yaml
+++ b/tests/e2e/testfiles/minimal-testfiles/storage_csm_powerstore.yaml
@@ -7,6 +7,9 @@ spec:
   driver:
     csiDriverType: "powerstore"
     configVersion: v2.14.0
+    common:
+      image: "quay.io/dell/container-storage-modules/csi-powerstore:nightly"
+      imagePullPolicy: Always
   modules:
     - name: resiliency
       enabled: false


### PR DESCRIPTION
# Description
Add/Verify HBNFS support for PowerStore with minimal manifest
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Manually deployed PowerStore and ensured that the HBNFS functionality works as expected (w/ minimal).
- [x] Add unit tests that allow configuration of the HBNFS parameters.
- [x] Add e2e test that uses an HBNFS enabled storage class and ensured that volumes were provisioned correctly (w/ minimal).
<details>

```
$ bash run-e2e-test.sh --minimal --hbnfs
/home/falfaroc/git/public/dell/csm-operator/tests/e2e
Running Suite: CSM Operator End-to-End Tests - /home/falfaroc/git/public/dell/csm-operator/tests/e2e
====================================================================================================
Random Seed: 1744038233

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/home/falfaroc/git/public/dell/csm-operator/tests/e2e/e2e_test.go:98
  STEP: Getting test environment variables @ 04/07/25 11:03:56.053
  STEP: [hbnfs] @ 04/07/25 11:03:56.053
  STEP: Reading values file @ 04/07/25 11:03:56.053
  STEP: Getting a k8s client @ 04/07/25 11:03:56.068
[BeforeSuite] PASSED [0.016 seconds]
------------------------------
[run-e2e-test] E2E Testing Running all test Given Test Scenarios
/home/falfaroc/git/public/dell/csm-operator/tests/e2e/e2e_test.go:139
  STEP: Starting: Install PowerStore Driver (Minimal, Standalone)  @ 04/07/25 11:03:56.069
  STEP: No matching tags for scenario @ 04/07/25 11:03:56.069
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:03:56.069
  STEP: Ending: Install PowerStore Driver (Minimal, Standalone)
   @ 04/07/25 11:03:56.069
  STEP: Starting: Install PowerStore Driver with HBNFS (Minimal, Standalone)  @ 04/07/25 11:03:56.069
  STEP: Returning false here @ 04/07/25 11:03:56.069
  STEP:      Executing  Given an environment with k8s or openshift, and CSM operator installed @ 04/07/25 11:03:56.069
  STEP:      Executing  Run [Is NFS Server Running] @ 04/07/25 11:03:56.594
  I0407 11:03:56.594599 18725 util.go:650] Running /bin/bash [scripts/verify_nfs.sh]
Assuming that 'node_credential' contains the nodes and their credentials. For more information, see tests/README.md.
Checking service status: nfs-mountd.service
Checking service status: nfs-server.service
NFS Server is running on all nodes.
  STEP:      Executing  Create storageclass with name [op-e2e-pstore-hbnfs] and template [testfiles/powerstore-templates/storage-class-hbnfs.yaml] for [pstore] @ 04/07/25 11:04:04.915
  STEP:      Executing  Set up secret with template [testfiles/powerstore-templates/powerstore-secret-template.yaml] name [powerstore-config] in namespace [powerstore] for [pstore] @ 04/07/25 11:04:06.811
  STEP:      Executing  Apply custom resource [1] @ 04/07/25 11:04:08.636
  I0407 11:04:08.636784 18725 builder.go:121] Running '/usr/local/bin/kubectl --namespace=powerstore apply --validate=true -f -'
  I0407 11:04:09.701869 18725 builder.go:146] stderr: ""
  I0407 11:04:09.701958 18725 builder.go:147] stdout: "containerstoragemodule.storage.dell.com/powerstore created\n"
  STEP:      Executing  Validate custom resource [1] @ 04/07/25 11:04:09.702
  STEP:      Executing  Validate [powerstore] driver from CR [1] is installed @ 04/07/25 11:04:30.24
  STEP:      Executing  Validate [powerstore] driver spec from CR [1] @ 04/07/25 11:04:50.631
  STEP:      Executing  Run [Cert CSI] @ 04/07/25 11:04:50.758
  I0407 11:04:50.758778 18725 util.go:650] Running cert-csi [test vio --sc op-e2e-pstore-hbnfs --chainNumber 2 --chainLength 2]
[2025-04-07 11:04:50]  INFO Starting cert-csi; ver. 1.6.0
[2025-04-07 11:04:50]  INFO Using EVENT observer type
[2025-04-07 11:04:50]  INFO Using config from /home/falfaroc/.kube/config
[2025-04-07 11:04:50]  INFO Successfully loaded config. Host: https://10.227.248.175:6443
[2025-04-07 11:04:51]  INFO Created new KubeClient
[2025-04-07 11:04:51]  INFO Running 1 iteration(s)
[2025-04-07 11:04:51]  INFO     *** ITERATION NUMBER 1 ***
[2025-04-07 11:04:51]  INFO Starting VolumeIoSuite with op-e2e-pstore-hbnfs storage class
[2025-04-07 11:04:51]  INFO Successfully created namespace volumeio-test-6bb7e6e4
[2025-04-07 11:04:51]  INFO Using default number of volumes
[2025-04-07 11:04:51]  INFO Using default image: quay.io/centos/centos:latest
[2025-04-07 11:04:51]  INFO Creating IO pod
[2025-04-07 11:04:52]  INFO Waiting for pod iowriter-test-hdptx to be READY
[2025-04-07 11:04:52]  INFO Waiting for pod iowriter-test-sqzmt to be READY
[2025-04-07 11:05:32]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-04-07 11:05:32]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2025-04-07 11:05:34]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-04-07 11:05:34]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2025-04-07 11:05:38]  INFO Waiting until no Volume Attachments with PV  left
[2025-04-07 11:05:38]  INFO VolumeAttachment deleted
[2025-04-07 11:05:38]  INFO Waiting for pod iowriter-test-7bbk6 to be READY
[2025-04-07 11:05:38]  INFO Waiting until no Volume Attachments with PV  left
[2025-04-07 11:05:38]  INFO VolumeAttachment deleted
[2025-04-07 11:05:38]  INFO Waiting for pod iowriter-test-b4hhs to be READY
[2025-04-07 11:05:44]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-0.sha512]
[2025-04-07 11:05:45]  INFO Executing command: [/bin/bash -c sha512sum -c /data0/writer-1.sha512]
[2025-04-07 11:05:46]  INFO Hashes match
[2025-04-07 11:05:46]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-0.data]
[2025-04-07 11:05:46]  INFO Hashes match
[2025-04-07 11:05:46]  INFO Executing command: [/bin/bash -c dd if=/dev/urandom bs=1M count=128 oflag=sync > /data0/writer-1.data]
[2025-04-07 11:05:48]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-0.data > /data0/writer-0.sha512]
[2025-04-07 11:05:49]  INFO Executing command: [/bin/bash -c sha512sum /data0/writer-1.data > /data0/writer-1.sha512]
[2025-04-07 11:05:51]  INFO Waiting until no Volume Attachments with PV  left
[2025-04-07 11:05:52]  INFO VolumeAttachment deleted
[2025-04-07 11:05:53]  INFO Waiting until no Volume Attachments with PV  left
[2025-04-07 11:05:53]  INFO VolumeAttachment deleted
[2025-04-07 11:05:53]  INFO Deleting all resources in namespace volumeio-test-6bb7e6e4
[2025-04-07 11:06:50]  INFO Namespace volumeio-test-6bb7e6e4 was deleted in 57.586051942s
Collecting metrics
[2025-04-07 11:06:51]  INFO SUCCESS: VolumeIoSuite in 2m0.518503535s
[2025-04-07 11:06:51]  INFO Started generating reports...
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-04-07 11:06:51]  INFO Started generating reports...
Collecting metrics
Generating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-04-07 11:06:51]  WARN No ResourceUsageMetrics provided
[2025-04-07 11:06:51] ERROR no ResourceUsageMetrics provided
report-test-run-6843fdc7:
Name: test-run-6843fdc7
Host: https://10.227.248.175:6443
StorageClass: op-e2e-pstore-hbnfs
Minimum and Maximum EntityOverTime charts:

/home/falfaroc/.cert-csi/reports/test-run-6843fdc7/PodsCreatingOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-6843fdc7/PodsReadyOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-6843fdc7/PodsTerminatingOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-6843fdc7/PvcsCreatingOverTime.png

/home/falfaroc/.cert-csi/reports/test-run-6843fdc7/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-04-07 11:04:51.368499014 -0400 -0400
            Ended:     2025-04-07 11:06:51.881840036 -0400 -0400
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 35.549554205s
                        Min: 35.456201171s
                        Max: 35.64290724s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCAttachment.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 704.330258ms
                        Min: 702.09933ms
                        Max: 706.561187ms
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCBind.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 36.826004477s
                        Min: 36.749986377s
                        Max: 36.902022577s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCCreation.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 58.566499ms
                        Min: 5.496928ms
                        Max: 111.636071ms
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCDeletion.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 23.298860775s
                        Min: 22.999390241s
                        Max: 23.598331309s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCUnattachment.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 22.184489651s
                        Min: 4.458532991s
                        Max: 40.09023927s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PodCreation.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.062413364s
                        Min: 922.979855ms
                        Max: 1.339397206s
                        Histogram:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PodDeletion.png
                        BoxPlot:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /home/falfaroc/.cert-csi/reports/test-run-6843fdc7/VolumeIoSuite13/EntityNumberOverTime.png

[2025-04-07 11:06:52]  INFO Avg time of a run:   61.67s
[2025-04-07 11:06:52]  INFO Avg time of a del:   57.59s
[2025-04-07 11:06:52]  INFO Avg time of all:     120.52s
[2025-04-07 11:06:52]  INFO During this run 100.0% of suites succeeded
  STEP:      Executing  Enable forceRemoveDriver on CR [1] @ 04/07/25 11:06:52.058
  STEP:      Executing  Delete custom resource [1] @ 04/07/25 11:06:52.537
  STEP:      Executing  Validate [powerstore] driver from CR [1] is not installed @ 04/07/25 11:06:52.771
  STEP:      Executing  Restore template [testfiles/powerstore-templates/powerstore-secret-template.yaml] for [pstore] @ 04/07/25 11:07:12.9
  STEP:      Executing  Restore template [testfiles/powerstore-templates/storage-class-hbnfs.yaml] for [pstore] @ 04/07/25 11:07:12.905
  STEP: Ending: Install PowerStore Driver with HBNFS (Minimal, Standalone)
   @ 04/07/25 11:07:12.909
  STEP: Starting: Install PowerStore Driver (Minimal, With Resiliency)  @ 04/07/25 11:07:17.913
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.913
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.913
  STEP: Ending: Install PowerStore Driver (Minimal, With Resiliency)
   @ 04/07/25 11:07:17.913
  STEP: Starting: Install PowerStore Driver (Minimal, Standalone), Enable Resiliency  @ 04/07/25 11:07:17.913
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.913
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.913
  STEP: Ending: Install PowerStore Driver (Minimal, Standalone), Enable Resiliency
   @ 04/07/25 11:07:17.913
  STEP: Starting: Install PowerStore Driver (Minimal, With no forceRemoveDriver)  @ 04/07/25 11:07:17.913
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.913
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.913
  STEP: Ending: Install PowerStore Driver (Minimal, With no forceRemoveDriver)
   @ 04/07/25 11:07:17.913
  STEP: Starting: Install PowerStore Driver (Minimal, With false forceRemoveDriver)  @ 04/07/25 11:07:17.913
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.913
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.913
  STEP: Ending: Install PowerStore Driver (Minimal, With false forceRemoveDriver)
   @ 04/07/25 11:07:17.913
  STEP: Starting: Install Unity Driver (Minimal, Standalone)  @ 04/07/25 11:07:17.913
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.913
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.913
  STEP: Ending: Install Unity Driver (Minimal, Standalone)
   @ 04/07/25 11:07:17.913
  STEP: Starting: Install Unity Driver (Minimal, With false forceRemoveDriver)  @ 04/07/25 11:07:17.913
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install Unity Driver (Minimal, With false forceRemoveDriver)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install Unity Driver (Minimal, With no forceRemoveDriver)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install Unity Driver (Minimal, With no forceRemoveDriver)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerFlex Driver (Minimal, Standalone)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerFlex Driver (Minimal, Standalone)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerFlex Driver (Minimal, With no forceRemoveDriver)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerFlex Driver (Minimal, With no forceRemoveDriver)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerFlex Driver (Minimal, With false forceRemoveDriver)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerFlex Driver (Minimal, With false forceRemoveDriver)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerFlex Driver (Minimal, With Resiliency)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerFlex Driver (Minimal, With Resiliency)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerFlex Driver (Minimal, Standalone), Enable/Disable Resiliency  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerFlex Driver (Minimal, Standalone), Enable/Disable Resiliency
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerFlex Driver (Minimal, With Authorization V2)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerFlex Driver (Minimal, With Authorization V2)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerFlex Driver (Minimal, With Authorization V1)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerFlex Driver (Minimal, With Authorization V1)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerFlex Driver (Minimal, With Observability)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerFlex Driver (Minimal, With Observability)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerFlex Driver (Minimal, With Observability and Custom Cert for Otel-Collector)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerFlex Driver (Minimal, With Observability and Custom Cert for Otel-Collector)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerScale Driver (Minimal, Standalone)  @ 04/07/25 11:07:17.914
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.914
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.914
  STEP: Ending: Install PowerScale Driver (Minimal, Standalone)
   @ 04/07/25 11:07:17.914
  STEP: Starting: Install PowerScale Driver (Minimal, With no forceRemoveDriver)  @ 04/07/25 11:07:17.915
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.915
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.915
  STEP: Ending: Install PowerScale Driver (Minimal, With no forceRemoveDriver)
   @ 04/07/25 11:07:17.915
  STEP: Starting: Install PowerScale Driver (Minimal, With false forceRemoveDriver)  @ 04/07/25 11:07:17.915
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.915
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.915
  STEP: Ending: Install PowerScale Driver (Minimal, With false forceRemoveDriver)
   @ 04/07/25 11:07:17.915
  STEP: Starting: Install PowerScale Driver (Minimal, Standalone), Enable/Disable Resiliency  @ 04/07/25 11:07:17.915
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.915
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.915
  STEP: Ending: Install PowerScale Driver (Minimal, Standalone), Enable/Disable Resiliency
   @ 04/07/25 11:07:17.915
  STEP: Starting: Install PowerScale Driver (Minimal, With Resiliency)  @ 04/07/25 11:07:17.915
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.915
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.915
  STEP: Ending: Install PowerScale Driver (Minimal, With Resiliency)
   @ 04/07/25 11:07:17.915
  STEP: Starting: Install PowerScale Driver (Minimal, With Replication)  @ 04/07/25 11:07:17.915
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.915
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.915
  STEP: Ending: Install PowerScale Driver (Minimal, With Replication)
   @ 04/07/25 11:07:17.915
  STEP: Starting: Install PowerScale Driver (Minimal, Standalone), Enable/Disable Replication  @ 04/07/25 11:07:17.915
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.915
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.915
  STEP: Ending: Install PowerScale Driver (Minimal, Standalone), Enable/Disable Replication
   @ 04/07/25 11:07:17.915
  STEP: Starting: Uninstall PowerScale Driver (Minimal)  @ 04/07/25 11:07:17.915
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.915
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.915
  STEP: Ending: Uninstall PowerScale Driver (Minimal)
   @ 04/07/25 11:07:17.915
  STEP: Starting: Install PowerScale Driver (Minimal, Standalone), Enable/Disable Observability  @ 04/07/25 11:07:17.915
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.915
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.915
  STEP: Ending: Install PowerScale Driver (Minimal, Standalone), Enable/Disable Observability
   @ 04/07/25 11:07:17.915
  STEP: Starting: Install PowerScale Driver (Minimal, With Observability and Custom Certs)  @ 04/07/25 11:07:17.915
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.915
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.915
  STEP: Ending: Install PowerScale Driver (Minimal, With Observability and Custom Certs)
   @ 04/07/25 11:07:17.915
  STEP: Starting: Install PowerScale Driver (Minimal, With Authorization V1)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerScale Driver (Minimal, With Authorization V1)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install PowerScale Driver (Minimal), Enable/Disable Authorization V1 module  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerScale Driver (Minimal), Enable/Disable Authorization V1 module
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install PowerScale Driver (Minimal, With Authorization V2)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerScale Driver (Minimal, With Authorization V2)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install Powerflex Driver (Minimal, With Replication)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install Powerflex Driver (Minimal, With Replication)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install PowerMax Driver (Minimal, Standalone)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerMax Driver (Minimal, Standalone)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install PowerMax Driver with Mount Credentials (Minimal)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerMax Driver with Mount Credentials (Minimal)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install PowerMax Driver with Mount Credentials (Minimal), Enable Observability  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerMax Driver with Mount Credentials (Minimal), Enable Observability
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install PowerMax Driver (Minimal, With no forceRemoveDriver)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerMax Driver (Minimal, With no forceRemoveDriver)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install PowerMax Driver (Minimal, With false forceRemoveDriver)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerMax Driver (Minimal, With false forceRemoveDriver)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install PowerMax Driver (Minimal, With Observability)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerMax Driver (Minimal, With Observability)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install PowerMax Driver (Minimal, With Auth V1 module)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install PowerMax Driver (Minimal, With Auth V1 module)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install Powermax Driver (Minimal, With Authorization v2)  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install Powermax Driver (Minimal, With Authorization v2)
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install Powermax Driver (Minimal, Standalone), Enable Resiliency  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.916
  STEP: Ending: Install Powermax Driver (Minimal, Standalone), Enable Resiliency
   @ 04/07/25 11:07:17.916
  STEP: Starting: Install Powermax Driver (Minimal, With Resiliency), Disable Resiliency module  @ 04/07/25 11:07:17.916
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.916
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.917
  STEP: Ending: Install Powermax Driver (Minimal, With Resiliency), Disable Resiliency module
   @ 04/07/25 11:07:17.917
  STEP: Starting: Install Powermax Driver (Minimal, With Replication)  @ 04/07/25 11:07:17.917
  STEP: No matching tags for scenario @ 04/07/25 11:07:17.917
  STEP: Not tagged for this test run, skipping @ 04/07/25 11:07:17.917
  STEP: Ending: Install Powermax Driver (Minimal, With Replication)
   @ 04/07/25 11:07:17.917
• [201.857 seconds]
------------------------------

Ran 1 of 1 Specs in 201.873 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 3m24.196269597s
Test Suite Passed
```

</details>
