### PR TITLE
operator does not handle k8sClientSet.Discovery().ServerGroupsAndResources() correctly

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -72,6 +72,9 @@ func IsOpenShift(log *zap.SugaredLogger) (bool, error) {
 			log.Info(fmt.Sprintf("isOpenShift err %v", err))
 		}
 	}
+	if serverGroups == nil {
+		return false, fmt.Errorf("serverGroups is nil")
+	}
 
 	openshiftAPIGroup := "security.openshift.io"
 	for i := 0; i < len(serverGroups); i++ {

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -14,6 +14,7 @@ package k8s
 
 import (
 	"os"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
@@ -24,6 +25,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"go.uber.org/zap"
 )
 
 // GetClientSetWrapper -
@@ -58,7 +60,7 @@ func GetKubeAPIServerVersion() (*version.Info, error) {
 }
 
 // IsOpenShift - Returns a boolean which indicates if we are running in an OpenShift cluster
-func IsOpenShift() (bool, error) {
+func IsOpenShift(log *zap.SugaredLogger) (bool, error) {
 	k8sClientSet, err := GetClientSetWrapper()
 	if err != nil {
 		return false, err
@@ -66,7 +68,7 @@ func IsOpenShift() (bool, error) {
 
 	serverGroups, _, err := k8sClientSet.Discovery().ServerGroupsAndResources()
 	if err != nil {
-		return false, err
+		log.Info(fmt.Sprintf("isOpenShift err %v", err))
 	}
 
 	openshiftAPIGroup := "security.openshift.io"

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -13,19 +13,19 @@
 package k8s
 
 import (
-	"os"
 	"fmt"
+	"os"
 
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
-	"go.uber.org/zap"
 )
 
 // GetClientSetWrapper -
@@ -68,7 +68,9 @@ func IsOpenShift(log *zap.SugaredLogger) (bool, error) {
 
 	serverGroups, _, err := k8sClientSet.Discovery().ServerGroupsAndResources()
 	if err != nil {
-		log.Info(fmt.Sprintf("isOpenShift err %v", err))
+		if log != nil {
+			log.Info(fmt.Sprintf("isOpenShift err %v", err))
+		}
 	}
 
 	openshiftAPIGroup := "security.openshift.io"

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/version"
 	discoveryfake "k8s.io/client-go/discovery/fake"
-	"go.uber.org/zap"
 )
 
 type testOverrides struct {
@@ -120,7 +120,7 @@ func Test_IsOpenShift(t *testing.T) {
 			assert.NoError(t, err)
 			_ = os.Setenv("KUBECONFIG", "./fake-kubeconfig")
 
-      var log *zap.SugaredLogger
+			var log *zap.SugaredLogger
 			isOpenshift, err := IsOpenShift(log)
 			if patch.ignoreError {
 				t.Log("cover  real Openshift setup")

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/version"
 	discoveryfake "k8s.io/client-go/discovery/fake"
+	"github.com/dell/csm-operator/pkg/logger"
 )
 
 type testOverrides struct {
@@ -120,7 +120,7 @@ func Test_IsOpenShift(t *testing.T) {
 			assert.NoError(t, err)
 			_ = os.Setenv("KUBECONFIG", "./fake-kubeconfig")
 
-			var log *zap.SugaredLogger
+			_, log := logger.GetNewContextWithLogger("main")
 			isOpenshift, err := IsOpenShift(log)
 			if patch.ignoreError {
 				t.Log("cover  real Openshift setup")

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/dell/csm-operator/pkg/logger"
 	"k8s.io/apimachinery/pkg/version"
 	discoveryfake "k8s.io/client-go/discovery/fake"
-	"github.com/dell/csm-operator/pkg/logger"
 )
 
 type testOverrides struct {

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/version"
 	discoveryfake "k8s.io/client-go/discovery/fake"
+	"go.uber.org/zap"
 )
 
 type testOverrides struct {
@@ -119,7 +120,8 @@ func Test_IsOpenShift(t *testing.T) {
 			assert.NoError(t, err)
 			_ = os.Setenv("KUBECONFIG", "./fake-kubeconfig")
 
-			isOpenshift, err := IsOpenShift()
+      var log *zap.SugaredLogger
+			isOpenshift, err := IsOpenShift(log)
 			if patch.ignoreError {
 				t.Log("cover  real Openshift setup")
 			} else if !success {

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ func getOperatorConfig(log *zap.SugaredLogger) (utils.OperatorConfig, error) {
 
 	isOpenShift, err := isOpenShift(log)
 	if err != nil {
-		log.Info(fmt.Sprintf("isOpenShift err %v", err))
+		log.Info(fmt.Sprintf("isOpenShift returned %v err %v", isOpenShift, err))
 	}
 	cfg.IsOpenShift = isOpenShift
 	if isOpenShift {

--- a/main.go
+++ b/main.go
@@ -97,8 +97,8 @@ func printVersion(log *zap.SugaredLogger) {
 }
 
 var (
-	isOpenShift = func() (bool, error) {
-		return k8sClient.IsOpenShift()
+	isOpenShift = func(log *zap.SugaredLogger) (bool, error) {
+		return k8sClient.IsOpenShift(log)
 	}
 
 	getKubeAPIServerVersion = func() (*version.Info, error) {
@@ -129,9 +129,9 @@ var (
 func getOperatorConfig(log *zap.SugaredLogger) (utils.OperatorConfig, error) {
 	cfg := utils.OperatorConfig{}
 
-	isOpenShift, err := isOpenShift()
+	isOpenShift, err := isOpenShift(log)
 	if err != nil {
-		log.Info(fmt.Sprintf("isOpenShift err %t", isOpenShift))
+		log.Info(fmt.Sprintf("isOpenShift err %v", err))
 	}
 	cfg.IsOpenShift = isOpenShift
 	if isOpenShift {

--- a/main_test.go
+++ b/main_test.go
@@ -406,8 +406,11 @@ func TestIsOpenshift(t *testing.T) {
 	assert.NoError(t, err)
 	_ = os.Setenv("KUBECONFIG", "./fake-kubeconfig")
 	var log *zap.SugaredLogger
-	_, err = isOpenShift(log)
-	assert.NotNil(t, err)
+	var isOpenShiftResult bool
+	isOpenShiftResult, _ = isOpenShift(log)
+	if ( isOpenShiftResult != false ) {
+		t.Errorf("IsOpenShift() = %v, want %v", isOpenShiftResult, true)
+	}
 }
 
 func TestGetKubeAPIServerVersion(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -56,7 +56,7 @@ func TestPrintVersion(_ *testing.T) {
 func TestGetOperatorConfig(t *testing.T) {
 	tests := []struct {
 		name                            string
-		isOpenShift                     func() (bool, error)
+		isOpenShift                     func(_ *zap.SugaredLogger) (bool, error)
 		getKubeAPIServerVersion         func() (*version.Info, error)
 		getConfigDir                    func() string
 		getK8sPathFn                    func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string
@@ -68,7 +68,7 @@ func TestGetOperatorConfig(t *testing.T) {
 	}{
 		{
 			name:                    "Openshift environment",
-			isOpenShift:             func() (bool, error) { return true, nil },
+			isOpenShift:             func(_ *zap.SugaredLogger) (bool, error) { return true, nil },
 			getKubeAPIServerVersion: func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil },
 			getConfigDir:            func() string { return "testdata" },
 			getK8sPathFn: func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -106,7 +106,7 @@ func TestGetOperatorConfig(t *testing.T) {
 		},
 		{
 			name:                    "Kubernetes environment",
-			isOpenShift:             func() (bool, error) { return false, nil },
+			isOpenShift:             func(_ *zap.SugaredLogger) (bool, error) { return false, nil },
 			getKubeAPIServerVersion: func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil },
 			getConfigDir:            func() string { return "testdata" },
 			getK8sPathFn: func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -144,7 +144,7 @@ func TestGetOperatorConfig(t *testing.T) {
 		},
 		{
 			name:                    "Bad config directory",
-			isOpenShift:             func() (bool, error) { return false, nil },
+			isOpenShift:             func(_ *zap.SugaredLogger) (bool, error) { return false, nil },
 			getKubeAPIServerVersion: func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil },
 			getConfigDir:            func() string { return "/bad/path/does/not/exist" },
 			getK8sPathFn: func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -174,7 +174,7 @@ func TestGetOperatorConfig(t *testing.T) {
 		},
 		{
 			name:                    "Fail get openshift",
-			isOpenShift:             func() (bool, error) { return false, errors.New("error") },
+			isOpenShift:             func(_ *zap.SugaredLogger) (bool, error) { return false, errors.New("error") },
 			getKubeAPIServerVersion: func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, errors.New("error") },
 			getConfigDir:            func() string { return "/bad/path/does/not/exist" },
 			getK8sPathFn: func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -204,7 +204,7 @@ func TestGetOperatorConfig(t *testing.T) {
 		},
 		{
 			name:                    "Fail get kube api version",
-			isOpenShift:             func() (bool, error) { return false, nil },
+			isOpenShift:             func(_ *zap.SugaredLogger) (bool, error) { return false, nil },
 			getKubeAPIServerVersion: func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, errors.New("error") },
 			getConfigDir:            func() string { return "/bad/path/does/not/exist" },
 			getK8sPathFn: func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -234,7 +234,7 @@ func TestGetOperatorConfig(t *testing.T) {
 		},
 		{
 			name:                    "Fail parse K8sMinimumSupportedVersion",
-			isOpenShift:             func() (bool, error) { return false, nil },
+			isOpenShift:             func(_ *zap.SugaredLogger) (bool, error) { return false, nil },
 			getKubeAPIServerVersion: func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, errors.New("error") },
 			getConfigDir:            func() string { return "/bad/path/does/not/exist" },
 			getK8sPathFn: func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -264,7 +264,7 @@ func TestGetOperatorConfig(t *testing.T) {
 		},
 		{
 			name:                    "Fail parse K8sMaximumSupportedVersion",
-			isOpenShift:             func() (bool, error) { return false, nil },
+			isOpenShift:             func(_ *zap.SugaredLogger) (bool, error) { return false, nil },
 			getKubeAPIServerVersion: func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, errors.New("error") },
 			getConfigDir:            func() string { return "/bad/path/does/not/exist" },
 			getK8sPathFn: func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -294,7 +294,7 @@ func TestGetOperatorConfig(t *testing.T) {
 		},
 		{
 			name:                    "Fail parse kube version",
-			isOpenShift:             func() (bool, error) { return false, nil },
+			isOpenShift:             func(_ *zap.SugaredLogger) (bool, error) { return false, nil },
 			getKubeAPIServerVersion: func() (*version.Info, error) { return &version.Info{Major: "test", Minor: "test"}, nil },
 			getConfigDir:            func() string { return "/bad/path/does/not/exist" },
 			getK8sPathFn: func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -324,7 +324,7 @@ func TestGetOperatorConfig(t *testing.T) {
 		},
 		{
 			name:                    "Fail yaml unmarshal",
-			isOpenShift:             func() (bool, error) { return false, nil },
+			isOpenShift:             func(_ *zap.SugaredLogger) (bool, error) { return false, nil },
 			getKubeAPIServerVersion: func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil },
 			getConfigDir:            func() string { return "/bad/path/does/not/exist" },
 			getK8sPathFn: func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -405,7 +405,8 @@ func TestIsOpenshift(t *testing.T) {
 	err := k8s.CreateTempKubeconfig("./fake-kubeconfig")
 	assert.NoError(t, err)
 	_ = os.Setenv("KUBECONFIG", "./fake-kubeconfig")
-	_, err = isOpenShift()
+	var log *zap.SugaredLogger
+	_, err = isOpenShift(log)
 	assert.NotNil(t, err)
 }
 
@@ -514,7 +515,7 @@ func TestMain(_ *testing.T) {
 		setupSignalHandler = originalSetupSignalHandler
 	}()
 
-	isOpenShift = func() (bool, error) { return true, nil }
+	isOpenShift = func(_ *zap.SugaredLogger) (bool, error) { return true, nil }
 	getKubeAPIServerVersion = func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil }
 	getConfigDir = func() string { return "testdata" }
 	getk8sPathFn = func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -606,7 +607,7 @@ func TestMainGetOperatorConfigError(_ *testing.T) {
 		osExit = originalOsExit
 	}()
 
-	isOpenShift = func() (bool, error) { return true, nil }
+	isOpenShift = func(_ *zap.SugaredLogger) (bool, error) { return true, nil }
 	getKubeAPIServerVersion = func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil }
 	getConfigDir = func() string { return "testdata" }
 	getk8sPathFn = func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -704,7 +705,7 @@ func TestMainNewManagerError(_ *testing.T) {
 		osExit = originalOsExit
 	}()
 
-	isOpenShift = func() (bool, error) { return true, nil }
+	isOpenShift = func(_ *zap.SugaredLogger) (bool, error) { return true, nil }
 	getKubeAPIServerVersion = func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil }
 	getConfigDir = func() string { return "testdata" }
 	getk8sPathFn = func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -777,7 +778,7 @@ func TestMainSetupWithManagerError(_ *testing.T) {
 		initZapFlags = originalInitZapFlags
 	}()
 
-	isOpenShift = func() (bool, error) { return true, nil }
+	isOpenShift = func(_ *zap.SugaredLogger) (bool, error) { return true, nil }
 	getKubeAPIServerVersion = func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil }
 	getConfigDir = func() string { return "testdata" }
 	getk8sPathFn = func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -853,7 +854,7 @@ func TestMainAddHealthzCheckError(_ *testing.T) {
 		getControllerWatchCh = originalGetControllerWatchCh
 	}()
 
-	isOpenShift = func() (bool, error) { return true, nil }
+	isOpenShift = func(_ *zap.SugaredLogger) (bool, error) { return true, nil }
 	getKubeAPIServerVersion = func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil }
 	getConfigDir = func() string { return "testdata" }
 	getk8sPathFn = func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -934,7 +935,7 @@ func TestMainAddReadyzCheckError(_ *testing.T) {
 		getControllerWatchCh = originalGetControllerWatchCh
 	}()
 
-	isOpenShift = func() (bool, error) { return true, nil }
+	isOpenShift = func(_ *zap.SugaredLogger) (bool, error) { return true, nil }
 	getKubeAPIServerVersion = func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil }
 	getConfigDir = func() string { return "testdata" }
 	getk8sPathFn = func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {
@@ -1018,7 +1019,7 @@ func TestMainStartError(_ *testing.T) {
 		setupSignalHandler = originalSetupSignalHandler
 	}()
 
-	isOpenShift = func() (bool, error) { return true, nil }
+	isOpenShift = func(_ *zap.SugaredLogger) (bool, error) { return true, nil }
 	getKubeAPIServerVersion = func() (*version.Info, error) { return &version.Info{Major: "1", Minor: "31"}, nil }
 	getConfigDir = func() string { return "testdata" }
 	getk8sPathFn = func(_ *zap.SugaredLogger, _ string, _, _, _ float64) string {

--- a/main_test.go
+++ b/main_test.go
@@ -408,7 +408,7 @@ func TestIsOpenshift(t *testing.T) {
 	var log *zap.SugaredLogger
 	var isOpenShiftResult bool
 	isOpenShiftResult, _ = isOpenShift(log)
-	if ( isOpenShiftResult != false ) {
+	if isOpenShiftResult != false {
 		t.Errorf("IsOpenShift() = %v, want %v", isOpenShiftResult, true)
 	}
 }


### PR DESCRIPTION
# Description
k8sClientSet.Discovery().ServerGroupsAndResources() may fail and still contain valid serverGroups, we should therefore handle this. See here: https://github.com/kubernetes/client-go/blob/e7397e54da6d91094f2a8ca6224af45c25682f7f/discovery/discovery_client.go#L130

**Operator will now not immediately fail on the call to k8s to get the service groups. If there is a failure on this call, it will now be logged, so we can see why it failed.**


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] K8s e2e test with PScale on cluster
- [ ] OCP sanity test 
