### PR TITLE
Passing namespace name as environment variable

### DIFF
--- a/operatorconfig/driverconfig/powerstore/v2.14.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.14.0/controller.yaml
@@ -260,6 +260,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: X_CSI_DRIVER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: GOPOWERSTORE_DEBUG
               value: <GOPOWERSTORE_DEBUG>
             - name: CSI_AUTO_ROUND_OFF_FILESYSTEM_SIZE

--- a/operatorconfig/driverconfig/powerstore/v2.14.0/node.yaml
+++ b/operatorconfig/driverconfig/powerstore/v2.14.0/node.yaml
@@ -119,6 +119,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: X_CSI_DRIVER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
               value: <X_CSI_POWERSTORE_NODE_NAME_PREFIX>
             - name: X_CSI_POWERSTORE_NODE_ID_PATH


### PR DESCRIPTION
# Description
PR to pass the Namespace name as environment variable for Powerstore required for HBNFS.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1742|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Deployed the driver in a non "Powerstore" namespace. Driver installation was successful and was also able to provision the volume successfully.
- [x] With these operator changes the namespace name is being passed through the environment variable and otherwise being read from the service account. 
