### PR TITLE
Add X_CSI_PROBE_TIMEOUT to PowerFlex sample

### DIFF
--- a/samples/v2.15.0/storage_csm_powerflex_v2150.yaml
+++ b/samples/v2.15.0/storage_csm_powerflex_v2150.yaml
@@ -57,6 +57,12 @@ spec:
         # Default value: None, required only when X_CSI_SDC_ENABLED is set to false
         - name: INTERFACE_NAMES
           value:
+        # X_CSI_PROBE_TIMEOUT: Specify the timeout limit for controller and node to communicate with the array.
+        # Allowed values: 1s, 10s, etc.
+        # In the format of a duration.
+        # Default value: 10s
+        - name: X_CSI_PROBE_TIMEOUT
+          value: "10s"
     sideCars:
       # 'csivol' represents a string prepended to each volume created by the CSI driver
       - name: provisioner


### PR DESCRIPTION
# Description
Port over the `X_CSI_PROBE_TIMEOUT` to latest PowerFlex sample.

All work has previously been ported over, see: https://github.com/dell/csm-operator/pull/1073

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1956 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensure when applying the parameter is processed by the nightly PowerFlex image.
```
time="2025-08-21T19:37:07Z" level=info msg="env variable 'X_CSI_PROBE_TIMEOUT' provided with value 15s"
```
```
$ k get csm -A
NAMESPACE    NAME         CREATIONTIME   CSIDRIVERTYPE   CONFIGVERSION   STATE
vxflexos     vxflexos     3m59s          powerflex       v2.15.0         Succeeded
```