### PR TITLE
Add new argument for tests/e2e - Unity

### DIFF
--- a/tests/e2e/testfiles/scenarios.yaml
+++ b/tests/e2e/testfiles/scenarios.yaml
@@ -1340,7 +1340,7 @@
     - "Apply custom resource [1]"
     - "Validate custom resource [1]"
     - "Validate [unity] driver from CR [1] is installed"
-    - "Validate deployment from CR [1] has argument [--skip_headers] in container [provisioner]"
+    - "Validate deployment from CR [1] has argument [--extra-create-metadata] in container [provisioner]"
     # cleanup
     - "Enable forceRemoveDriver on CR [1]"
     - "Delete custom resource [1]"

--- a/tests/e2e/testfiles/storage_csm_unity_extra_arg.yaml
+++ b/tests/e2e/testfiles/storage_csm_unity_extra_arg.yaml
@@ -34,7 +34,7 @@ spec:
     sideCars:
       # '--skip_headers' is an extra arg to test functionality for adding args in CSM object
       - name: provisioner
-        args: ["--volume-name-prefix=csivol", "--skip_headers"]
+        args: ["--volume-name-prefix=csivol", "--extra-create-metadata"]
       - name: external-health-monitor
         enabled: false
         args: ["--monitor-interval=60s"]


### PR DESCRIPTION
# Description
--skip_headers argument is not supported with csi provisioner v5.3.0. Updated tests file with new argument.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility
- [x] I have executed the relevant end-to-end test scenarios

# How Has This Been Tested?

Manually tested the new argument working. Operator E2E is passing. 