### PR TITLE
PowerScale Create Snapshot fix: Get isiPath from source volume's export path, thus removing X_CSI_VOL_PREFIX env variable

### DIFF
--- a/config/samples/storage_v1_csm_powerscale.yaml
+++ b/config/samples/storage_v1_csm_powerscale.yaml
@@ -156,10 +156,6 @@ spec:
         # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
           value: "192"
-        # X_CSI_VOL_PREFIX: this parameter specifies the volume prefix used for the names of PersistentVolumes created.
-        # Default value: csivol
-        - name: X_CSI_VOL_PREFIX
-          value: "csivol"
       # nodeSelector: Define node selection constraints for pods of controller deployment.
       # For the pod to be eligible to run on a node, the node must have each
       # of the indicated key-value pairs as labels.
@@ -244,6 +240,7 @@ spec:
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+        args: ["--volume-name-prefix=csivol"]
       - name: attacher
         image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
       - name: registrar

--- a/operatorconfig/driverconfig/powerscale/v2.15.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerscale/v2.15.0/controller.yaml
@@ -209,7 +209,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--volume-name-prefix=<CSI_VOL_PREFIX>"
+            - "--volume-name-prefix=csivol"
             - "--volume-name-uuid-length=10"
             - "--worker-threads=5"
             - "--timeout=120s"
@@ -326,8 +326,6 @@ spec:
               value: /isilon-configs/config
             - name: X_CSI_MAX_PATH_LIMIT
               value: "192"
-            - name: X_CSI_VOL_PREFIX
-              value: "<CSI_VOL_PREFIX>"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/pkg/drivers/powerscale.go
+++ b/pkg/drivers/powerscale.go
@@ -211,7 +211,7 @@ func ModifyPowerScaleCR(yamlString string, cr csmv1.ContainerStorageModule, file
 		yamlString = strings.ReplaceAll(yamlString, CsiHealthMonitorEnabled, healthMonitorController)
 		yamlString = strings.ReplaceAll(yamlString, PowerScaleCSMNameSpace, cr.Namespace)
 		yamlString = strings.ReplaceAll(yamlString, PowerScaleDebug, debug)
-		yamlString = strings.ReplaceAll(yamlString, PowerScaleCsiVolPrefix, csiVolPrefix)
+		yamlString = strings.ReplaceAll(yamlString, PowerScaleCsiVolPrefix, csiVolPrefix) // applicable only for v2.14.0/controller.yaml
 	case "Node":
 		if cr.Spec.Driver.Node != nil {
 			for _, env := range cr.Spec.Driver.Node.Envs {

--- a/samples/storage_csm_powerscale_v2150.yaml
+++ b/samples/storage_csm_powerscale_v2150.yaml
@@ -156,10 +156,6 @@ spec:
         # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
           value: "192"
-        # X_CSI_VOL_PREFIX: this parameter specifies the volume prefix used for the names of PersistentVolumes created.
-        # Default value: csivol
-        - name: X_CSI_VOL_PREFIX
-          value: "csivol"
       # nodeSelector: Define node selection constraints for pods of controller deployment.
       # For the pod to be eligible to run on a node, the node must have each
       # of the indicated key-value pairs as labels.
@@ -244,6 +240,7 @@ spec:
     sideCars:
       - name: provisioner
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+        args: ["--volume-name-prefix=csivol"]
       - name: attacher
         image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
       - name: registrar


### PR DESCRIPTION
# Description
For the PowerScale CreateSnapshot call, the required isiPath is now retrieved from the source volume's export path like it is done in the replication code. So, there will be no need to get PV's 'Path' value or remove any prefix. Hence, reverting the changes made in previous PR https://github.com/dell/csm-operator/pull/974

Related PRs:
https://github.com/dell/csi-powerscale/pull/406
https://github.com/dell/helm-charts/pull/753
https://github.com/dell/csm-docs/pull/1573

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1920 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- With 2.14 sample and 2.14 driver image:
   - tested create snapshot with "X_CSI_VOL_PREFIX=csivol" (default).
   - tested create snapshot with "X_CSI_VOL_PREFIX=k8s".
- With 2.15 sample and driver image with fix: (Operator is not yet updated with 2.15 configVersion, so used it as 2.14)
   - tested create snapshot with "volume-name-prefix=csivol" (default).
   - tested create snapshot with "volume-name-prefix=k8s".
   - tested create snapshot for PV that was created with different prefix.
- For detailed driver test results, please refer PR https://github.com/dell/csi-powerscale/pull/406