### PR TITLE
pvc on target param

### DIFF
--- a/config/samples/storage_v1_csm_powerflex.yaml
+++ b/config/samples/storage_v1_csm_powerflex.yaml
@@ -406,6 +406,13 @@ spec:
             # Default value: false
             - name: "DISABLE_PVC_REMAP"
               value: "false"
+            # REPLICATION_ALLOW_PVC_CREATION_ON_TARGET: It Creates PVC on target cluster using replicated PV.
+            # Allowed values:
+            #   true: It creates a PVC on target cluster against replicated PV
+            #   false: simply updates claimref on replicated PV on target cluster without actually creating a PVC
+            # Default value: false
+            - name: "REPLICATION_ALLOW_PVC_CREATION_ON_TARGET"
+              value: "false"
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature
       # Allowed values:

--- a/config/samples/storage_v1_csm_powermax.yaml
+++ b/config/samples/storage_v1_csm_powermax.yaml
@@ -376,6 +376,13 @@ spec:
             # Default value: false
             - name: "DISABLE_PVC_REMAP"
               value: "false"
+            # REPLICATION_ALLOW_PVC_CREATION_ON_TARGET: It Creates PVC on target cluster using replicated PV.
+            # Allowed values:
+            #   true: It creates a PVC on target cluster against replicated PV
+            #   false: simply updates claimref on replicated PV on target cluster without actually creating a PVC
+            # Default value: false
+            - name: "REPLICATION_ALLOW_PVC_CREATION_ON_TARGET"
+              value: "false"
     # observability: allows to configure observability
     - name: observability
       # enabled: Enable/Disable observability

--- a/config/samples/storage_v1_csm_powerscale.yaml
+++ b/config/samples/storage_v1_csm_powerscale.yaml
@@ -344,6 +344,13 @@ spec:
             # Default value: false
             - name: "DISABLE_PVC_REMAP"
               value: "false"
+            # REPLICATION_ALLOW_PVC_CREATION_ON_TARGET: It Creates PVC on target cluster using replicated PV.
+            # Allowed values:
+            #   true: It creates a PVC on target cluster against replicated PV
+            #   false: simply updates claimref on replicated PV on target cluster without actually creating a PVC
+            # Default value: false
+            - name: "REPLICATION_ALLOW_PVC_CREATION_ON_TARGET"
+              value: "false"
     # observability: allows to configure observability
     - name: observability
       # enabled: Enable/Disable observability

--- a/operatorconfig/moduleconfig/replication/v1.12.0/controller.yaml
+++ b/operatorconfig/moduleconfig/replication/v1.12.0/controller.yaml
@@ -250,6 +250,7 @@ spec:
       containers:
         - args:
             - --disable-pvc-remap=<DISABLE_PVC_REMAP>
+            - --allow-pvc-creation-on-target=<REPLICATION_ALLOW_PVC_CREATION_ON_TARGET>
             - --enable-leader-election
             - --prefix=replication.storage.dell.com
           command:

