### PR TITLE
PowerScale Create Snapshot fix: Get isiPath from source volume's export path, thus removing X_CSI_VOL_PREFIX env variable

### DIFF
--- a/config/samples/storage_v1_csm_powerscale.yaml
+++ b/config/samples/storage_v1_csm_powerscale.yaml
@@ -156,10 +156,6 @@ spec:
         # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
           value: "192"
-        # X_CSI_VOL_PREFIX: this parameter specifies the volume prefix used for the names of PersistentVolumes created.
-        # Default value: csivol
-        - name: X_CSI_VOL_PREFIX
-          value: "csivol"
       # nodeSelector: Define node selection constraints for pods of controller deployment.
       # For the pod to be eligible to run on a node, the node must have each
       # of the indicated key-value pairs as labels.
@@ -244,6 +240,7 @@ spec:
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+        args: ["--volume-name-prefix=csivol"]
       - name: attacher
         image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
       - name: registrar

--- a/operatorconfig/driverconfig/powerscale/v2.14.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.14.0/controller.yaml
@@ -209,7 +209,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--volume-name-prefix=<CSI_VOL_PREFIX>"
+            - "--volume-name-prefix=csivol"
             - "--volume-name-uuid-length=10"
             - "--worker-threads=5"
             - "--timeout=120s"
@@ -326,8 +326,6 @@ spec:
               value: /isilon-configs/config
             - name: X_CSI_MAX_PATH_LIMIT
               value: "192"
-            - name: X_CSI_VOL_PREFIX
-              value: "<CSI_VOL_PREFIX>"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/pkg/drivers/powerscale.go
+++ b/pkg/drivers/powerscale.go
@@ -42,9 +42,6 @@ const (
 
 	// PowerScaleDebug - will be used to control the GOISILON_DEBUG variable
 	PowerScaleDebug string = "<GOISILON_DEBUG>"
-
-	// PowerScaleCsiVolPrefix - will be used to control the CSI_VOL_PREFIX variable
-	PowerScaleCsiVolPrefix string = "<CSI_VOL_PREFIX>"
 )
 
 // PrecheckPowerScale do input validation
@@ -180,8 +177,6 @@ func ModifyPowerScaleCR(yamlString string, cr csmv1.ContainerStorageModule, file
 	healthMonitorController := "false"
 	// GOISILON_DEBUG defaults to false
 	debug := "false"
-	// CSI_VOL_PREFIX defaults to csivol
-	csiVolPrefix := "csivol"
 
 	if cr.Spec.Driver.Common != nil {
 		for _, env := range cr.Spec.Driver.Common.Envs {
@@ -203,15 +198,11 @@ func ModifyPowerScaleCR(yamlString string, cr csmv1.ContainerStorageModule, file
 				if env.Name == "X_CSI_HEALTH_MONITOR_ENABLED" {
 					healthMonitorController = env.Value
 				}
-				if env.Name == "X_CSI_VOL_PREFIX" {
-					csiVolPrefix = env.Value
-				}
 			}
 		}
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorController)
 		yamlString = strings.ReplaceAll(yamlString, PowerScaleCSMNameSpace, cr.Namespace)
 		yamlString = strings.ReplaceAll(yamlString, PowerScaleDebug, debug)
-		yamlString = strings.ReplaceAll(yamlString, PowerScaleCsiVolPrefix, csiVolPrefix)
 	case "Node":
 		if cr.Spec.Driver.Node != nil {
 			for _, env := range cr.Spec.Driver.Node.Envs {

--- a/samples/ocp/1.9.0/storage_csm_powerscale_v2140.yaml
+++ b/samples/ocp/1.9.0/storage_csm_powerscale_v2140.yaml
@@ -156,10 +156,6 @@ spec:
         # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
           value: "192"
-        # X_CSI_VOL_PREFIX: this parameter specifies the volume prefix used for the names of PersistentVolumes created.
-        # Default value: csivol
-        - name: X_CSI_VOL_PREFIX
-          value: "csivol"
       # nodeSelector: Define node selection constraints for pods of controller deployment.
       # For the pod to be eligible to run on a node, the node must have each
       # of the indicated key-value pairs as labels.
@@ -244,6 +240,7 @@ spec:
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner@sha256:672e45d6a55678abc1d102de665b5cbd63848e75dc7896f238c8eaaf3c7d322f
+        args: ["--volume-name-prefix=csivol"]
       - name: attacher
         image: registry.k8s.io/sig-storage/csi-attacher@sha256:a399393ff5bd156277c56bae0c08389b1a1b95b7fd6ea44a316ce55e0dd559d7
       - name: registrar

--- a/samples/storage_csm_powerscale_v2140.yaml
+++ b/samples/storage_csm_powerscale_v2140.yaml
@@ -156,10 +156,6 @@ spec:
         # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
           value: "192"
-        # X_CSI_VOL_PREFIX: this parameter specifies the volume prefix used for the names of PersistentVolumes created.
-        # Default value: csivol
-        - name: X_CSI_VOL_PREFIX
-          value: "csivol"
       # nodeSelector: Define node selection constraints for pods of controller deployment.
       # For the pod to be eligible to run on a node, the node must have each
       # of the indicated key-value pairs as labels.
@@ -244,6 +240,7 @@ spec:
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+        args: ["--volume-name-prefix=csivol"]
       - name: attacher
         image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
       - name: registrar


### PR DESCRIPTION
# Description
For the PowerScale CreateSnapshot call, the required isiPath is now retrieved from the source volume's export path like it is done in the replication code. So, there will be no need to get PV's 'Path' value or remove any prefix. Hence, reverting the changes made in previous PR https://github.com/dell/csm-operator/pull/974

Related PRs:
https://github.com/dell/csi-powerscale/pull/406

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1920 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Please see test results added in PR https://github.com/dell/csi-powerscale/pull/406