### PR TITLE
Add relatedImages needed for certification CI to pass

### DIFF
--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -4513,4 +4513,14 @@ spec:
       name: externalhealthmonitorcontroller
     - image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
       name: metadataretriever
+    - image: docker.io/nginxinc/nginx-unprivileged:1.27
+      name: nginx
+    - image: docker.io/redis:7.4.1-alpine
+      name: redis
+    - image: docker.io/rediscommander/redis-commander:latest
+      name: redis-commander
+    - image: docker.io/openpolicyagent/opa:latest
+      name: opa
+    - image: docker.io/openpolicyagent/kube-mgmt:8.5.10
+      name: kube-mgmt
   version: 1.9.0


### PR DESCRIPTION
# Description
The certification CI pipeline compares the count of referenced images with the count of related images and fails the CI checks if they do not match.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] certified-operators passed with the sha256 versions of these images.

