### PR TITLE
Fixed Authorization Upgrade from 2.2 to 2.3

### DIFF
--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -1006,13 +1006,22 @@ func authorizationStorageServiceV2(ctx context.Context, isDeleting bool, cr csmv
 	if v2Version {
 		for i, c := range deployment.Spec.Template.Spec.Containers {
 			if c.Name == "storage-service" {
-				deployment.Spec.Template.Spec.Containers[i].Ports = append(deployment.Spec.Template.Spec.Containers[i].Ports,
-					corev1.ContainerPort{
-						Name:          "promhttp",
-						Protocol:      "TCP",
-						ContainerPort: 2112,
-					},
-				)
+				hasPromhttpPort := false
+				for _, port := range c.Ports {
+					if port.Name == "promhttp" {
+						hasPromhttpPort = true
+						break
+					}
+				}
+				if !hasPromhttpPort {
+					deployment.Spec.Template.Spec.Containers[i].Ports = append(deployment.Spec.Template.Spec.Containers[i].Ports,
+						corev1.ContainerPort{
+							Name:          "promhttp",
+							Protocol:      "TCP",
+							ContainerPort: 2112,
+						},
+					)
+				}
 				break
 			}
 		}

--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	applyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	acorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -1042,9 +1043,9 @@ func removeVaultFromStorageService(ctx context.Context, cr csmv1.ContainerStorag
 	err := ctrlClient.Get(ctx, client.ObjectKey{
 		Namespace: dp.Namespace,
 		Name:      dp.Name,
-	}, &cr)
+	}, dp)
 	if err != nil {
-		log.Infof("%s not found. No need to remvoe vault from storage service.", cr.Name)
+		log.Infof("%s not found. No need to remove vault from storage service.", dp.Name)
 		return nil
 	}
 

--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -1076,7 +1076,7 @@ func removeVaultFromStorageService(ctx context.Context, cr csmv1.ContainerStorag
 		}
 	}
 
