### PR TITLE
Fixes overriding driver container env with driver.common.envs when dr…

### DIFF
--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -166,6 +166,20 @@ func csmForPowerFlex(customCSMName string) csmv1.ContainerStorageModule {
 	return res
 }
 
+// makes a csm object with proxy
+func csmForPowerMax(customization string) csmv1.ContainerStorageModule {
+	res := csmForPowerMaxNOProxy()
+	revproxy := shared.MakeReverseProxyModule(shared.ConfigVersion)
+	res.Spec.Modules = append(res.Spec.Modules, revproxy)
+
+	if customization == "common-env-override-no-node" {
+		res.Spec.Driver.Common.Envs = []corev1.EnvVar{{Name: "X_CSI_K8S_CLUSTER_PREFIX", Value: "UNIT-TEST"}}
+		res.Spec.Driver.Node = nil
+	}
+
+	return res
+}
+
 func csmWithPowerstore(driver csmv1.DriverType, version string) csmv1.ContainerStorageModule {
 	res := shared.MakeCSM("csm", "driver-test", shared.ConfigVersion)
 

--- a/pkg/drivers/powermax.go
+++ b/pkg/drivers/powermax.go
@@ -47,7 +47,6 @@ const (
 	// CSIPmaxManagedArray and following  used for replacing user values in config files
 	CSIPmaxManagedArray    = "<X_CSI_MANAGED_ARRAY>"
 	CSIPmaxEndpoint        = "<X_CSI_POWERMAX_ENDPOINT>"
-	CSIPmaxClusterPrefix   = "<X_CSI_K8S_CLUSTER_PREFIX>"
 	CSIPmaxDebug           = "<X_CSI_POWERMAX_DEBUG>"
 	CSIPmaxPortGroup       = "<X_CSI_POWERMAX_PORTGROUPS>"
 	CSIPmaxProtocol        = "<X_CSI_TRANSPORT_PROTOCOL>"
@@ -174,7 +173,6 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 	// Parameters to initialise CR values
 	managedArray := ""
 	endpoint := ""
-	clusterPrefix := ""
 	debug := "false"
 	portGroup := ""
 	protocol := ""
@@ -201,9 +199,6 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 				}
 				if env.Name == "X_CSI_POWERMAX_ENDPOINT" {
 					endpoint = env.Value
-				}
-				if env.Name == "X_CSI_K8S_CLUSTER_PREFIX" {
-					clusterPrefix = env.Value
 				}
 				if env.Name == "X_CSI_POWERMAX_DEBUG" {
 					debug = env.Value
@@ -267,7 +262,6 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxManagedArray, managedArray)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxEndpoint, endpoint)
-		yamlString = strings.ReplaceAll(yamlString, CSIPmaxClusterPrefix, clusterPrefix)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxDebug, debug)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxPortGroup, portGroup)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxProtocol, protocol)
@@ -291,9 +285,6 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 				}
 				if env.Name == "X_CSI_POWERMAX_ENDPOINT" {
 					endpoint = env.Value
-				}
-				if env.Name == "X_CSI_K8S_CLUSTER_PREFIX" {
-					clusterPrefix = env.Value
 				}
 				if env.Name == "X_CSI_POWERMAX_DEBUG" {
 					debug = env.Value
@@ -346,7 +337,6 @@ func ModifyPowermaxCR(yamlString string, cr csmv1.ContainerStorageModule, fileTy
 
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxManagedArray, managedArray)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxEndpoint, endpoint)
-		yamlString = strings.ReplaceAll(yamlString, CSIPmaxClusterPrefix, clusterPrefix)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxDebug, debug)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxPortGroup, portGroup)
 		yamlString = strings.ReplaceAll(yamlString, CSIPmaxProtocol, protocol)

--- a/pkg/drivers/powermax_test.go
+++ b/pkg/drivers/powermax_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	powerMaxCSM                   = csmForPowerMax()
+	powerMaxCSM                   = csmForPowerMax("")
 	powerMaxReverseProxySecret    = csmWithReverseProxySecret()
 	powerMaxBadReverseProxySecret = csmWithBadReverseProxySecret()
 	powerMaxCSMNoProxy            = csmForPowerMaxNOProxy()
@@ -256,14 +256,6 @@ func csmForPowerMaxNOProxy() csmv1.ContainerStorageModule {
 	res.Spec.Driver.ConfigVersion = shared.PmaxConfigVersion
 	res.Spec.Driver.CSIDriverType = csmv1.PowerMax
 
-	return res
-}
-
-// makes a csm object with proxy
-func csmForPowerMax() csmv1.ContainerStorageModule {
-	res := csmForPowerMaxNOProxy()
-	revproxy := shared.MakeReverseProxyModule(shared.ConfigVersion)
-	res.Spec.Modules = append(res.Spec.Modules, revproxy)
 	return res
 }
 


### PR DESCRIPTION
# Description
Fixes overriding driver container env with driver.common.envs when driver.node section is absent. Before this change, environment variables set in the CSM object in the driver.common.envs section were ignored by the Operator unless the CSM object had the section driver.node present with any content.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1959 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] existing and new unit-tests
- [x] by applying a powermax CSM CR with custom X_CSI_K8S_CLUSTER_PREFIX value and absent driver.node section and then checking the running driver node container spec.
