### PR TITLE
Resiliency RBAC changes

### DIFF
--- a/controllers/csm_controller.go
+++ b/controllers/csm_controller.go
@@ -835,12 +835,21 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 				}
 				controller.Deployment = *dp
 
+				// Injecting clusterroles
 				clusterRole, err := modules.ResiliencyInjectClusterRole(controller.Rbac.ClusterRole, cr, operatorConfig, "controller")
 				if err != nil {
 					return fmt.Errorf("injecting resiliency into controller cluster role: %v", err)
 				}
 
 				controller.Rbac.ClusterRole = *clusterRole
+
+				// Injecting roles
+				role, err := modules.ResiliencyInjectRole(controller.Rbac.Role, cr, operatorConfig, "controller")
+				if err != nil {
+					return fmt.Errorf("injecting resiliency into controller role: %v", err)
+				}
+
+				controller.Rbac.Role = *role
 
 				// for node-pod
 				ds, err := modules.ResiliencyInjectDaemonset(node.DaemonSetApplyConfig, cr, operatorConfig, driverName)
@@ -849,12 +858,22 @@ func (r *ContainerStorageModuleReconciler) SyncCSM(ctx context.Context, cr csmv1
 				}
 				node.DaemonSetApplyConfig = *ds
 
+				// Injecting clusterroles
 				clusterRoleForNode, err := modules.ResiliencyInjectClusterRole(node.Rbac.ClusterRole, cr, operatorConfig, "node")
 				if err != nil {
 					return fmt.Errorf("injecting resiliency into node cluster role: %v", err)
 				}
 
 				node.Rbac.ClusterRole = *clusterRoleForNode
+
+				// Injecting roles
+				roleForNode, err := modules.ResiliencyInjectRole(node.Rbac.Role, cr, operatorConfig, "node")
+				if err != nil {
+					return fmt.Errorf("injecting resiliency into controller role: %v", err)
+				}
+
+				node.Rbac.Role = *roleForNode
+
 			case csmv1.Replication:
 				// This function adds replication sidecar to driver pods.
 				log.Info("Injecting CSM Replication")

--- a/controllers/csm_controller_test.go
+++ b/controllers/csm_controller_test.go
@@ -856,6 +856,10 @@ func (suite *CSMControllerTestSuite) TestSyncCSM() {
 	powerflexCSM.Spec.Driver.CSIDriverType = csmv1.PowerFlex
 	suite.makeFakeCSM(csmName, suite.namespace, false, []csmv1.Module{})
 
+	resiliencyCSM := shared.MakeCSM(csmName, suite.namespace, configVersion)
+	resiliencyCSM.Spec.Modules = getResiliencyModule()
+	resiliencyCSM.Spec.Driver.CSIDriverType = csmv1.PowerFlex
+
 	syncCSMTests := []struct {
 		name        string
 		csm         csmv1.ContainerStorageModule
@@ -870,6 +874,7 @@ func (suite *CSMControllerTestSuite) TestSyncCSM() {
 		{"getDriverConfig error", csmBadType, badOperatorConfig, "no such file or directory"},
 		{"success: deployAsSidecar with secret", reverseProxyWithSecret, operatorConfig, ""},
 		{"powerflex on openshift - delete mount", powerflexCSM, operatorConfig, ""},
+		{"resiliency module happy path", resiliencyCSM, operatorConfig, ""},
 	}
 
 	for _, tt := range syncCSMTests {
@@ -1750,7 +1755,7 @@ func getResiliencyModule() []csmv1.Module {
 		{
 			Name:          csmv1.Resiliency,
 			Enabled:       true,
-			ConfigVersion: "v1.11.0",
+			ConfigVersion: "v1.13.0",
 			Components: []csmv1.ContainerTemplate{
 				{
 					Name: utils.ResiliencySideCarName,

--- a/operatorconfig/moduleconfig/resiliency/v1.13.0/controller-clusterroles.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.13.0/controller-clusterroles.yaml
@@ -13,6 +13,12 @@
 # limitations under the License.
 #
 #
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "delete"]

--- a/operatorconfig/moduleconfig/resiliency/v1.13.0/node-clusterroles.yaml
+++ b/operatorconfig/moduleconfig/resiliency/v1.13.0/node-clusterroles.yaml
@@ -14,11 +14,5 @@
 #
 #
 - apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get", "list", "watch", "patch"]
-- apiGroups: ["storage.k8s.io"]
-  resources: ["volumeattachments"]
-  verbs: ["get", "list", "watch", "update", "patch", "delete"]
-- apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "list", "watch", "update", "delete"]
+  verbs: ["get", "list", "watch"]

--- a/pkg/modules/resiliency.go
+++ b/pkg/modules/resiliency.go
@@ -118,7 +118,6 @@ func ResiliencyInjectClusterRole(clusterRole rbacv1.ClusterRole, cr csmv1.Contai
 
 // ResiliencyInjectRole - inject resiliency into role
 func ResiliencyInjectRole(role rbacv1.Role, cr csmv1.ContainerStorageModule, op utils.OperatorConfig, mode string) (*rbacv1.Role, error) {
-
 	// There are no roles for controller in Resliency
 	if mode == "controller" {
 		return &role, nil


### PR DESCRIPTION
# Description
RBAC changes for Resiliency module.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1751 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] PowerFlex with Resiliency Integration tests

Interface down scenario:
![image](https://github.com/user-attachments/assets/0c01d3ab-c9ca-45c1-a127-4011056d9ac6)

Node reboot scenario:
![image](https://github.com/user-attachments/assets/55aa4394-6a81-4847-bd51-a24ed1df3803)

Driver pods down scenario:
![image](https://github.com/user-attachments/assets/bdf43e87-6842-40e2-8146-5d00dd94e193)

Kubelet down scenario:
![image](https://github.com/user-attachments/assets/fa058347-0874-44a1-baed-2e7f35bdcf41)



- [x] PowerStore with Resiliency Integration tests

Interface down scenario:
![image](https://github.com/user-attachments/assets/8fcffceb-4cc9-460f-8886-5be4830b58bf)

Node reboot scenario:
![image](https://github.com/user-attachments/assets/a8191b8d-8b2c-4ec2-8ed2-821c792de93e)

Driver pods down scenario:
![image](https://github.com/user-attachments/assets/6d62e9ef-3ee6-4945-9a0f-af11986a7e8f)

Kubelet down scenario:
![image](https://github.com/user-attachments/assets/6bad991e-6fdb-4072-9916-faebcc3c2e3f)