-	// Filter out vault volumes
+	// filter out vault volumes
 	var newVolumes []corev1.Volume
 	for _, volume := range currentDeployment.Spec.Template.Spec.Volumes {
 		if !strings.Contains(volume.Name, "vault-client-certificate-") {
@@ -1086,13 +1086,11 @@ func removeVaultFromStorageService(ctx context.Context, cr csmv1.ContainerStorag
 	}
 	currentDeployment.Spec.Template.Spec.Volumes = newVolumes
 
-	// Update the deployment
+	// update the storage-service deployment
 	err = ctrlClient.Update(ctx, currentDeployment)
 	if err != nil {
 		return fmt.Errorf("updating storage service deployment for upgrading: %w", err)
 	}
-
-	log.Infof("current deployment: %+v", currentDeployment)
 
 	return nil
 }
@@ -2309,7 +2307,7 @@ func updateRedisGlobalVars(component csmv1.ContainerTemplate) {
 
 // updateConfigGlobalVars - update the global config vars from the config secret provider class
 func updateConfigGlobalVars(component csmv1.ContainerTemplate) {
-	configSecretName = ""
+	configSecretName = defaultConfigSecretName
 	configSecretProviderClassName = ""
 	configSecretPath = ""
 	for _, config := range component.ConfigSecretProviderClass {

--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -150,6 +150,8 @@ const (
 	defaultRedisUsernameKey = "commander_user"
 	// defaultRedisPasswordKey - name of default password key
 	defaultRedisPasswordKey = "password"
+	// defaultConfigSecretName - the default secret name used for the "config-volume" volume
+	defaultConfigSecretName = "karavi-config-secret"
 
 	// AuthLocalStorageClass -
 	AuthLocalStorageClass = "csm-authorization-local-storage"
@@ -794,6 +796,7 @@ func authorizationStorageServiceV1(ctx context.Context, isDeleting bool, cr csmv
 
 	// get component variables
 	image := ""
+	configSecretName = defaultConfigSecretName
 	for _, component := range authModule.Components {
 		switch component.Name {
 		case AuthProxyServerComponent:
@@ -865,7 +868,7 @@ func authorizationStorageServiceV2(ctx context.Context, isDeleting bool, cr csmv
 	var secrets []string
 	leaderElection := true
 	otelCollector := ""
-	configSecretName = ""
+	configSecretName = defaultConfigSecretName
 	for _, component := range authModule.Components {
 		switch component.Name {
 		case AuthProxyServerComponent:
@@ -1320,6 +1323,7 @@ func applyDeleteAuthorizationProxyServerV2(ctx context.Context, isDeleting bool,
 	proxyImage := ""
 	opaImage := ""
 	opaKubeMgmtImage := ""
+	configSecretName = defaultConfigSecretName
 	for _, component := range authModule.Components {
 		switch component.Name {
 		case AuthProxyServerComponent:
@@ -1374,6 +1378,7 @@ func applyDeleteAuthorizationTenantServiceV2(ctx context.Context, isDeleting boo
 	redisReplicas := 0
 	image := ""
 	sentinelName := ""
+	configSecretName = defaultConfigSecretName
 	for _, component := range authModule.Components {
 		switch component.Name {
 		case AuthProxyServerComponent:

--- a/pkg/modules/authorization.go
+++ b/pkg/modules/authorization.go
@@ -151,7 +151,7 @@ const (
 	// defaultRedisPasswordKey - name of default password key
 	defaultRedisPasswordKey = "password"
 	// defaultConfigSecretName - the default secret name used for the "config-volume" volume
-	defaultConfigSecretName = "karavi-config-secret"
+	defaultConfigSecretName = "karavi-config-secret" // #nosec G101 -- This is a false positive
 
 	// AuthLocalStorageClass -
 	AuthLocalStorageClass = "csm-authorization-local-storage"

--- a/pkg/modules/authorization_deployment_scaffold.go
+++ b/pkg/modules/authorization_deployment_scaffold.go
@@ -22,6 +22,8 @@ import (
 
 // getProxyServerScaffold returns proxy-server deployment for authorization v2
 func getProxyServerScaffold(name, sentinelName, namespace, proxyImage, opaImage, opaKubeMgmtImage, configSecretName, redisSecretName, redisPasswordKey string, replicas int32, sentinelReplicas int) appsv1.Deployment {
+	volumes, volumeMounts := createConfigSecretVolumeAndVolumeMnts(configSecretName)
+
 	return appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -85,16 +87,7 @@ func getProxyServerScaffold(name, sentinelName, namespace, proxyImage, opaImage,
 									ContainerPort: 8080,
 								},
 							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "config-volume",
-									MountPath: "/etc/karavi-authorization/config",
-								},
-								{
-									Name:      "csm-config-params",
-									MountPath: "/etc/karavi-authorization/csm-config-params",
-								},
-							},
+							VolumeMounts: volumeMounts,
 						},
 						{
 							Name:            "opa",
@@ -129,26 +122,7 @@ func getProxyServerScaffold(name, sentinelName, namespace, proxyImage, opaImage,
 							},
 						},
 					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "config-volume",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: configSecretName,
-								},
-							},
-						},
-						{
-							Name: "csm-config-params",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "csm-config-params",
-									},
-								},
-							},
-						},
-					},
+					Volumes: volumes,
 				},
 			},
 		},
@@ -158,6 +132,8 @@ func getProxyServerScaffold(name, sentinelName, namespace, proxyImage, opaImage,
 // getStorageServiceScaffold returns the storage-service deployment with the common elements between v1 and v2
 // callers must ensure that other elements specific for the version get set in the returned deployment
 func getStorageServiceScaffold(name string, namespace string, image string, replicas int32, configSecretName string) appsv1.Deployment {
+	volumes, volumeMounts := createConfigSecretVolumeAndVolumeMnts(configSecretName)
+
 	return appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -204,38 +180,10 @@ func getStorageServiceScaffold(name string, namespace string, image string, repl
 									Value: namespace,
 								},
 							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "config-volume",
-									MountPath: "/etc/karavi-authorization/config",
-								},
-								{
-									Name:      "csm-config-params",
-									MountPath: "/etc/karavi-authorization/csm-config-params",
-								},
-							},
+							VolumeMounts: volumeMounts,
 						},
 					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "config-volume",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: configSecretName,
-								},
-							},
-						},
-						{
-							Name: "csm-config-params",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "csm-config-params",
-									},
-								},
-							},
-						},
-					},
+					Volumes: volumes,
 				},
 			},
 		},
