### PR TITLE
Replace Docker.io References - nginxinc (2)

### DIFF
--- a/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csm-operator.clusterserviceversion.yaml
@@ -4548,7 +4548,7 @@ spec:
                       - name: RELATED_IMAGE_metadataretriever
                         value: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
                       - name: RELATED_IMAGE_nginx
-                        value: docker.io/nginxinc/nginx-unprivileged:1.27
+                        value: quay.io/nginx/nginx-unprivileged:1.27
                       - name: RELATED_IMAGE_redis-commander
                         value: docker.io/rediscommander/redis-commander:latest
                       - name: RELATED_IMAGE_opa

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -91,7 +91,7 @@ spec:
               name: RELATED_IMAGE_externalhealthmonitorcontroller
             - value: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
               name: RELATED_IMAGE_metadataretriever
-            - value: docker.io/nginxinc/nginx-unprivileged:1.27
+            - value: quay.io/nginx/nginx-unprivileged:1.27
               name: RELATED_IMAGE_nginx
             - value: docker.io/rediscommander/redis-commander:latest
               name: RELATED_IMAGE_redis-commander

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -946,7 +946,7 @@ spec:
             - name: RELATED_IMAGE_metadataretriever
               value: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
             - name: RELATED_IMAGE_nginx
-              value: docker.io/nginxinc/nginx-unprivileged:1.27
+              value: quay.io/nginx/nginx-unprivileged:1.27
             - name: RELATED_IMAGE_redis-commander
               value: docker.io/rediscommander/redis-commander:latest
             - name: RELATED_IMAGE_opa


### PR DESCRIPTION
# Description
Outdated docker.io tags are replaced with quay.io tags per our policy to use quay.io. This is a follow-up to #1122 that hits some images added as a part of RedHat certification.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility
- [ ] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?
Basic Operator E2E test case (standalone PowerMax install) completed with no issues. 