### PR TITLE
Port PowerFlex probe timeout changes to v2.15.0

### DIFF
--- a/operatorconfig/driverconfig/powerflex/v2.15.0/controller.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.15.0/controller.yaml
@@ -267,6 +267,8 @@ spec:
               value: <GOSCALEIO_DEBUG>
             - name: GOSCALEIO_SHOWHTTP
               value: <GOSCALEIO_SHOWHTTP>
+            - name: X_CSI_PROBE_TIMEOUT
+              value: <X_CSI_PROBE_TIMEOUT>
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/operatorconfig/driverconfig/powerflex/v2.15.0/node.yaml
+++ b/operatorconfig/driverconfig/powerflex/v2.15.0/node.yaml
@@ -143,6 +143,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: RELEASE_NAME
               value: <DriverDefaultReleaseName>
+            - name: X_CSI_PROBE_TIMEOUT
+              value: <X_CSI_PROBE_TIMEOUT>
           volumeMounts:
             - name: driver-path
               mountPath: <KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -80,6 +80,9 @@ const (
 
 	// PowerFlexSdcRepoEnabled - will be used to control the GOSCALEIO_SHOWHTTP variable
 	PowerFlexSdcRepoEnabled string = "<X_CSI_SDC_SFTP_REPO_ENABLED>"
+
+	// PowerFlexProbeTimeout - will be used to control the X_CSI_PROBE_TIMEOUT variable
+	PowerFlexProbeTimeout string = "<X_CSI_PROBE_TIMEOUT>"
 )
 
 // PrecheckPowerFlex do input validation
@@ -312,6 +315,7 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 	sftpRepoAddress := "sftp://0.0.0.0"
 	sftpRepoUser := ""
 	sftpEnabled := ""
+	probeTimeout := "10s"
 
 	if cr.Spec.Driver.Common != nil {
 		for _, env := range cr.Spec.Driver.Common.Envs {
@@ -320,6 +324,9 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 			}
 			if env.Name == "GOSCALEIO_SHOWHTTP" {
 				showHTTP = env.Value
+			}
+			if env.Name == "X_CSI_PROBE_TIMEOUT" {
+				probeTimeout = env.Value
 			}
 		}
 	}
@@ -342,6 +349,7 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 		yamlString = strings.ReplaceAll(yamlString, PowerFlexCSMNameSpace, cr.Namespace)
 		yamlString = strings.ReplaceAll(yamlString, PowerFlexDebug, debug)
 		yamlString = strings.ReplaceAll(yamlString, PowerFlexShowHTTP, showHTTP)
+		yamlString = strings.ReplaceAll(yamlString, PowerFlexProbeTimeout, probeTimeout)
 
 	case "Node":
 		if cr.Spec.Driver.Node != nil {
@@ -387,6 +395,7 @@ func ModifyPowerflexCR(yamlString string, cr csmv1.ContainerStorageModule, fileT
 		yamlString = strings.ReplaceAll(yamlString, PowerFlexSftpRepoAddress, sftpRepoAddress)
 		yamlString = strings.ReplaceAll(yamlString, PowerFlexSftpRepoUser, sftpRepoUser)
 		yamlString = strings.ReplaceAll(yamlString, PowerFlexSdcRepoEnabled, sftpEnabled)
+		yamlString = strings.ReplaceAll(yamlString, PowerFlexProbeTimeout, probeTimeout)
 
 	case "CSIDriverSpec":
 		if cr.Spec.Driver.CSIDriverSpec != nil && cr.Spec.Driver.CSIDriverSpec.StorageCapacity {

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -226,6 +226,23 @@ var (
 			fileType: "Node",
 			expected: "false",
 		},
+		{
+			name:       "update common X_CSI_PROBE_TIMEOUT value in CR",
+			yamlString: "X_CSI_PROBE_TIMEOUT=<X_CSI_PROBE_TIMEOUT>",
+			cr: csmv1.ContainerStorageModule{
+				Spec: csmv1.ContainerStorageModuleSpec{
+					Driver: csmv1.Driver{
+						Common: &csmv1.ContainerTemplate{
+							Envs: []corev1.EnvVar{
+								{Name: "X_CSI_PROBE_TIMEOUT", Value: "5s"},
+							},
+						},
+					},
+				},
+			},
+			fileType: "Controller",
+			expected: "X_CSI_PROBE_TIMEOUT=5s",
+		},
 	}
 )
 


### PR DESCRIPTION
# Description
Port over the changes made for the v2.14.1 patch to main and ensure that it is available for PowerFlex v2.15.0

See: https://github.com/dell/csm-operator/pull/1053

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1956 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] All testing was verified and done for the patch, this is a port over of those changes.