@@ -244,6 +192,8 @@ func getStorageServiceScaffold(name string, namespace string, image string, repl
 
 // getTenantServiceScaffold returns tenant-service deployment for authorization v2
 func getTenantServiceScaffold(name, namespace, sentinelName, image, configSecretName, redisSecretName, redisPasswordKey string, replicas int32, sentinelReplicas int) appsv1.Deployment {
+	volumes, volumeMounts := createConfigSecretVolumeAndVolumeMnts(configSecretName)
+
 	return appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -305,38 +255,10 @@ func getTenantServiceScaffold(name, namespace, sentinelName, image, configSecret
 									Name:          "grpc",
 								},
 							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "config-volume",
-									MountPath: "/etc/karavi-authorization/config",
-								},
-								{
-									Name:      "csm-config-params",
-									MountPath: "/etc/karavi-authorization/csm-config-params",
-								},
-							},
+							VolumeMounts: volumeMounts,
 						},
 					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "config-volume",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: configSecretName,
-								},
-							},
-						},
-						{
-							Name: "csm-config-params",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "csm-config-params",
-									},
-								},
-							},
-						},
-					},
+					Volumes: volumes,
 				},
 			},
 		},
@@ -874,4 +796,43 @@ func createRedisK8sSecret(name, namespace string) corev1.Secret {
 			"commander_user": "dev",
 		},
 	}
+}
+
+func createConfigSecretVolumeAndVolumeMnts(configSecretName string) ([]corev1.Volume, []corev1.VolumeMount) {
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "config-volume",
+			MountPath: "/etc/karavi-authorization/config",
+		},
+		{
+			Name:      "csm-config-params",
+			MountPath: "/etc/karavi-authorization/csm-config-params",
+		},
+	}
+	volSecName := "karavi-config-secret"
+	if configSecretName != "" {
+		volSecName = configSecretName
+	}
+	volumes := []corev1.Volume{
+		{
+			Name: "config-volume",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: volSecName,
+				},
+			},
+		},
+		{
+			Name: "csm-config-params",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "csm-config-params",
+					},
+				},
+			},
+		},
+	}
+
+	return volumes, volumeMounts
 }

--- a/pkg/modules/authorization_test.go
+++ b/pkg/modules/authorization_test.go
@@ -2660,7 +2660,7 @@ func TestUpdateConfigGlobalVars(t *testing.T) {
 			},
 			want: map[string]string{
 				"configSecretProviderClassName ": "",
-				"configSecretName":               "",
+				"configSecretName":               "karavi-config-secret",
 				"configSecretPath ":              "",
 			},
 		},
@@ -2678,7 +2678,7 @@ func TestUpdateConfigGlobalVars(t *testing.T) {
 			},
 			want: map[string]string{
 				"configSecretProviderClassName ": "",
-				"configSecretName":               "",
+				"configSecretName":               "karavi-config-secret",
 				"configSecretPath":               "",
 			},
 		},
@@ -2720,7 +2720,7 @@ func TestUpdateConfigGlobalVars(t *testing.T) {
 			},
 			want: map[string]string{
 				"configSecretProviderClassName ": "",
-				"configSecretName":               "",
+				"configSecretName":               "karavi-config-secret",
 				"configSecretPath":               "",
 			},
 		},