--- a/pkg/modules/replication.go
+++ b/pkg/modules/replication.go
@@ -62,6 +62,8 @@ const (
 	ReplicationCSMNameSpace = "<CSM_NAMESPACE>"
 	// DefaultPVCRemapState - default state of Disable PVC remap argument
 	DefaultDisablePVCRemapState = "<DISABLE_PVC_REMAP>"
+	// AllowPvcCreationOnTarget -
+	AllowPvcCreationOnTarget = "<REPLICATION_ALLOW_PVC_CREATION_ON_TARGET>"
 )
 
 var (
@@ -364,6 +366,7 @@ func getReplicaController(op utils.OperatorConfig, cr csmv1.ContainerStorageModu
 	replicaImage := ""
 	replicaInitImage := ""
 	disablePVCRemapState := "false"
+	allowPVCCreationOnTarget := "false"
 
 	for _, component := range replica.Components {
 		if component.Name == utils.ReplicationControllerManager {
@@ -381,6 +384,8 @@ func getReplicaController(op utils.OperatorConfig, cr csmv1.ContainerStorageModu
 					retryMax = env.Value
 				} else if strings.Contains(DefaultDisablePVCRemapState, env.Name) && env.Value != "" {
 					disablePVCRemapState = env.Value
+				} else if strings.Contains(AllowPvcCreationOnTarget, env.Name) && env.Value != "" {
+					allowPVCCreationOnTarget = env.Value
 				}
 			}
 		} else if component.Name == utils.ReplicationControllerInit {
@@ -397,6 +402,7 @@ func getReplicaController(op utils.OperatorConfig, cr csmv1.ContainerStorageModu
 	YamlString = strings.ReplaceAll(YamlString, DefaultRetryMin, retryMin)
 	YamlString = strings.ReplaceAll(YamlString, ReplicationCSMNameSpace, cr.Namespace)
 	YamlString = strings.ReplaceAll(YamlString, DefaultDisablePVCRemapState, disablePVCRemapState)
+	YamlString = strings.ReplaceAll(YamlString, AllowPvcCreationOnTarget, allowPVCCreationOnTarget)
 
 	ctrlObjects, err := utils.GetModuleComponentObj([]byte(YamlString))
 	if err != nil {

--- a/pkg/modules/testdata/cr_powerflex_replica.yaml
+++ b/pkg/modules/testdata/cr_powerflex_replica.yaml
@@ -43,3 +43,5 @@ spec:
               value: "5m"
             - name: "DISABLE_PVC_REMAP"
               value: "false"
+            - name: "REPLICATION_ALLOW_PVC_CREATION_ON_TARGET"
+              value: "false"

--- a/pkg/modules/testdata/cr_powermax_replica.yaml
+++ b/pkg/modules/testdata/cr_powermax_replica.yaml
@@ -52,3 +52,5 @@ spec:
               value: "5m"
             - name: "DISABLE_PVC_REMAP"
               value: "false"
+            - name: "REPLICATION_ALLOW_PVC_CREATION_ON_TARGET"
+              value: "false"

--- a/pkg/modules/testdata/cr_powerscale_replica.yaml
+++ b/pkg/modules/testdata/cr_powerscale_replica.yaml
@@ -40,3 +40,5 @@ spec:
               value: "5m"
             - name: "DISABLE_PVC_REMAP"
               value: "false"
+            - name: "REPLICATION_ALLOW_PVC_CREATION_ON_TARGET"
+              value: "false"

--- a/samples/storage_csm_powerflex_v2140.yaml
+++ b/samples/storage_csm_powerflex_v2140.yaml
@@ -406,6 +406,13 @@ spec:
             # Default value: false
             - name: "DISABLE_PVC_REMAP"
               value: "false"
+            # REPLICATION_ALLOW_PVC_CREATION_ON_TARGET: It Creates PVC on target cluster using replicated PV.
+            # Allowed values:
+            #   true: It creates a PVC on target cluster against replicated PV
+            #   false: simply updates claimref on replicated PV on target cluster without actually creating a PVC
+            # Default value: false
+            - name: "REPLICATION_ALLOW_PVC_CREATION_ON_TARGET"
+              value: "false"
     - name: resiliency
       # enabled: Enable/Disable Resiliency feature
       # Allowed values:

--- a/samples/storage_csm_powermax_v2140.yaml
+++ b/samples/storage_csm_powermax_v2140.yaml
@@ -376,6 +376,13 @@ spec:
             # Default value: false
             - name: "DISABLE_PVC_REMAP"
               value: "false"
+            # REPLICATION_ALLOW_PVC_CREATION_ON_TARGET: It Creates PVC on target cluster using replicated PV.
+            # Allowed values:
+            #   true: It creates a PVC on target cluster against replicated PV
+            #   false: simply updates claimref on replicated PV on target cluster without actually creating a PVC
+            # Default value: false
+            - name: "REPLICATION_ALLOW_PVC_CREATION_ON_TARGET"
+              value: "false"
     # observability: allows to configure observability
     - name: observability
       # enabled: Enable/Disable observability

--- a/samples/storage_csm_powerscale_v2140.yaml
+++ b/samples/storage_csm_powerscale_v2140.yaml
@@ -344,6 +344,13 @@ spec:
             # Default value: false
             - name: "DISABLE_PVC_REMAP"
               value: "false"
+            # REPLICATION_ALLOW_PVC_CREATION_ON_TARGET: It Creates PVC on target cluster using replicated PV.
+            # Allowed values:
+            #   true: It creates a PVC on target cluster against replicated PV
+            #   false: simply updates claimref on replicated PV on target cluster without actually creating a PVC
+            # Default value: false
+            - name: "REPLICATION_ALLOW_PVC_CREATION_ON_TARGET"
+              value: "false"
     # observability: allows to configure observability
     - name: observability
       # enabled: Enable/Disable observability


### PR DESCRIPTION
# Description

- Parameterize PVC creation on Target cluster
  [ provided an option, to decide whether PVC can be provisioned on Target cluster or not, Instead can simply populate claimref on target PV ]

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1862|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Installed replication controller with both the flags -
- [x] False case scenario
  
![image](https://github.com/user-attachments/assets/2336adbe-7b7c-45ca-abb2-b177027209eb)

- [x] True case scenario
  
![image](https://github.com/user-attachments/assets/b09eb4e7-0586-472f-a411-d314baa1f783)

