### PR TITLE
Usr/ghivad/driver prefix length

### DIFF
--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -145,7 +145,7 @@ func csmForPowerFlex(customCSMName string) csmv1.ContainerStorageModule {
 		Tolerations:     []corev1.Toleration{},
 	}}
 
-	// Add sdc-monitor Sidecar
+	// Add provisioner Sidecar
 	res.Spec.Driver.SideCars = []csmv1.ContainerTemplate{{
 		Name: "provisioner",
 		Args: []string{},

--- a/pkg/drivers/common_test.go
+++ b/pkg/drivers/common_test.go
@@ -145,6 +145,12 @@ func csmForPowerFlex(customCSMName string) csmv1.ContainerStorageModule {
 		Tolerations:     []corev1.Toleration{},
 	}}
 
+	// Add sdc-monitor Sidecar
+	res.Spec.Driver.SideCars = []csmv1.ContainerTemplate{{
+		Name: "provisioner",
+		Args: []string{},
+	}}
+
 	// res.Spec.Driver.CSIDriverSpec.FSGroupPolicy == "ReadWriteOnceWithFSType"
 
 	// Add pflex driver version
@@ -155,27 +161,21 @@ func csmForPowerFlex(customCSMName string) csmv1.ContainerStorageModule {
 
 	// Add Authorization and Replication modules
 	if strings.Contains(customCSMName, "auth-repl") {
-		res.Spec.Modules = append(res.Spec.Modules, csmv1.Module{
-			Name:        "authorization",
-			Enabled:     &trueBool,
-			Image:       "image",
-			Args:        []string{},
-			Envs:        []corev1.EnvVar{},
-			Tolerations: []corev1.Toleration{},
-		})
-		res.Spec.Modules = append(res.Spec.Modules, csmv1.Module{
-			Name:        "replication",
-			Enabled:     &trueBool,
-			Image:       "image",
-			Args:        []string{},
-			Envs:        []corev1.EnvVar{},
-			Tolerations: []corev1.Toleration{},
-		})
+		res.Spec.Modules = []csmv1.Module{
+			{
+				Name:    csmv1.Authorization,
+				Enabled: true,
+			},
+			{
+				Name:    csmv1.Replication,
+				Enabled: true,
+			},
+		}
 
 		// Add --volume-name-prefix
-		if strings.Contains(customCSMName, "valid-prefix") {
+		if strings.Contains(customCSMName, "auth-repl-valid") {
 			res.Spec.Driver.SideCars[0].Args = append(res.Spec.Driver.SideCars[0].Args, "--volume-name-prefix=abc")
-		} else if strings.Contains(customCSMName, "invalid-prefix") {
+		} else if strings.Contains(customCSMName, "auth-repl-invalid") {
 			res.Spec.Driver.SideCars[0].Args = append(res.Spec.Driver.SideCars[0].Args, "--volume-name-prefix=abcdefghij")
 		}
 	}

--- a/pkg/drivers/powerflex.go
+++ b/pkg/drivers/powerflex.go
@@ -89,7 +89,67 @@ const (
 func PrecheckPowerFlex(ctx context.Context, cr *csmv1.ContainerStorageModule, operatorConfig operatorutils.OperatorConfig, ct client.Client) error {
 	log := logger.GetLogger(ctx)
 
-	// Check if driver version is supported by doing a stat on a config file
+	// // Check if Authorization and Replication modules are enabled and volume name prefix is less than 5 characters
+	// for _, module := range cr.Spec.Modules {
+	// 	if module.Name == "authorization" && module.Enabled {
+	// 		for _, replicationModule := range cr.Spec.Modules {
+	// 			if replicationModule.Name == "replication" && replicationModule.Enabled {
+	// 				for _, sideCar := range cr.Spec.Driver.SideCars {
+	// 					if sideCar.Name == "provisioner" {
+	// 						for _, arg := range sideCar.Args {
+	// 							if strings.Contains(arg, "--volume-name-prefix=") {
+	// 								prefix := strings.Split(arg, "--volume-name-prefix=")[1]
+	// 								if len(prefix) > 5 {
+	// 									log.Errorw("PreCheckPowerFlex failed: Authorization and Replication modules cannot be enabled together with invalid volume name prefix")
+	// 									return fmt.Errorf("Authorization and Replication modules cannot be enabled together and volume name prefix cannot be longer than 5 characters")
+	// 								}
+	// 							}
+	// 						}
+	// 					}
+	// 				}
+	// 				log.Errorw("PreCheckPowerFlex failed: Authorization and Replication modules cannot be enabled together")
+	// 				return fmt.Errorf("Authorization and Replication modules cannot be enabled together")
+	// 			}
+	// 		}
+	// 	}
+	// }
+
+	// const (
+// 		Authorization csmv1.ModuleType = "authorization"
+// 		Replication   csmv1.ModuleType = "replication"
+// 	)
+//
+// 	// Check if Authorization and Replication modules are enabled
+// 	authorizationEnabled := containsModule(cr.Spec.Modules, Authorization)
+// 	replicationEnabled := containsModule(cr.Spec.Modules, Replication)
+//
+// 	if authorizationEnabled && replicationEnabled {
+// 		// Check if volume name prefix is valid
+// 		prefix := getVolumeNamePrefix(cr.Spec.Driver.SideCars)
+// 		if len(prefix) > 5 {
+// 			log.Errorw("PreCheckPowerFlex failed: Volume name prefix cannot be longer than 5 characters with Authorization and Replication modules enabled.", "prefix", prefix)
+// 			return fmt.Errorf("Volume name prefix cannot be longer than 5 characters with Authorization and Replication modules enabled.")
+// 		}
+// 	}
+//
+        const (
+            Authorization csmv1.ModuleType = "authorization"
+            Replication   csmv1.ModuleType = "replication"
+        )
+
+        // Check if both Authorization and Replication modules are enabled
+        authEnabled := isModuleEnabled(cr.Spec.Modules, Authorization)
+        replEnabled := isModuleEnabled(cr.Spec.Modules, Replication)
+
+        if authEnabled && replEnabled {
+            prefix := getVolumeNamePrefix(cr.Spec.Driver.SideCars)
+            if len(prefix) > 5 {
+                log.Errorw("PreCheckPowerFlex failed: Volume name prefix too long", "prefix", prefix)
+                return fmt.Errorf("volume name prefix '%s' cannot exceed 5 characters when both Authorization and Replication modules are enabled", prefix)
+            }
+        }
+
+        // Check if driver version is supported by doing a stat on a config file
 	configFilePath := fmt.Sprintf("%s/driverconfig/%s/%s/upgrade-path.yaml", operatorConfig.ConfigDirectory, csmv1.PowerFlex, cr.Spec.Driver.ConfigVersion)
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
 		log.Errorw("PreCheckPowerFlex failed in version check", "Error", err.Error())
@@ -104,6 +164,53 @@ func PrecheckPowerFlex(ctx context.Context, cr *csmv1.ContainerStorageModule, op
 
 	return nil
 }
+
+
+// isModuleEnabled checks if a module is enabled in the list
+func isModuleEnabled(modules []csmv1.Module, name csmv1.ModuleType) bool {
+    for _, m := range modules {
+        if m.Name == name && m.Enabled {
+            return true
+        }
+    }
+    return false
+}
+
+// getVolumeNamePrefix extracts the volume name prefix from the provisioner sidecar args
+func getVolumeNamePrefix(sideCars []csmv1.ContainerTemplate) string {
+    for _, sc := range sideCars {
+        if sc.Name == "provisioner" {
+            for _, arg := range sc.Args {
+                if strings.HasPrefix(arg, "--volume-name-prefix=") {
+                    return strings.TrimPrefix(arg, "--volume-name-prefix=")
+                }
+            }
+        }
+    }
+    return ""
+}
+
+// func containsModule(modules []csmv1.Module, moduleName csmv1.ModuleType) bool {
+// 	for _, module := range modules {
+// 		if module.Name == moduleName && module.Enabled {
+// 			return true
+// 		}
+// 	}
+// 	return false
+// }
+//
+// func getVolumeNamePrefix(sideCars []csmv1.ContainerTemplate) string {
+// 	for _, sideCar := range sideCars {
+// 		if sideCar.Name == "provisioner" {
+// 			for _, arg := range sideCar.Args {
+// 				if strings.Contains(arg, "--volume-name-prefix=") {
+// 					return strings.Split(arg, "--volume-name-prefix=")[1]
+// 				}
+// 			}
+// 		}
+// 	}
+// 	return ""
+// }
 
 func SetSDCinitContainers(ctx context.Context, cr csmv1.ContainerStorageModule, ct client.Client) (csmv1.ContainerStorageModule, error) {
 	mdmVar, _ := GetMDMFromSecret(ctx, &cr, ct)

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -72,6 +72,8 @@ var (
 		{"duplicate system id", csmForPowerFlex("dupl-sysid"), powerFlexClient, shared.MakeSecretWithJSON("dupl-sysid-config", pFlexNS, configJSONFileDuplSysID), "Duplicate SystemID"},
 		{"empty config", csmForPowerFlex("empty"), powerFlexClient, shared.MakeSecretWithJSON("empty-config", pFlexNS, configJSONFileEmpty), "Arrays details are not provided"},
 		{"bad config", csmForPowerFlex("bad"), powerFlexClient, shared.MakeSecretWithJSON("bad-config", pFlexNS, configJSONFileBad), "unable to parse"},
+		{"Auth and Replication enabled with valid prefix", csmForPowerFlex("auth-repl-valid-prefix"), powerFlexClient, shared.MakeSecretWithJSON("auth-repl-valid-prefix-config", pFlexNS, configJSONFileGood), ""},
+		{"Auth and Replication enabled with invalid prefix", csmForPowerFlex("auth-repl-invalid-prefix"), powerFlexClient, shared.MakeSecretWithJSON("auth-repl-invalid-prefix-config", pFlexNS, configJSONFileGood), "Volume name prefix cannot be longer than 5 characters with Authorization and Replication modules enabled."},
 	}
 
 	modifyPowerflexCRTests = []struct {

--- a/pkg/drivers/powerflex_test.go
+++ b/pkg/drivers/powerflex_test.go
@@ -73,7 +73,7 @@ var (
 		{"empty config", csmForPowerFlex("empty"), powerFlexClient, shared.MakeSecretWithJSON("empty-config", pFlexNS, configJSONFileEmpty), "Arrays details are not provided"},
 		{"bad config", csmForPowerFlex("bad"), powerFlexClient, shared.MakeSecretWithJSON("bad-config", pFlexNS, configJSONFileBad), "unable to parse"},
 		{"Auth and Replication enabled with valid prefix", csmForPowerFlex("auth-repl-valid-prefix"), powerFlexClient, shared.MakeSecretWithJSON("auth-repl-valid-prefix-config", pFlexNS, configJSONFileGood), ""},
-		{"Auth and Replication enabled with invalid prefix", csmForPowerFlex("auth-repl-invalid-prefix"), powerFlexClient, shared.MakeSecretWithJSON("auth-repl-invalid-prefix-config", pFlexNS, configJSONFileGood), "Volume name prefix cannot be longer than 5 characters with Authorization and Replication modules enabled."},
+		{"Auth and Replication enabled with invalid prefix", csmForPowerFlex("auth-repl-invalid-prefix"), powerFlexClient, shared.MakeSecretWithJSON("auth-repl-invalid-prefix-config", pFlexNS, configJSONFileGood), "volume name prefix"},
 	}
 
 	modifyPowerflexCRTests = []struct {


### PR DESCRIPTION
# Description
When using CSM Authorization and CSM Replication together with PowerFlex, the generated volume names can exceed the platform's maximum allowed length of 31 characters. This leads to truncation of the volume name, which reduces its uniqueness and may result in naming conflicts or duplicate volume names.
This PR adds a precheck during the driver deployment to ensure the volume name prefix length < 5 chars with Authorization and Replication module enabled.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1992|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Precheck successfully stopping the driver deployment with Auth V2 and Replication enabled with volume name prefix > 5 chars.