--- a/pkg/modules/authorization_test.go
+++ b/pkg/modules/authorization_test.go
@@ -2742,8 +2742,6 @@ func TestUpdateConfigGlobalVars(t *testing.T) {
 func TestRemoveVaultFromStorageService(t *testing.T) {
 	// Create a fake client
 	ctrlClient := ctrlClientFake.NewClientBuilder().Build()
-
-	// Create a test context
 	ctx := context.TODO()
 
 	// Create a test ContainerStorageModule
@@ -2753,8 +2751,12 @@ func TestRemoveVaultFromStorageService(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Spec: csmv1.ContainerStorageModuleSpec{
-			Driver: csmv1.DriverSpec{
-				ConfigVersion: "v2.2.0",
+			Modules: []csmv1.Module{
+				{
+					Name:    csmv1.AuthorizationServer,
+					Enabled: true,
+					ConfigVersion: "v2.3.0",
+				},
 			},
 		},
 	}
@@ -2806,10 +2808,7 @@ func TestRemoveVaultFromStorageService(t *testing.T) {
 	// Add the test deployment to the fake client
 	ctrlClient.Create(ctx, &dp)
 
-	// Call the removeVaultFromStorageService function
 	err := removeVaultFromStorageService(ctx, cr, ctrlClient, dp)
-
-	// Check if the error is nil
 	if err != nil {
 		t.Errorf("Expected nil error, but got %v", err)
 	}
@@ -2852,4 +2851,6 @@ func TestRemoveVaultFromStorageService(t *testing.T) {
 			t.Errorf("Expected vault volumes to be removed, but found %s", volume.Name)
 		}
 	}
+
+	ctrlClient.Delete(ctx, &dp)
 }

--- a/pkg/modules/authorization_test.go
+++ b/pkg/modules/authorization_test.go
@@ -2753,8 +2753,8 @@ func TestRemoveVaultFromStorageService(t *testing.T) {
 		Spec: csmv1.ContainerStorageModuleSpec{
 			Modules: []csmv1.Module{
 				{
-					Name:    csmv1.AuthorizationServer,
-					Enabled: true,
+					Name:          csmv1.AuthorizationServer,
+					Enabled:       true,
 					ConfigVersion: "v2.3.0",
 				},
 			},


### PR DESCRIPTION
# Description
Fixed Authorization upgrade from 2.2 to 2.3 where the vault references needs to be removed from the deployment. New storage system credentials and redis configurations are used during upgrade.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1468 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Upgrading from Auth 2.2 to 2.3 (full upgrade logs attached to story)
- [x] Authorization E2E
```bash
=== RUN   TestVolume
2025/09/05 09:56:46 Starting volume test
Feature: CSM Authorization
  As a consumer of the CSM Authorization
  I want to test various volume creation scenarios
  So that they are known to work
2025/09/05 09:56:47 === Creating Stateless Storage for powerscale === 
2025/09/05 09:56:49 === Completed Stateless Storage === 
2025/09/05 09:56:49 === Checking if Storage is Connected to Array ===
2025/09/05 09:57:00 === Creating Stateless Role role1 === 
2025/09/05 09:57:01 === Completed Stateless Role === 
2025/09/05 09:57:12 === Creating Stateless Tenant tenant1 === 
2025/09/05 09:57:13 === Completed Stateless Tenant === 
2025/09/05 09:57:25 Created admin token: [dellctl admin token --name admin --refresh-token-expiration 10h0m0s --access-token-expiration 1h0m0s --jwt-signing-secret secret > /tmp/admin.yaml]
2025/09/05 09:57:25 Created tenant token: [dellctl generate token --addr csm-authorization.com:31439 --insecure true --tenant tenant1 --refresh-token-expiration 48h0m0s --access-token-expiration 15m0s --admin-token /tmp/admin.yaml]
2025/09/05 09:57:26 Applying tenant token: /tmp/tenant-token-1757080646.yaml
2025/09/05 09:57:27 === Restarting driver ===

    Examples:
      | storageName  | role    | roleSize | tenant    |
      | "powerscale" | "role1" | "0GiB"   | "tenant1" |
2025/09/05 09:57:34 === Creating PVC lemonade ===
2025/09/05 09:57:35 === Creating demo-pod for pvc lemonade ===
Found created volume csivol-6852b056a9 in PowerScale array

    Examples:
      | storageclass    | size   | pvc        |
      | "STORAGE_CLASS" | "50Mi" | "lemonade" |
=== Deleting Stateless Tenant tenant1 ===2025/09/05 09:58:44 === Deleting Stateless Role role1 ===
2025/09/05 09:58:45 === Deleted Stateless Role role1 ===
2025/09/05 09:58:45 === Deleting Stateless Storage powerscale ===

    Examples:
      | storageName  | role    | tenant    |
      | "powerscale" | "role1" | "tenant1" |

3 scenarios (3 passed)
20 steps (20 passed)
2m0.626328894s
2025/09/05 09:58:46 Volume test finished
--- PASS: TestVolume (120.64s)
=== RUN   TestSnapshot
2025/09/05 09:58:46 Starting volume snapshot test
Feature: CSM Authorization
  As a consumer of the CSM Authorization
  I want to test CSM Authorization
  So that they are known to work
2025/09/05 09:58:47 === Creating Stateless Storage for powerscale === 
2025/09/05 09:58:49 === Completed Stateless Storage === 
2025/09/05 09:58:49 === Checking if Storage is Connected to Array ===
2025/09/05 09:58:59 === Creating Stateless Role role1 === 
2025/09/05 09:59:01 === Completed Stateless Role === 
2025/09/05 09:59:11 === Creating Stateless Tenant tenant1 === 
2025/09/05 09:59:13 === Completed Stateless Tenant === 
2025/09/05 09:59:25 Created admin token: [dellctl admin token --name admin --refresh-token-expiration 10h0m0s --access-token-expiration 1h0m0s --jwt-signing-secret secret > /tmp/admin.yaml]
2025/09/05 09:59:25 Created tenant token: [dellctl generate token --addr csm-authorization.com:31439 --insecure true --tenant tenant1 --refresh-token-expiration 48h0m0s --access-token-expiration 15m0s --admin-token /tmp/admin.yaml]
2025/09/05 09:59:26 Applying tenant token: /tmp/tenant-token-1757080766.yaml
2025/09/05 09:59:27 === Restarting driver ===

    Examples:
      | storageName  | role    | roleSize | tenant    |
      | "powerscale" | "role1" | "0GiB"   | "tenant1" |
2025/09/05 09:59:35 === Creating PVC lemonade ===
2025/09/05 09:59:36 === Creating demo-pod for pvc lemonade ===
Found created volume csivol-dc9a85cb29 in PowerScale array
2025/09/05 10:00:29 === Creating Snapshot lemonade-snapshot ===

    Examples:
      | storageclass    | snapshotclass    | size  | pvc        |
      | "STORAGE_CLASS" | "SNAPSHOT_CLASS" | "2Mi" | "lemonade" |
=== Deleting Stateless Tenant tenant1 ===2025/09/05 10:01:10 === Deleting Stateless Role role1 ===
2025/09/05 10:01:11 === Deleted Stateless Role role1 ===
2025/09/05 10:01:11 === Deleting Stateless Storage powerscale ===

    Examples:
      | storageName  | role    | tenant    |
      | "powerscale" | "role1" | "tenant1" |

3 scenarios (3 passed)
25 steps (25 passed)
2m26.370908079s
2025/09/05 10:01:13 volume snapshot tests finished
--- PASS: TestSnapshot (146.39s)
PASS
status 0
ok      karavi-testing/csm-authorization/auth-test      268.083s
```
- [x] Passed the following related Operator E2E scenarios (logs attached to story)
```
Install Authorization CRDs for V2
Install Authorization Proxy Server V2
Install Authorization Proxy Server V2 (With Kubernetes Secret)
Install Authorization Proxy Server V2 With Default Redis Storage Class
Install PowerFlex Driver (With Authorization V2)
Install PowerFlex Driver (With Authorization V2), Upgrade driver and authorization sidecar
```