### PR TITLE
ClusterRole with permissions required to install PowerStore

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -47,6 +47,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: dell-csm-operator-endpointslices-role
+rules:
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - create
+      - delete
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: dell-csm-operator-manager-role
 rules:
   - nonResourceURLs:
@@ -759,6 +774,19 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
+    namespace: dell-csm-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dell-csm-operator-endpointslices-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dell-csm-operator-endpointslices-role
+subjects:
+  - kind: ServiceAccount
+    name: dell-csm-operator-manager-service-account
     namespace: dell-csm-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -62,6 +62,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: dell-csm-operator-namespace-deleter-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: dell-csm-operator-manager-role
 rules:
   - nonResourceURLs:
@@ -784,6 +796,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: dell-csm-operator-endpointslices-role
+subjects:
+  - kind: ServiceAccount
+    name: dell-csm-operator-manager-service-account
+    namespace: dell-csm-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dell-csm-operator-namespace-deleter-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dell-csm-operator-namespace-deleter-role
 subjects:
   - kind: ServiceAccount
     name: dell-csm-operator-manager-service-account

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -27,11 +27,22 @@ NAMESPACE=$(echo $NS_STRING | cut -d ' ' -f2)
 log separator
 echo "Deleting the Operator Deployment"
 log separator
-kubectl delete -f ${DEPLOYDIR}/operator.yaml
+kubectl delete -f ${DEPLOYDIR}/operator.yaml --ignore-not-found
 echo
 
 log separator
 echo "Deleting the Operator CRDs"
 log separator
-kubectl delete -f ${DEPLOYDIR}/crds/storage.dell.com.crds.all.yaml
+kubectl delete -f ${DEPLOYDIR}/crds/storage.dell.com.crds.all.yaml --ignore-not-found
+echo
+
+
+# Cleanup for resources that existed in previous versions of operator.yaml
+# but are no longer defined in the current one. Since the new manifest is unaware of them,
+# they won't be deleted by `kubectl delete -f operator.yaml` and must be removed manually
+log separator
+echo "Deleting unused pre-v1.15 resources"
+log separator
+kubectl delete clusterrolebinding dell-csm-operator-application-mobility-velero-server-rolebinding --ignore-not-found
+kubectl delete clusterrole dell-csm-operator-application-mobility-velero-server --ignore-not-found
 echo


### PR DESCRIPTION
# Description
Added clusterrole with permissions required to install the powerstore driver. 
Added clusterrole with permissions required to cleanup replication controller namespace after uninstallation.
Added a cleanup procedure to the Operator uninistal script to remove clusterrole that was eliminated in this release.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1986 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?

- Successfully installed PowerStore with the fixed Operator
- Successfully executed operator e2e test with '--pstore' (log attached to the defect)
